### PR TITLE
feat: add Cloudflare-compatible CONNECT-IP client support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.2.0 - 2026-08-18
+
+### Added
+
+- Compatibility with VPN-style MASQUE clients modelled on Cloudflare WARP, such
+  as usque:
+  - `ip_proxy.connect_protocols` accepts Cloudflare's `cf-connect-ip` alongside
+    the registered `connect-ip`, both by default.
+  - `auth.mode = "client_cert"` authenticates clients by TLS client
+    certificate, matched against a `[[clients]]` roster by public key. An
+    unregistered key is refused during the handshake with a TLS `access_denied`
+    alert.
+  - `[[clients]].ipv4` / `.ipv6` pin a client's CONNECT-IP addresses, which
+    clients that configure their tunnel interface out of band require. Pinned
+    addresses are withheld from dynamic pool allocation.
+  - `masque-server enroll-client` generates a client key pair and prints both
+    the server's `[[clients]]` block and the client's own configuration,
+    replacing the vendor enrollment API for self-hosted setups.
+  - Pinned-address leases tolerate an authenticated reconnect overlapping its
+    stale predecessor; the newest tunnel takes over the return route.
+  - `tests/client_cert_connect_ip.rs` drives a synthetic client imitating this
+    family against a real server, covering certificate authentication,
+    `cf-connect-ip`, pinned assignment, reconnect overlap, full-MTU datagram
+    sizing, and rejection of unenrolled and absent certificates.
+  - A documented interop procedure and failure-signature table for qualifying a
+    real client on Linux, where packet forwarding can be exercised.
+  - `enroll-client` also prints a mihomo-style `proxies:` entry, which needs the
+    same key in a different encoding (bare base64 rather than PEM) and addresses
+    in CIDR form.
+  - `SIGHUP` reloads the `[[clients]]` roster. Revoked clients are disconnected
+    and refused at their next handshake, other tunnels are untouched, and a
+    roster that fails validation is rejected as a whole so the running one stays
+    in force. Previously revoking a client required a restart, which dropped
+    every other client's tunnel.
+
+### Fixed
+
+- The Docker build installs `clang` and `libclang-dev`. Without them the
+  `boring-sys` bindgen step fails with "Unable to find libclang".
+- Roster reload keeps pinned leases bound to the public key that owns them, so
+  moving an address between clients cannot create a cross-identity overlap.
+- `SIGHUP` cannot switch a running server into `client_cert` mode and validates
+  reservations against the IP-proxy state the process bound with rather than
+  unrelated edits awaiting restart.
+- Generated mihomo configuration uses the configured `ip_proxy.tun_mtu` instead
+  of always emitting 1280.
+
+### Changed
+
+- The binary now reports the package version through `masque-server --version`.
+- `server.idle_timeout_secs` now defaults to 60 rather than 30, so a tunnel
+  whose client uses the common 30s keepalive period does not race its own
+  keepalive against the timeout.
+- Dynamic CONNECT-IP allocation starts at network address `+2`, leaving `+1`
+  exclusively to the server's TUN gateway.
+- Client enrollment files are created with mode `0600` on Unix and never
+  overwrite an existing path. The endpoint port is printed as usque's required
+  `--connect-port` argument because its JSON schema stores only the IP.
+- CONNECT-IP sends `200` only after address allocation succeeds, so exhaustion
+  and setup failures return a real `503` instead of a successful dead tunnel.
+
 ## 0.1.0-rc.11 - 2026-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,11 +727,12 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "argon2",
  "base64",
+ "boring",
  "bytes",
  "clap",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"
@@ -27,6 +27,10 @@ path = "src/main.rs"
 anyhow = "1"
 argon2 = { version = "0.5.3", features = ["std", "zeroize"] }
 base64 = "0.22.1"
+# Same BoringSSL binding quiche links against, so the two share one library.
+# Needed to build the TLS context by hand: requesting a client certificate
+# without verifying its chain has no equivalent in quiche's own Config API.
+boring = "4.3"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 ipnet = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,25 @@
 # Stage 1: build
 FROM rust:1.88-bookworm AS builder
 
-RUN apt-get update && apt-get install -y cmake golang-go && rm -rf /var/lib/apt/lists/*
+# cmake and go build BoringSSL; clang/libclang-dev are for the bindgen step in
+# boring-sys, which fails with "Unable to find libclang" without them.
+RUN apt-get update \
+    && apt-get install -y cmake golang-go clang libclang-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
 # Dependency caching layer: copy manifests + stub sources, build deps first.
+#
+# The bench target declared in Cargo.toml has to exist as a file or cargo
+# refuses to parse the manifest at all, so it is stubbed here alongside the
+# sources and replaced by the real one below.
 COPY Cargo.toml Cargo.lock ./
 COPY tools/masque-e2e/Cargo.toml tools/masque-e2e/Cargo.toml
-RUN mkdir -p src tools/masque-e2e/src \
+RUN mkdir -p src benches tools/masque-e2e/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
+    && echo "fn main() {}" > benches/core.rs \
     && echo "fn main() {}" > tools/masque-e2e/src/main.rs \
     && cargo build --release -p masque-server 2>/dev/null || true \
     && rm -f target/release/masque-server target/release/deps/masque_server-* \
@@ -19,6 +28,7 @@ RUN mkdir -p src tools/masque-e2e/src \
 
 # Copy real source and build.
 COPY src/ src/
+COPY benches/ benches/
 COPY tools/masque-e2e/ tools/masque-e2e/
 RUN touch src/main.rs src/lib.rs && cargo build --release -p masque-server --bin masque-server
 

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -1,6 +1,9 @@
 [server]
 listen_addr = "0.0.0.0:443"
-idle_timeout_secs = 30
+# Keep this above the client's keepalive period. VPN-style MASQUE clients
+# commonly default to 30s, and matching that exactly makes a quiet tunnel race
+# its own keepalive against the timeout.
+idle_timeout_secs = 60
 max_connections = 10000
 max_tunnels_per_connection = 100
 # Independent event loops, each with its own SO_REUSEPORT socket and its own
@@ -15,8 +18,36 @@ key_path = "/etc/masque/certs/server.key"
 
 [auth]
 enabled = true
+# "basic"       — RFC 7617 Proxy-Authorization, checked per request.
+# "client_cert" — a TLS client certificate, matched against [[clients]] below.
+#
+# Pick "client_cert" for VPN-style clients modelled on Cloudflare WARP MASQUE
+# (for example usque): they authenticate during the QUIC handshake and never
+# send Proxy-Authorization, so they cannot work against "basic".
+mode = "basic"
 username = "__MASQUE_AUTH_USERNAME__"
 password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"
+
+# Clients allowed in when mode = "client_cert". Generate an entry, then reload
+# or restart the service:
+#
+#   masque-server enroll-client --name laptop --endpoint <public-ip>:443 \
+#       --ipv4 10.89.0.2 --ipv6 fd00:abcd::2
+#
+# That prints this block plus the client's own configuration file. The pinned
+# addresses are required for clients that configure their tunnel interface from
+# their config file rather than from the ADDRESS_ASSIGN capsule — the two sides
+# must agree, or every packet is dropped as spoofed.
+#
+# The client JSON stores only the endpoint IP. The command also prints the
+# matching usque --connect-port/-P argument; do not omit it on non-443 servers.
+# An --out path is created as a new 0600 file on Unix and is never overwritten.
+#
+# [[clients]]
+# name = "laptop"
+# public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
+# ipv4 = "10.89.0.2"
+# ipv6 = "fd00:abcd::2"
 
 [quic]
 max_datagram_size = 1350
@@ -83,6 +114,11 @@ deny_targets = [
 [ip_proxy]
 enabled = true
 uri_template = "/.well-known/masque/ip/{target}/{ipproto}/"
+# Accepted `:protocol` values. RFC 9484 registers "connect-ip"; Cloudflare's
+# endpoint uses "cf-connect-ip" and clients built against it send only that.
+# Both are accepted by default, which costs nothing: an RFC client never sends
+# the second one.
+connect_protocols = ["connect-ip", "cf-connect-ip"]
 tun_name = "masque0"
 tun_mtu = 1280
 # Linux GSO/GRO on the TUN device: one read carries a whole aggregate and one

--- a/deploy/systemd/masque.service
+++ b/deploy/systemd/masque.service
@@ -9,6 +9,9 @@ Type=simple
 User=masque
 Group=masque
 ExecStart=/usr/local/bin/masque-server --config /etc/masque/masque.toml
+# Re-reads the [[clients]] roster only, so revoking a client does not drop
+# every other client's tunnel. Everything else still needs a restart.
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=2s
 LimitNOFILE=1048576

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,12 +13,29 @@ file is the canonical deployable example and is tested by the release flow.
 ```text
 masque-server [OPTIONS]
 masque-server hash-password
+masque-server enroll-client [OPTIONS] --name <NAME> --endpoint <ADDR:PORT>
 
   -c, --config <PATH>       Config file [default: masque.toml]
   -l, --listen <ADDR>       Override server.listen_addr
       --cert <PATH>         Override tls.cert_path
       --key <PATH>          Override tls.key_path
   -v, --verbose             Increase verbosity; repeat for trace logging
+  -V, --version             Print the server version
+```
+
+`hash-password` reads a password on stdin and prints an Argon2id hash for
+`auth.password_hash`. `enroll-client` generates a client key pair for
+`auth.mode = "client_cert"`; it reads `tls.cert_path` from `--config`, so pass
+the same config the server uses. Both are described under
+[Authentication](#authentication).
+
+```text
+enroll-client options:
+      --name <NAME>         Label for this client, used in the server's logs
+      --endpoint <ADDR:PORT>  What clients dial; must be reachable from them
+      --ipv4 <ADDR>         Fixed tunnel IPv4, inside ip_proxy.ipv4_pool
+      --ipv6 <ADDR>         Fixed tunnel IPv6, inside ip_proxy.ipv6_pool
+  -o, --out <PATH>          Write the client JSON here instead of stdout
 ```
 
 `RUST_LOG` overrides the default tracing filter.
@@ -28,7 +45,7 @@ masque-server hash-password
 ```toml
 [server]
 listen_addr = "0.0.0.0:443"
-idle_timeout_secs = 30
+idle_timeout_secs = 60
 max_connections = 10000
 max_tunnels_per_connection = 100
 shards = 1
@@ -58,23 +75,198 @@ as group `masque`; install both files as `root:masque` with mode `0640`.
 
 ## Authentication
 
+`auth.mode` selects how clients prove who they are. The two modes are mutually
+exclusive — `client_cert` makes the TLS handshake demand a certificate, so a
+credential-based client cannot even connect, and vice versa. Serving both kinds
+of client requires two server instances.
+
+| Key | Meaning |
+| --- | --- |
+| `enabled` | Master switch. `false` disables authentication whatever `mode` says |
+| `mode` | `basic` (default) or `client_cert` |
+| `username` | `basic` only |
+| `password_hash` | `basic` only; Argon2id PHC string |
+| `[[clients]]` | `client_cert` only; the roster of allowed clients |
+
+Choose `basic` for standards-compliant MASQUE clients. Choose `client_cert` for
+VPN-style clients modelled on Cloudflare WARP, such as usque and mihomo, which
+never send credentials; see
+[Cloudflare-compatible clients](protocols.md#cloudflare-compatible-clients).
+
+### `mode = "basic"` (default)
+
+Credentials are checked on every CONNECT request, so one authorized tunnel does
+not authorize later streams that omit the header.
+
 ```toml
 [auth]
 enabled = true
+mode = "basic"
 username = "proxy-user"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$..."
 ```
 
-Generate a hash without placing the password in process arguments:
+Generate the hash without placing the password in process arguments, which
+would expose it to every user on the host through the process list:
 
 ```sh
 printf '%s' 'a-strong-password' | masque-server hash-password
 ```
 
-Clients send `Proxy-Authorization: Basic ...` on every CONNECT request.
-Missing or invalid credentials receive `407 Proxy Authentication Required`.
-Set `enabled = false` only in an isolated test environment or behind another
-trusted authentication boundary.
+Clients send `Proxy-Authorization: Basic BASE64(user:password)` on each
+request. Missing, malformed, duplicated, or wrong credentials receive
+`407 Proxy Authentication Required`.
+
+The server refuses to start if `username` is empty or contains `:`, or if
+`password_hash` is not a valid Argon2id PHC string.
+
+### `mode = "client_cert"`
+
+Clients authenticate once, with a TLS client certificate, during the QUIC
+handshake. Nothing is checked per request: every stream on an established
+connection is already authorized. Standard CONNECT and CONNECT-UDP keep working
+if their sections are enabled — the mode changes who may connect, not what they
+may ask for.
+
+```toml
+[auth]
+enabled = true
+mode = "client_cert"
+
+[[clients]]
+name = "laptop"
+public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
+ipv4 = "10.89.0.2"
+ipv6 = "fd00:abcd::2"
+
+[[clients]]
+name = "phone"
+public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
+ipv4 = "10.89.0.3"
+ipv6 = "fd00:abcd::3"
+```
+
+| `[[clients]]` key | Meaning |
+| --- | --- |
+| `name` | Label used in the server's logs. Optional but makes them readable |
+| `public_key` | The client's ECDSA P-256 public key: base64 SubjectPublicKeyInfo DER, or a `-----BEGIN PUBLIC KEY-----` block |
+| `ipv4` | Fixed CONNECT-IP address, inside `ip_proxy.ipv4_pool` |
+| `ipv6` | Fixed CONNECT-IP address, inside `ip_proxy.ipv6_pool` |
+
+#### Enrolling a client
+
+There is no enrollment API to call. The operator generates the key pair and
+distributes it:
+
+```sh
+masque-server --config masque.toml enroll-client \
+    --name laptop --endpoint 203.0.113.9:443 \
+    --ipv4 10.89.0.2 --ipv6 fd00:abcd::2 --out client.json
+```
+
+This prints three things: the `[[clients]]` block for this file, a JSON
+configuration for usque-style clients, and a `proxies:` entry for mihomo-style
+clients. The client halves contain the private key — treat the output as a
+secret. Generating both spellings matters because the same key is encoded
+differently for each: usque takes the server key as PEM and addresses bare,
+mihomo takes it as bare base64 and addresses in CIDR form.
+
+The generated mihomo entry uses the active `ip_proxy.tun_mtu` value from the
+same server configuration, so a non-default MTU stays consistent on both ends.
+
+`--out` writes the JSON to a file created as a new `0600` file on Unix; an
+existing path is never overwritten. Without it the JSON goes to the terminal.
+
+Nothing is written to the server configuration automatically. Append the
+`[[clients]]` block yourself, then run `systemctl reload masque` or restart.
+
+The usque JSON schema stores the endpoint IP but not its port, so enrollment
+also prints the matching launch argument — `--connect-port 443` for the example
+above, `--connect-port 8449` for a server on 8449. Omitting it silently falls
+back to the client's default port.
+
+#### How the certificate is checked
+
+Only the public key inside the certificate is compared against the roster. The
+certificate itself is a disposable envelope: these clients self-sign a fresh
+one per connection with an empty subject and 24-hour validity, so its chain,
+name, and dates carry nothing worth verifying.
+
+A key that is not on the roster is refused during the handshake with a TLS
+`access_denied` alert, before it can open a stream. The rejected key is logged
+in exactly the form you can paste into a `[[clients]]` entry, so enrolling a new
+client needs no separate key extraction step.
+
+The **server** certificate must use an ECDSA key, because these clients pin its
+public key and reject any other key type. `scripts/gen-certs.sh` produces a
+suitable P-256 certificate. Replacing the server certificate invalidates every
+client configuration that pinned the old key.
+
+#### Pinned addresses
+
+`ipv4` / `ipv6` bypass the dynamic pool and give that client the same address
+every time. This is required for clients that configure their tunnel interface
+from their own configuration rather than from the `ADDRESS_ASSIGN` capsule: if
+the two sides disagree, traffic is dropped in both directions — inbound as a
+spoofed source, outbound by the client's own filtering. Omit them only for
+clients that do read `ADDRESS_ASSIGN`.
+
+Pinned addresses are withheld from dynamic allocation for the process lifetime,
+so an offline client keeps its address. When a replacement connection arrives
+before its stale predecessor times out, the same authenticated identity may
+reclaim the addresses immediately and the newest tunnel owns their return
+route — a network change does not cost a minute of downtime.
+
+Dynamic allocation begins at network address `+2`; `+1` belongs to the server's
+own TUN interface.
+
+#### Revoking a client
+
+Edit the roster and send `SIGHUP`:
+
+```sh
+systemctl reload masque            # or: kill -HUP $(pidof masque-server)
+```
+
+The server re-reads `[[clients]]` from the same file it was started with,
+disconnects any live connection whose entry was removed or changed, and leaves
+every other tunnel untouched. A removed client's next attempt is refused at the
+handshake like any unenrolled key. Adding an entry works the same way, so a
+client can be re-enrolled without a restart either.
+
+Only the roster is reloaded. Listen address, TLS material, pools, and tuning are
+fixed at bind time; changing those still needs a restart. A reload that does not
+validate — an unparseable key, a pinned address outside the pool, `auth.mode` no
+longer `client_cert` — is rejected as a whole and the running roster stays in
+force, so a typo cannot lock everyone out.
+
+Editing an existing entry counts as revocation: the client is disconnected and
+must reconnect to pick up its new pinned addresses, which are chosen when the
+tunnel is set up.
+
+Reload is unavailable when the server was started without a config file, since
+there is nothing to re-read.
+
+#### Startup validation
+
+The server refuses to start when:
+
+- `mode = "client_cert"` and no `[[clients]]` entry exists — an empty roster
+  admits nobody, which looks exactly like a broken TLS setup;
+- a `public_key` is unparseable or is not ECDSA P-256;
+- two entries share a `public_key`, or pin the same address;
+- a pinned address falls outside its pool, or is the pool's gateway address —
+  checked only while `ip_proxy.enabled = true`, since there is no pool to
+  validate against otherwise.
+
+`[[clients]]` entries outside this mode are ignored, do not reserve addresses,
+and produce a startup warning.
+
+### Disabling authentication
+
+`auth.enabled = false` turns off both modes and logs a warning. This is only
+appropriate in an isolated test environment or behind another trusted
+authentication boundary.
 
 ## QUIC and UDP
 
@@ -154,12 +346,19 @@ different.
 [ip_proxy]
 enabled = true
 uri_template = "/.well-known/masque/ip/{target}/{ipproto}/"
+connect_protocols = ["connect-ip", "cf-connect-ip"]
 tun_name = "masque0"
 tun_mtu = 1280
 tun_offload = true
 ipv4_pool = "10.89.0.0/16"
 ipv6_pool = "fd00:abcd::/64"
 ```
+
+`connect_protocols` lists the accepted `:protocol` values. RFC 9484 registers
+`connect-ip`; Cloudflare's endpoint uses `cf-connect-ip` and clients built
+against it send only that. Both are accepted by default, which costs nothing
+because an RFC client never sends the second one. Narrow the list to
+`["connect-ip"]` to accept only standards-compliant clients.
 
 CONNECT-IP is Linux-only. Pools must not overlap host, container, VPN, or
 upstream networks. The host is responsible for routing, forwarding, firewall,

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -16,8 +16,8 @@ Extended CONNECT are advertised during connection setup.
 
 ## Authentication
 
-Every CONNECT form passes through the same proxy authentication pipeline. The
-client supplies:
+With `auth.mode = "basic"` (the default), every CONNECT form passes through the
+same proxy authentication pipeline. The client supplies:
 
 ```text
 Proxy-Authorization: Basic BASE64(username:password)
@@ -33,6 +33,12 @@ proxy-authenticate: Basic realm="masque", charset="UTF-8"
 
 Authentication is per request, so one authenticated tunnel does not authorize
 later streams that omit the header.
+
+With `auth.mode = "client_cert"` there is no per-request step: the client is
+identified once, from its TLS client certificate, during the QUIC handshake. An
+unregistered key never reaches the request path — it is refused with a TLS
+`access_denied` alert. See
+[Cloudflare-compatible clients](#cloudflare-compatible-clients).
 
 ## Standard CONNECT
 
@@ -69,12 +75,20 @@ by the Capsule Protocol unless they affect tunnel state.
 
 ## CONNECT-IP
 
-The request contains `:protocol = connect-ip` and follows the configured URI
-template. A successful setup allocates addresses and returns `200`, followed
-by:
+The request contains a `:protocol` from `ip_proxy.connect_protocols` — the
+registered `connect-ip`, or Cloudflare's `cf-connect-ip` — and follows the
+configured URI template. A successful setup assigns addresses and returns `200`,
+followed by:
 
 - `ADDRESS_ASSIGN` capsules for assigned IPv4 and IPv6 addresses; and
 - `ROUTE_ADVERTISEMENT` capsules for reachable prefixes.
+
+Addresses come from the pool, unless the client authenticated with a certificate
+whose `[[clients]]` entry pins them. A pinned client receives exactly its pinned
+addresses and nothing from the pool. Reconnection may briefly overlap a stale
+connection carrying the same enrolled key; the newest tunnel atomically takes
+over the return route, while reference-counted leases keep later cleanup from
+freeing an address that is still live.
 
 IP packets use HTTP Datagrams with Context ID `0`. Before writing a client
 packet to TUN, the server checks the source address against the tunnel's
@@ -104,3 +118,57 @@ Clients must support HTTP/3 proxy CONNECT and the relevant MASQUE extension.
 Configuration syntaxes in products such as Surge are client-specific and are
 not part of the RFCs. Test authentication, target policy, TCP, UDP, and DNS
 separately when qualifying a client.
+
+## Cloudflare-compatible clients
+
+VPN-style MASQUE clients modelled on Cloudflare WARP — for example
+[usque](https://github.com/Diniboy1123/usque) and
+[mihomo](https://wiki.metacubex.one/config/proxies/masque/) — diverge from
+RFC 9484 in ways the server accommodates. Everything below is on by default
+except the authentication mode.
+
+**`:protocol` is `cf-connect-ip`.** Cloudflare's endpoint uses that instead of
+the registered `connect-ip`, and these clients send only it. Both are in
+`ip_proxy.connect_protocols` by default. This is not optional: usque and mihomo
+are independent implementations, and both were observed sending byte-identical
+requests — `:protocol: cf-connect-ip`, `:authority: cloudflareaccess.com`,
+`:path: /` — so a server accepting only `connect-ip` answers `404` to every
+client in this family.
+
+**`:authority` and `:path` are fixed.** The request arrives as
+`:authority: cloudflareaccess.com` and `:path: /`, with no URI Template
+variables. The CONNECT-IP path ignores both, so `ip_proxy.uri_template` does not
+apply to these clients.
+
+**Authentication is a TLS client certificate.** No `Proxy-Authorization` is
+ever sent, so `auth.mode = "basic"` refuses these clients with `407`. Use
+`auth.mode = "client_cert"` and enroll each client's public key; see
+[Authentication](configuration.md#authentication).
+
+**Extended CONNECT is not required of the server.** Cloudflare does not
+advertise `SETTINGS_ENABLE_CONNECT_PROTOCOL`, and these clients tolerate its
+absence. This server advertises it anyway, which is compatible.
+
+**Addresses come from the client's own configuration, not from
+`ADDRESS_ASSIGN`.** Cloudflare sends no capsules at all; the client learns its
+tunnel addresses from its config file and configures its interface from those.
+Two consequences:
+
+- The address must be pinned per client with `[[clients]].ipv4` / `.ipv6`, and
+  the client's configuration must carry the same values. A pool-allocated
+  address would leave the two sides disagreeing, and the server would drop every
+  client packet as a spoofed source.
+- `ADDRESS_ASSIGN` is still sent, and it must agree with the pinned addresses.
+  These clients ignore it for interface configuration but do use it to filter
+  inbound packets, so an address the client is not expecting causes silent drops
+  in the other direction too.
+
+`masque-server enroll-client` generates both sides at once, which is the
+reliable way to keep them consistent.
+
+**Keepalive interacts with the idle timeout.** These clients default to a 30s
+keepalive period. Keep `server.idle_timeout_secs` above it; the default is 60.
+
+**HTTP/2 fallback is not supported.** Some of these clients can carry
+CONNECT-IP over TCP and HTTP/2 instead of QUIC. This server is HTTP/3 only, so
+those clients must use their default QUIC transport.

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,6 +9,8 @@ packets through the host. The principal risks are:
 
 - unauthenticated resource exhaustion;
 - password guessing and memory-hard hash amplification;
+- disclosure or misdistribution of an enrolled client's private key, which is a
+  bearer credential;
 - access to loopback, metadata, management, or private networks;
 - unbounded buffering under a slow client or target;
 - malformed packet or capsule parsing;
@@ -29,6 +31,16 @@ work that has not started and discards results for work already running.
 Use a unique, high-entropy password. Basic credentials are protected by QUIC
 TLS in transit but are reusable bearer secrets at the HTTP layer. Rotate them
 after suspected client or log compromise.
+
+With `auth.mode = "client_cert"` the cost profile is different: identity is
+established once during the handshake, by public key, so there is no per-request
+verification to bound and no password to brute-force. An unenrolled key is
+refused with a TLS alert before it can open a stream, which keeps unauthorized
+callers off the request path entirely. The trade-off is that authorization is
+per connection rather than per request — every stream on an established
+connection is already authorized. See
+[TLS and credentials](#tls-and-credentials) for what counts as a credential
+under that mode.
 
 ## Target policy
 
@@ -60,11 +72,62 @@ packet loss into seconds of latency and make memory exhaustion easier.
 
 ## TLS and credentials
 
-- Use a certificate trusted by clients and covering the exact proxy hostname.
 - Keep the private key and configuration `root:masque` mode `0640`.
 - Do not pass passwords as command-line arguments.
 - Do not commit real certificates, hashes, passwords, IPs, or server inventory.
 - Avoid trace logging in production except during a short controlled incident.
+
+The right server certificate depends on the authentication mode, because the
+two modes establish server identity in completely different ways.
+
+### With `auth.mode = "basic"`
+
+Clients validate the certificate normally. Use one trusted by them and covering
+the exact proxy hostname, and renew it before expiry as usual.
+
+### With `auth.mode = "client_cert"`
+
+Clients in this family skip chain validation entirely — the SNI they send names
+a vendor endpoint rather than this server — and instead pin the leaf public key
+they were enrolled with. Chain, hostname, and expiry therefore play no part in
+their trust decision.
+
+A self-signed certificate is appropriate here, and is what `scripts/gen-certs.sh`
+produces. Pinning trusts exactly one key distributed out of band rather than
+every public CA, so the trusted set is smaller than under PKI. A CA-issued
+certificate brings no benefit to these clients and introduces a hazard: ACME
+renewal rotates the key by default, and a new key invalidates every client's
+pin. If you use one anyway, renew with a stable key.
+
+Consequences worth planning for:
+
+- **Replacing the certificate is a flag day.** Every enrolled client pins the
+  old key and stops connecting. Re-enroll and redistribute, or renew with the
+  same key to preserve the pin.
+- **A client's `--insecure`-style flag disables pinning** and exposes it to
+  interception. Use it only to diagnose a pin mismatch, never in production.
+- **Compromise of the server private key** allows impersonating this server to
+  every client, exactly as it would under PKI.
+
+### What is and is not a credential
+
+- `[[clients]]` holds only **public** keys. A leaked server configuration does
+  not let anyone connect.
+- The **client private key** — in the enrolled JSON or `proxies:` entry — is a
+  bearer credential: whoever holds it is that client. With `--out`,
+  `enroll-client` writes the JSON as `0600` and refuses to overwrite an existing
+  path. Distribute it over a confidential channel and treat the command's
+  terminal output, including the mihomo entry, as secret.
+- Skipping chain validation does not weaken proof of possession. TLS 1.3 makes
+  the client sign the handshake transcript with the certificate's private key,
+  and that signature is verified by the TLS stack; the roster check replaces
+  only the X.509 trust decision. Knowing a client's public key is therefore not
+  enough to impersonate it.
+- Roster entries do not expire on their own. Revoke a client by deleting its
+  `[[clients]]` entry and sending `SIGHUP`: the server disconnects that
+  client's live connections and refuses its next handshake, without restarting
+  and without disturbing other tunnels. A reload that fails validation keeps
+  the previous roster, so a bad edit cannot lock everyone out.
 
 ## Linux privilege
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,7 @@
 | Microbenchmark | `cargo bench --bench core` | Codec, routing, and allocation regressions |
 | Network benchmark | `scripts/network-bench.sh` | Local direct-vs-MASQUE throughput and RTT |
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
+| Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth and CONNECT-IP setup |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
 
 ## Local tests
@@ -61,12 +62,178 @@ A release candidate is not complete until an x86_64 Linux host verifies:
 3. standard CONNECT and CONNECT-UDP work through a real client;
 4. `sendmmsg` and `recvmmsg` appear under traffic;
 5. UDP GSO on/off behavior is tested across the external path;
-6. single- and multi-shard modes pass concurrent traffic; and
-7. memory and CPU remain bounded under invalid authentication load.
+6. single- and multi-shard modes pass concurrent traffic;
+7. memory and CPU remain bounded under invalid authentication load; and
+8. a real Cloudflare-compatible client passes traffic through a TUN device —
+   see [Cloudflare-compatible client interop](#cloudflare-compatible-client-interop).
 
 For target datagram sizing, raise `quic.max_datagram_size` above 2048 in a test
 configuration and verify oversized responses are rejected rather than silently
 truncated.
+
+## Cloudflare-compatible client interop
+
+`cargo test --test client_cert_connect_ip` covers the handshake, the
+`cf-connect-ip` request, pinned address assignment, reconnect overlap, datagram
+sizing, and rejection of unenrolled keys — all against a synthetic client that
+imitates this family. It runs anywhere.
+
+What it cannot cover is packet forwarding, because that needs a TUN device.
+Qualifying a real client therefore needs a Linux host with root. Two clients are
+known to interoperate, and testing both is worthwhile because they are
+independent implementations of the same protocol:
+
+- [mihomo](https://wiki.metacubex.one/config/proxies/masque/) — ships prebuilt
+  binaries, and can be run as a plain local proxy, so it needs neither a
+  toolchain nor a TUN device nor root. Start here.
+- [usque](https://github.com/Diniboy1123/usque) — the reference client; needs a
+  Go toolchain (currently Go ≥ 1.26) and root, since it only runs as a TUN.
+
+`masque-server enroll-client` prints configuration for both. Their field
+encodings differ in ways that are easy to get wrong by hand — mihomo wants the
+server key as bare base64 and addresses in CIDR form, usque wants PEM and bare
+addresses — so use the generated blocks rather than transcribing.
+
+**1. Build the client.** Only needed for usque; mihomo ships binaries.
+
+```sh
+git clone https://github.com/Diniboy1123/usque && cd usque && go build .
+```
+
+**2. Configure the server.** `auth.mode = "client_cert"`, and a certificate with
+an ECDSA key so the client can pin it:
+
+```sh
+scripts/gen-certs.sh certs
+```
+
+```toml
+[server]
+listen_addr = "0.0.0.0:4433"
+
+[tls]
+cert_path = "certs/server.crt"
+key_path = "certs/server.key"
+
+[auth]
+enabled = true
+mode = "client_cert"
+
+[ip_proxy]
+enabled = true
+ipv4_pool = "10.89.0.0/24"
+ipv6_pool = "fd00:abcd::/64"
+```
+
+**3. Enroll the client.** Do not hand-write either side; the pinned addresses
+must match exactly, and enrollment is what guarantees that:
+
+```sh
+masque-server --config masque.toml enroll-client \
+    --name interop --endpoint <server-ip>:4433 \
+    --ipv4 10.89.0.2 --ipv6 fd00:abcd::2 --out config.json
+```
+
+Append the printed `[[clients]]` block to `masque.toml` and start the server.
+
+**4. Let the host forward and translate.** The server moves packets between
+QUIC and its TUN device and nothing more; egress is the host's job:
+
+```sh
+sysctl -w net.ipv4.ip_forward=1
+iptables -t nat -A POSTROUTING -s 10.89.0.0/24 -o <wan-if> -j MASQUERADE
+```
+
+**5. Connect.** With mihomo, paste the generated `proxies:` block into a config
+with a listener and a catch-all rule, then run it unprivileged:
+
+```yaml
+mixed-port: 7899
+mode: rule
+proxies:
+  # ... the generated block ...
+rules:
+  - MATCH,<proxy name>
+```
+
+```sh
+./mihomo -d <config-dir>          # no root, no TUN
+```
+
+With usque, the JSON stores the endpoint IP but not its port, so the port is a
+flag — enrollment prints the exact argument:
+
+```sh
+sudo ./usque nativetun --config config.json --connect-port 4433
+```
+
+**6. Verify.** The most decisive target is the server's own TUN address, because
+it exercises the tunnel end to end without depending on the host's egress path
+at all. Serve a large file there and pull it through the tunnel, comparing
+checksums:
+
+```sh
+# on the server, bound to the TUN gateway only
+python3 -m http.server 8080 --bind 10.89.0.1
+
+# from the client
+curl -x http://127.0.0.1:7899 -o out.bin http://10.89.0.1:8080/blob.bin   # mihomo
+curl -o out.bin http://10.89.0.1:8080/blob.bin                            # usque
+```
+
+Then an ICMP echo to `10.89.0.1`, both address families, and a full-MTU probe:
+
+```sh
+ping -M do -s 1252 -I 10.89.0.2 10.89.0.1   # 1252 + 28 = the 1280-byte MTU
+ping -M do -s 1253 -I 10.89.0.2 10.89.0.1   # must fail: proves where the limit is
+```
+
+Only then test egress to the internet. Small-packet success with bulk-transfer
+failure means MTU, not routing.
+
+### Egress testing needs an uncontended host
+
+Egress is the least reliable thing to test, because it depends on the server
+host's own networking rather than on MASQUE. Before concluding the server is at
+fault, confirm the packet actually left:
+
+```sh
+tcpdump -ni masque0 host <target>   # did the tunnel deliver it?
+tcpdump -ni <wan-if> host <target>  # did the host forward it?
+```
+
+If it arrives on `masque0` but never leaves the WAN interface, the server did
+its job and the host dropped the packet. Three environment traps produce exactly
+that, and all three were hit while qualifying this feature:
+
+- **Docker sets the `FORWARD` policy to `DROP`.** Add the tunnel's rules to the
+  `DOCKER-USER` chain, which Docker leaves for exactly this and traverses first.
+- **A transparent proxy on the server host captures forwarded traffic.** A
+  policy-routing setup (`ip rule show` revealing a table for a proxy's own TUN)
+  will divert forwarded TCP into the proxy instead of the WAN interface. Such
+  setups commonly exempt ICMP explicitly, which produces the confusing signature
+  of working pings and hanging TCP. Check `ip rule show` before blaming MASQUE.
+- **A published container port hijacks that port for forwarded traffic too.** A
+  container publishing `0.0.0.0:80` installs a DNAT rule matching *any* packet
+  with that destination port, including tunnel traffic merely passing through, so
+  it never reaches the WAN interface. Pick a test port nothing publishes.
+
+### Failure signatures
+
+| Symptom | Cause |
+| --- | --- |
+| `login failed! Please double-check if your tls key and cert is enrolled` | The client's public key is not in `[[clients]]`. The server logs the key it received in pasteable form. |
+| Client reports a different public key than enrollment printed | `config.json` and the `[[clients]]` block came from different runs. Re-enroll. |
+| `remote endpoint has a different public key than what we trust in config.json` | `tls.cert_path` changed after enrollment. Re-run enrollment, or pass `--insecure` to skip pinning while testing. |
+| HTTP 404 on the CONNECT | `cf-connect-ip` is missing from `ip_proxy.connect_protocols`, or `ip_proxy.enabled = false`. |
+| HTTP 407 | The server is in `auth.mode = "basic"`; these clients never send credentials. |
+| HTTP 503 | The dynamic address pool is exhausted, or `max_tunnels_per_connection` is reached. A pinned client is unaffected by pool exhaustion — its address is reserved at startup. |
+| Tunnel comes up, no traffic passes | Host forwarding or NAT is missing, or the TUN device failed to appear — check the server's startup warnings. |
+| In-tunnel traffic works, egress does not | The host's forwarding path, not the server. See [Egress testing needs an uncontended host](#egress-testing-needs-an-uncontended-host). |
+| Egress ICMP works but TCP hangs | Almost always a transparent proxy on the server host that exempts ICMP from its policy routing. Check `ip rule show`. |
+| Server logs `spoofed source address, dropping` | The client's interface address disagrees with its pinned address. Re-enroll so both sides match. |
+| Small packets work, bulk transfers stall | The framed MTU exceeds the datagram budget. Raise `quic.max_datagram_size` or lower the client's MTU; keep the client at 1280 unless both ends were changed together. |
+| Tunnel drops roughly every 30s | `server.idle_timeout_secs` is at or below the client's keepalive period. |
 
 ## Release checklist
 

--- a/src/address_pool.rs
+++ b/src/address_pool.rs
@@ -3,7 +3,7 @@
 // Allocates individual host addresses from configured CIDR ranges and
 // returns them to the pool when tunnels are torn down.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnet::{Ipv4Net, Ipv6Net};
@@ -17,6 +17,8 @@ pub enum PoolError {
     OutOfRange(IpAddr),
     /// The requested address is already allocated.
     AlreadyAllocated(IpAddr),
+    /// The requested address is not pinned to this authenticated identity.
+    NotReserved(IpAddr),
     /// Invalid CIDR string.
     InvalidCidr(String),
 }
@@ -27,6 +29,9 @@ impl std::fmt::Display for PoolError {
             PoolError::Exhausted => write!(f, "address pool exhausted"),
             PoolError::OutOfRange(a) => write!(f, "address {a} out of pool range"),
             PoolError::AlreadyAllocated(a) => write!(f, "address {a} already allocated"),
+            PoolError::NotReserved(a) => {
+                write!(f, "address {a} is not reserved for this client")
+            }
             PoolError::InvalidCidr(s) => write!(f, "invalid CIDR: {s}"),
         }
     }
@@ -38,11 +43,48 @@ impl std::error::Error for PoolError {}
 pub struct AddressPool {
     v4_net: Option<Ipv4Net>,
     v6_net: Option<Ipv6Net>,
-    allocated: HashSet<IpAddr>,
+    /// Live leases per address.
+    ///
+    /// Dynamic addresses always have a count of one. A pinned address can have
+    /// a short overlap while the same authenticated client reconnects before
+    /// its dead QUIC connection times out, so those leases are reference
+    /// counted instead of turning a normal reconnect into a minute-long
+    /// outage.
+    allocated: HashMap<IpAddr, Allocation>,
+    /// Addresses pinned to a configured client identity, keyed by its public
+    /// key.
+    ///
+    /// Held for the process lifetime, not just while the client is connected:
+    /// otherwise a dynamic client could take the address an offline client is
+    /// expected to reappear on, and that client would then be unable to attach.
+    reserved: HashMap<IpAddr, Vec<u8>>,
     /// Next candidate for v4 allocation (host part counter).
     v4_next: u32,
     /// Next candidate for v6 allocation (host part counter).
     v6_next: u128,
+}
+
+/// One live address lease.
+struct Allocation {
+    claims: usize,
+    /// Public key that owns a pinned lease. Dynamic leases have no owner.
+    owner: Option<Vec<u8>>,
+}
+
+impl Allocation {
+    fn dynamic() -> Self {
+        Self {
+            claims: 1,
+            owner: None,
+        }
+    }
+
+    fn pinned(owner: &[u8]) -> Self {
+        Self {
+            claims: 1,
+            owner: Some(owner.to_vec()),
+        }
+    }
 }
 
 impl AddressPool {
@@ -73,11 +115,113 @@ impl AddressPool {
         Ok(Self {
             v4_net,
             v6_net,
-            allocated: HashSet::new(),
-            // Start at 1 to skip the network address.
-            v4_next: 1,
-            v6_next: 1,
+            allocated: HashMap::new(),
+            reserved: HashMap::new(),
+            // network+1 belongs to the server's TUN device, so clients start at
+            // network+2 in both families.
+            v4_next: 2,
+            v6_next: 2,
         })
+    }
+
+    /// Withhold `addr` from dynamic allocation for the process lifetime.
+    ///
+    /// Called once per pinned client address at startup. The address must lie
+    /// inside the matching pool range, because the TUN device is configured
+    /// with that range as its on-link prefix and the server would have no route
+    /// back to anything outside it.
+    pub fn reserve_static(&mut self, addr: IpAddr, owner: &[u8]) -> Result<(), PoolError> {
+        if !self.in_range(&addr) {
+            return Err(PoolError::OutOfRange(addr));
+        }
+        // The gateway address is the pool network plus one, and it belongs to
+        // the server's own TUN device.
+        if self.is_gateway(&addr) {
+            return Err(PoolError::AlreadyAllocated(addr));
+        }
+        if self.reserved.contains_key(&addr) {
+            return Err(PoolError::AlreadyAllocated(addr));
+        }
+        self.reserved.insert(addr, owner.to_vec());
+        Ok(())
+    }
+
+    /// Replace the whole set of pinned addresses.
+    ///
+    /// Every address is validated before anything changes, so a roster that
+    /// fails validation leaves the previous reservations intact rather than
+    /// half-applied. Live leases live in a separate map and are untouched: an
+    /// address dropped here stays held until the tunnel using it goes away.
+    pub fn set_static_reservations<K: AsRef<[u8]>>(
+        &mut self,
+        reservations: impl IntoIterator<Item = (IpAddr, K)>,
+    ) -> Result<(), PoolError> {
+        let mut next = HashMap::new();
+        for (addr, owner) in reservations {
+            if !self.in_range(&addr) {
+                return Err(PoolError::OutOfRange(addr));
+            }
+            if self.is_gateway(&addr) {
+                return Err(PoolError::AlreadyAllocated(addr));
+            }
+            if next.insert(addr, owner.as_ref().to_vec()).is_some() {
+                return Err(PoolError::AlreadyAllocated(addr));
+            }
+        }
+        self.reserved = next;
+        Ok(())
+    }
+
+    /// Take a specific address for a tunnel.
+    ///
+    /// Used for clients pinned to a fixed address. Reserved addresses are
+    /// reference counted: a reconnect can overlap its stale predecessor until
+    /// the old QUIC idle timeout fires. Duplicate static addresses across
+    /// different identities are rejected even while a roster reload is moving
+    /// an address from one key to another.
+    pub fn claim(&mut self, addr: IpAddr, owner: &[u8]) -> Result<(), PoolError> {
+        if !self.in_range(&addr) {
+            return Err(PoolError::OutOfRange(addr));
+        }
+        if self.is_gateway(&addr) {
+            return Err(PoolError::AlreadyAllocated(addr));
+        }
+        if !self
+            .reserved
+            .get(&addr)
+            .is_some_and(|reserved_owner| reserved_owner == owner)
+        {
+            return Err(PoolError::NotReserved(addr));
+        }
+        if let Some(allocation) = self.allocated.get_mut(&addr) {
+            if allocation.owner.as_deref() != Some(owner) {
+                return Err(PoolError::AlreadyAllocated(addr));
+            }
+            allocation.claims += 1;
+            return Ok(());
+        }
+        self.allocated.insert(addr, Allocation::pinned(owner));
+        Ok(())
+    }
+
+    /// Whether `addr` falls inside the pool range for its family.
+    fn in_range(&self, addr: &IpAddr) -> bool {
+        match addr {
+            IpAddr::V4(v4) => self.v4_net.is_some_and(|net| net.contains(v4)),
+            IpAddr::V6(v6) => self.v6_net.is_some_and(|net| net.contains(v6)),
+        }
+    }
+
+    /// Whether `addr` is the network-plus-one address assigned to the TUN device.
+    fn is_gateway(&self, addr: &IpAddr) -> bool {
+        match addr {
+            IpAddr::V4(v4) => self
+                .v4_net
+                .is_some_and(|net| u32::from(net.network()) | 1 == u32::from(*v4)),
+            IpAddr::V6(v6) => self
+                .v6_net
+                .is_some_and(|net| u128::from(net.network()) | 1 == u128::from(*v6)),
+        }
     }
 
     /// Allocate the next available IPv4 address.
@@ -86,20 +230,21 @@ impl AddressPool {
         let host_mask = !u32::from(net.netmask());
         let net_addr = u32::from(net.network());
 
-        // max_hosts excludes the broadcast address.
-        let max_hosts = host_mask; // e.g. /30 -> mask=3, usable host offsets 1..2
-        if max_hosts == 0 {
+        // Offset 0 is the network, 1 is the TUN gateway, and host_mask is the
+        // broadcast address. A /30 therefore has one client address: .2.
+        let max_hosts = host_mask;
+        if max_hosts <= 2 {
             return Err(PoolError::Exhausted);
         }
 
-        // We'll scan at most (max_hosts - 1) candidates (offsets 1..max_hosts-1).
+        // Scan offsets 2 through host_mask-1 at most once.
         let mut checked = 0u64;
-        let total_usable = (max_hosts - 1) as u64; // offsets 1 through max_hosts-1
+        let total_usable = (max_hosts - 2) as u64;
 
         while checked < total_usable {
             // Wrap around if we've gone past the usable range.
             if self.v4_next >= max_hosts {
-                self.v4_next = 1;
+                self.v4_next = 2;
             }
 
             let addr = Ipv4Addr::from(net_addr | self.v4_next);
@@ -107,8 +252,8 @@ impl AddressPool {
             checked += 1;
 
             let ip = IpAddr::V4(addr);
-            if !self.allocated.contains(&ip) {
-                self.allocated.insert(ip);
+            if !self.allocated.contains_key(&ip) && !self.reserved.contains_key(&ip) {
+                self.allocated.insert(ip, Allocation::dynamic());
                 return Ok(addr);
             }
         }
@@ -127,28 +272,33 @@ impl AddressPool {
             (1u128 << (128 - prefix_len)) - 1
         };
 
-        if host_mask == 0 {
+        // Offset 0 is the subnet-router anycast address and 1 belongs to the
+        // TUN gateway. IPv6 has no broadcast, so offsets 2..=host_mask remain.
+        if host_mask <= 1 {
             return Err(PoolError::Exhausted);
         }
 
-        // For IPv6 we don't reserve a "broadcast", so usable offsets are 1..host_mask.
-        let total_usable = host_mask; // offsets 1 through host_mask
+        let total_usable = host_mask - 1;
         // Cap iteration to avoid spinning on enormous /64 pools.
         let max_iter = total_usable.min(u64::MAX as u128) as u64;
         let mut checked = 0u64;
 
         while checked < max_iter {
             if self.v6_next > host_mask {
-                self.v6_next = 1;
+                self.v6_next = 2;
             }
 
             let addr = Ipv6Addr::from(net_bits | self.v6_next);
-            self.v6_next += 1;
+            self.v6_next = if self.v6_next == host_mask {
+                2
+            } else {
+                self.v6_next + 1
+            };
             checked += 1;
 
             let ip = IpAddr::V6(addr);
-            if !self.allocated.contains(&ip) {
-                self.allocated.insert(ip);
+            if !self.allocated.contains_key(&ip) && !self.reserved.contains_key(&ip) {
+                self.allocated.insert(ip, Allocation::dynamic());
                 return Ok(addr);
             }
         }
@@ -158,13 +308,21 @@ impl AddressPool {
 
     /// Release an address back to the pool.
     pub fn release(&mut self, addr: IpAddr) -> bool {
-        self.allocated.remove(&addr)
+        let Some(allocation) = self.allocated.get_mut(&addr) else {
+            return false;
+        };
+        if allocation.claims > 1 {
+            allocation.claims -= 1;
+        } else {
+            self.allocated.remove(&addr);
+        }
+        true
     }
 
     /// Release multiple addresses.
     pub fn release_all(&mut self, addrs: &[IpAddr]) {
         for addr in addrs {
-            self.allocated.remove(addr);
+            self.release(*addr);
         }
     }
 
@@ -175,7 +333,7 @@ impl AddressPool {
 
     /// Check if an address is currently allocated.
     pub fn is_allocated(&self, addr: &IpAddr) -> bool {
-        self.allocated.contains(addr)
+        self.allocated.contains_key(addr)
     }
 }
 
@@ -211,6 +369,145 @@ mod tests {
         ));
     }
 
+    // ── Pinned addresses ──────────────────────────────────────────────
+
+    #[test]
+    fn reserved_addresses_are_skipped_by_dynamic_allocation() {
+        let mut pool = AddressPool::new("10.89.0.0/24", "fd00:abcd::/64").unwrap();
+        let pinned_v4 = "10.89.0.2".parse().unwrap();
+        let pinned_v6 = "fd00:abcd::2".parse().unwrap();
+        pool.reserve_static(pinned_v4, b"client").unwrap();
+        pool.reserve_static(pinned_v6, b"client").unwrap();
+
+        // Reserving must not consume the address, only withhold it.
+        assert_eq!(pool.allocated_count(), 0);
+
+        // The gateway at .1 and the pinned .2 are both skipped.
+        assert_eq!(pool.allocate_v4().unwrap(), Ipv4Addr::new(10, 89, 0, 3));
+        assert_eq!(pool.allocate_v4().unwrap(), Ipv4Addr::new(10, 89, 0, 4));
+        assert_eq!(pool.allocate_v6().unwrap().to_string(), "fd00:abcd::3");
+        assert_eq!(pool.allocate_v6().unwrap().to_string(), "fd00:abcd::4");
+    }
+
+    #[test]
+    fn reserved_address_stays_claimable_by_its_owner() {
+        let mut pool = AddressPool::new("10.89.0.0/24", "").unwrap();
+        let pinned = "10.89.0.2".parse().unwrap();
+        pool.reserve_static(pinned, b"owner").unwrap();
+
+        pool.claim(pinned, b"owner").unwrap();
+        assert!(pool.is_allocated(&pinned));
+
+        // A reconnect with the same registered key can overlap the stale
+        // connection until its idle timeout fires.
+        pool.claim(pinned, b"owner").unwrap();
+
+        // Releasing one of the overlapping tunnels keeps the other lease live.
+        assert!(pool.release(pinned));
+        assert!(pool.is_allocated(&pinned));
+        assert!(pool.release(pinned));
+        assert!(!pool.is_allocated(&pinned));
+
+        // Once both tunnels are gone the same pinned address is claimable again.
+        pool.claim(pinned, b"owner").unwrap();
+    }
+
+    #[test]
+    fn reservation_owner_changes_are_isolated_during_reload() {
+        let mut pool = AddressPool::new("10.89.0.0/24", "").unwrap();
+        let pinned = "10.89.0.2".parse().unwrap();
+        pool.reserve_static(pinned, b"old-key").unwrap();
+        assert_eq!(
+            pool.reserve_static(pinned, b"new-key"),
+            Err(PoolError::AlreadyAllocated(pinned))
+        );
+        assert_eq!(
+            pool.claim(pinned, b"new-key"),
+            Err(PoolError::NotReserved(pinned))
+        );
+        pool.claim(pinned, b"old-key").unwrap();
+
+        // A roster reload moves the address to another public key. The new
+        // identity cannot overlap the old identity's still-live lease.
+        pool.set_static_reservations([(pinned, b"new-key".as_slice())])
+            .unwrap();
+        assert_eq!(
+            pool.claim(pinned, b"new-key"),
+            Err(PoolError::AlreadyAllocated(pinned))
+        );
+        // Nor may the removed identity open another tunnel in the narrow gap
+        // between updating reservations and replacing the shared roster.
+        assert_eq!(
+            pool.claim(pinned, b"old-key"),
+            Err(PoolError::NotReserved(pinned))
+        );
+
+        pool.release(pinned);
+        pool.claim(pinned, b"new-key").unwrap();
+    }
+
+    #[test]
+    fn reserve_static_rejects_addresses_outside_the_pool() {
+        let mut pool = AddressPool::new("10.89.0.0/24", "fd00:abcd::/64").unwrap();
+        let outside = "10.90.0.2".parse().unwrap();
+        assert_eq!(
+            pool.reserve_static(outside, b"owner"),
+            Err(PoolError::OutOfRange(outside))
+        );
+
+        // Right family, wrong pool.
+        let outside_v6 = "fd00:ffff::2".parse().unwrap();
+        assert_eq!(
+            pool.reserve_static(outside_v6, b"owner"),
+            Err(PoolError::OutOfRange(outside_v6))
+        );
+
+        // A family the pool does not cover at all.
+        let mut v4_only = AddressPool::new("10.89.0.0/24", "").unwrap();
+        let v6 = "fd00:abcd::2".parse().unwrap();
+        assert_eq!(
+            v4_only.reserve_static(v6, b"owner"),
+            Err(PoolError::OutOfRange(v6))
+        );
+    }
+
+    #[test]
+    fn reserve_static_rejects_the_tun_gateway() {
+        // network+1 is what the server's own TUN device answers on, so handing
+        // it to a client would black-hole that client's return traffic.
+        let mut pool = AddressPool::new("10.89.0.0/24", "fd00:abcd::/64").unwrap();
+        let v4_gw = "10.89.0.1".parse().unwrap();
+        let v6_gw = "fd00:abcd::1".parse().unwrap();
+        assert_eq!(
+            pool.reserve_static(v4_gw, b"owner"),
+            Err(PoolError::AlreadyAllocated(v4_gw))
+        );
+        assert_eq!(
+            pool.reserve_static(v6_gw, b"owner"),
+            Err(PoolError::AlreadyAllocated(v6_gw))
+        );
+    }
+
+    #[test]
+    fn claim_rejects_addresses_outside_the_pool() {
+        let mut pool = AddressPool::new("10.89.0.0/24", "").unwrap();
+        let outside = "192.168.1.5".parse().unwrap();
+        assert_eq!(
+            pool.claim(outside, b"owner"),
+            Err(PoolError::OutOfRange(outside))
+        );
+    }
+
+    #[test]
+    fn a_dynamic_address_is_not_claimable_as_a_static_lease() {
+        let mut pool = AddressPool::new("10.89.0.0/24", "").unwrap();
+        let first = IpAddr::V4(pool.allocate_v4().unwrap());
+        assert_eq!(
+            pool.claim(first, b"owner"),
+            Err(PoolError::NotReserved(first))
+        );
+    }
+
     // ── IPv4 allocation ───────────────────────────────────────────────
 
     #[test]
@@ -220,19 +517,17 @@ mod tests {
         let a2 = pool.allocate_v4().unwrap();
         let a3 = pool.allocate_v4().unwrap();
 
-        assert_eq!(a1, Ipv4Addr::new(10, 89, 0, 1));
-        assert_eq!(a2, Ipv4Addr::new(10, 89, 0, 2));
-        assert_eq!(a3, Ipv4Addr::new(10, 89, 0, 3));
+        assert_eq!(a1, Ipv4Addr::new(10, 89, 0, 2));
+        assert_eq!(a2, Ipv4Addr::new(10, 89, 0, 3));
+        assert_eq!(a3, Ipv4Addr::new(10, 89, 0, 4));
         assert_eq!(pool.allocated_count(), 3);
     }
 
     #[test]
     fn allocate_v4_exhaustion() {
-        // /30 gives 4 addresses: network, 2 hosts, broadcast
-        // host_mask = 3, so max_hosts = 3, usable = 1,2
+        // /30 gives 4 addresses: network, gateway, one client, broadcast.
         let mut pool = AddressPool::new("10.0.0.0/30", "").unwrap();
-        let _a1 = pool.allocate_v4().unwrap(); // .1
-        let _a2 = pool.allocate_v4().unwrap(); // .2
+        assert_eq!(pool.allocate_v4().unwrap(), Ipv4Addr::new(10, 0, 0, 2));
         assert!(matches!(pool.allocate_v4(), Err(PoolError::Exhausted)));
     }
 
@@ -240,13 +535,12 @@ mod tests {
     fn allocate_v4_release_reuse() {
         let mut pool = AddressPool::new("10.0.0.0/30", "").unwrap();
         let a1 = pool.allocate_v4().unwrap();
-        let _a2 = pool.allocate_v4().unwrap();
         // Pool is full
         assert!(pool.allocate_v4().is_err());
 
         // Release a1
         assert!(pool.release(IpAddr::V4(a1)));
-        assert_eq!(pool.allocated_count(), 1);
+        assert_eq!(pool.allocated_count(), 0);
 
         // Can allocate again — should get a1 back (wraps around)
         let a3 = pool.allocate_v4().unwrap();
@@ -267,17 +561,22 @@ mod tests {
         let a1 = pool.allocate_v6().unwrap();
         let a2 = pool.allocate_v6().unwrap();
 
-        assert_eq!(a1, "fd00:abcd::1".parse::<Ipv6Addr>().unwrap());
-        assert_eq!(a2, "fd00:abcd::2".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(a1, "fd00:abcd::2".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(a2, "fd00:abcd::3".parse::<Ipv6Addr>().unwrap());
     }
 
     #[test]
     fn allocate_v6_exhaustion() {
-        // /126 gives 4 addresses, usable hosts = 1,2,3
+        // /126 gives network, gateway, and two client addresses.
         let mut pool = AddressPool::new("", "fd00::/126").unwrap();
-        let _a1 = pool.allocate_v6().unwrap();
-        let _a2 = pool.allocate_v6().unwrap();
-        let _a3 = pool.allocate_v6().unwrap();
+        assert_eq!(
+            pool.allocate_v6().unwrap(),
+            "fd00::2".parse::<Ipv6Addr>().unwrap()
+        );
+        assert_eq!(
+            pool.allocate_v6().unwrap(),
+            "fd00::3".parse::<Ipv6Addr>().unwrap()
+        );
         assert!(matches!(pool.allocate_v6(), Err(PoolError::Exhausted)));
     }
 
@@ -322,7 +621,7 @@ mod tests {
     fn allocate_many_v4() {
         let mut pool = AddressPool::new("10.89.0.0/16", "").unwrap();
         // Allocate 100 addresses
-        for i in 1..=100u32 {
+        for i in 2..=101u32 {
             let addr = pool.allocate_v4().unwrap();
             let expected = Ipv4Addr::from(u32::from(Ipv4Addr::new(10, 89, 0, 0)) | i);
             assert_eq!(addr, expected);

--- a/src/client_identity.rs
+++ b/src/client_identity.rs
@@ -1,0 +1,529 @@
+//! Pre-registered client identities for TLS client-certificate authentication.
+//!
+//! Clients built against Cloudflare's WARP MASQUE endpoint authenticate with a
+//! TLS client certificate rather than `Proxy-Authorization`, and the
+//! certificate is self-signed, freshly minted per connection, and carries no
+//! usable subject: only the key inside it identifies the caller. So the roster
+//! is keyed by public key, and the certificate around it is treated as a
+//! disposable envelope.
+//!
+//! Nothing here talks to an enrollment API. An operator generates a key pair
+//! per client, records the public key in `[[clients]]`, and hands the private
+//! key over out of band.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use anyhow::{Context, bail};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::nid::Nid;
+use boring::pkey::{PKey, Public};
+use boring::x509::X509;
+
+use crate::config::ClientEntry;
+
+/// One pre-registered client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientIdentity {
+    /// Operator-chosen label, used in logs.
+    pub name: String,
+    /// The canonical SubjectPublicKeyInfo DER this identity was matched by.
+    ///
+    /// Kept on the identity so a live connection can be rechecked against a
+    /// replaced roster without re-parsing its certificate.
+    pub key: Vec<u8>,
+    /// Fixed IPv4 for this client's CONNECT-IP tunnels, if configured.
+    pub ipv4: Option<Ipv4Addr>,
+    /// Fixed IPv6 for this client's CONNECT-IP tunnels, if configured.
+    pub ipv6: Option<Ipv6Addr>,
+}
+
+impl ClientIdentity {
+    /// The fixed addresses this client is pinned to, in no particular order.
+    pub fn static_addresses(&self) -> impl Iterator<Item = IpAddr> + '_ {
+        self.ipv4
+            .map(IpAddr::V4)
+            .into_iter()
+            .chain(self.ipv6.map(IpAddr::V6))
+    }
+
+    /// Whether any address is pinned, i.e. whether the address pool should be
+    /// bypassed for this client.
+    pub fn has_static_addresses(&self) -> bool {
+        self.ipv4.is_some() || self.ipv6.is_some()
+    }
+}
+
+/// The configured clients, indexed by public key.
+#[derive(Debug, Default)]
+pub struct ClientRegistry {
+    /// Keyed by canonical SubjectPublicKeyInfo DER.
+    ///
+    /// Both the roster and the presented certificate are re-encoded through
+    /// BoringSSL before they reach this map, so a key written as PEM matches
+    /// the same key written as base64 DER, and a non-canonical encoding on the
+    /// wire cannot dodge a lookup.
+    by_spki: HashMap<Vec<u8>, Arc<ClientIdentity>>,
+}
+
+impl ClientRegistry {
+    /// Build the registry from the `[[clients]]` tables.
+    ///
+    /// Every problem here is a configuration mistake that would otherwise show
+    /// up as an unexplained handshake failure, so all of them are fatal.
+    pub fn from_config(entries: &[ClientEntry]) -> anyhow::Result<Self> {
+        let mut by_spki: HashMap<Vec<u8>, Arc<ClientIdentity>> =
+            HashMap::with_capacity(entries.len());
+
+        for (position, entry) in entries.iter().enumerate() {
+            // Fall back to the position so every diagnostic can name the entry
+            // even before the operator has labelled it.
+            let label = if entry.name.is_empty() {
+                format!("clients[{position}]")
+            } else {
+                entry.name.clone()
+            };
+
+            let spki = parse_public_key(&entry.public_key)
+                .with_context(|| format!("client {label}: invalid public_key"))?;
+
+            let ipv4 = entry
+                .ipv4
+                .as_deref()
+                .map(|text| {
+                    text.parse::<Ipv4Addr>()
+                        .with_context(|| format!("client {label}: invalid ipv4 {text:?}"))
+                })
+                .transpose()?;
+            let ipv6 = entry
+                .ipv6
+                .as_deref()
+                .map(|text| {
+                    text.parse::<Ipv6Addr>()
+                        .with_context(|| format!("client {label}: invalid ipv6 {text:?}"))
+                })
+                .transpose()?;
+
+            let identity = Arc::new(ClientIdentity {
+                name: label.clone(),
+                key: spki.clone(),
+                ipv4,
+                ipv6,
+            });
+
+            // Two entries sharing a key means one of them can never be
+            // selected, and which one wins would come down to file order.
+            if let Some(existing) = by_spki.insert(spki, identity) {
+                bail!(
+                    "clients {} and {label} share the same public_key",
+                    existing.name
+                );
+            }
+        }
+
+        // A fixed address handed to two clients would make the routing table
+        // hand one client's traffic to the other.
+        let mut seen: HashMap<IpAddr, &str> = HashMap::new();
+        for identity in by_spki.values() {
+            for addr in identity.static_addresses() {
+                if let Some(other) = seen.insert(addr, &identity.name) {
+                    bail!(
+                        "clients {other} and {} are both pinned to {addr}",
+                        identity.name
+                    );
+                }
+            }
+        }
+
+        Ok(Self { by_spki })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_spki.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.by_spki.len()
+    }
+
+    /// Look an identity up by the key it was matched on.
+    ///
+    /// Used to recheck a live connection after the roster is replaced: an
+    /// identity that is gone, or that no longer matches the entry the
+    /// connection was admitted under, must not keep its tunnel.
+    pub fn lookup_key(&self, key: &[u8]) -> Option<&Arc<ClientIdentity>> {
+        self.by_spki.get(key)
+    }
+
+    /// Whether `identity` is still current, i.e. present and unchanged.
+    pub fn still_authorizes(&self, identity: &ClientIdentity) -> bool {
+        self.lookup_key(&identity.key)
+            .is_some_and(|current| **current == *identity)
+    }
+
+    /// Every fixed address across the roster.
+    pub fn static_addresses(&self) -> impl Iterator<Item = IpAddr> + '_ {
+        self.by_spki
+            .values()
+            .flat_map(|identity| identity.static_addresses())
+    }
+
+    /// Every fixed address together with the public key allowed to claim it.
+    pub fn static_reservations(&self) -> impl Iterator<Item = (IpAddr, &[u8])> + '_ {
+        self.by_spki.values().flat_map(|identity| {
+            identity
+                .static_addresses()
+                .map(move |addr| (addr, identity.key.as_slice()))
+        })
+    }
+
+    /// Resolve a presented certificate to a configured client.
+    ///
+    /// Only the key matters: the certificate is self-signed with an empty
+    /// subject and a fresh serial per connection, so its chain, validity, and
+    /// name carry no information worth checking.
+    pub fn identify(&self, cert_der: &[u8]) -> Result<Arc<ClientIdentity>, IdentityError> {
+        let spki = spki_from_cert_der(cert_der).map_err(|_| IdentityError::MalformedCertificate)?;
+        match self.by_spki.get(&spki) {
+            Some(identity) => Ok(Arc::clone(identity)),
+            // Hand back the key so the operator can paste it straight into a
+            // `[[clients]]` entry instead of reverse-engineering it.
+            None => Err(IdentityError::UnknownKey(STANDARD.encode(&spki))),
+        }
+    }
+}
+
+/// A roster that can be replaced while the server is running.
+///
+/// Revoking a client would otherwise mean restarting the process, which drops
+/// every other client's tunnel to remove one. Reads happen once per handshake
+/// rather than per packet, so an `RwLock` is cheap enough and avoids a
+/// dependency for the same effect.
+#[derive(Debug)]
+pub struct SharedRoster {
+    current: RwLock<Arc<ClientRegistry>>,
+    /// Bumped on every replacement.
+    ///
+    /// Event loops compare this against the generation they last acted on, so
+    /// a reload costs one atomic read per sweep rather than a rescan.
+    generation: AtomicU64,
+}
+
+impl Default for SharedRoster {
+    fn default() -> Self {
+        Self::new(ClientRegistry::default())
+    }
+}
+
+impl SharedRoster {
+    pub fn new(registry: ClientRegistry) -> Self {
+        Self {
+            current: RwLock::new(Arc::new(registry)),
+            generation: AtomicU64::new(0),
+        }
+    }
+
+    /// The roster in force right now.
+    pub fn load(&self) -> Arc<ClientRegistry> {
+        Arc::clone(&self.current.read().expect("roster poisoned"))
+    }
+
+    /// Install a new roster, returning its generation.
+    pub fn replace(&self, registry: ClientRegistry) -> u64 {
+        *self.current.write().expect("roster poisoned") = Arc::new(registry);
+        // Released after the write, so an event loop that observes the new
+        // generation is guaranteed to read the new roster.
+        self.generation.fetch_add(1, Ordering::Release) + 1
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+}
+
+/// Why a presented client certificate was not accepted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityError {
+    /// The certificate did not parse, or its key is not a supported type.
+    MalformedCertificate,
+    /// A well-formed key that is not in the roster. Carries the base64 SPKI so
+    /// it can be logged for enrollment.
+    UnknownKey(String),
+}
+
+impl std::fmt::Display for IdentityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IdentityError::MalformedCertificate => {
+                write!(
+                    f,
+                    "client certificate is malformed or uses an unsupported key"
+                )
+            }
+            IdentityError::UnknownKey(key) => {
+                write!(f, "client public key is not registered: {key}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IdentityError {}
+
+/// Extract the canonical SubjectPublicKeyInfo DER from a certificate.
+pub fn spki_from_cert_der(cert_der: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let cert = X509::from_der(cert_der).context("certificate is not valid DER")?;
+    let key = cert.public_key().context("certificate has no public key")?;
+    canonical_spki(&key)
+}
+
+/// Parse a roster `public_key` value: base64 SPKI DER, or a PEM public key.
+///
+/// Both forms show up in practice — vendor APIs exchange the base64 DER, while
+/// `openssl x509 -pubkey` prints PEM — and telling them apart is unambiguous.
+pub fn parse_public_key(text: &str) -> anyhow::Result<Vec<u8>> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        bail!("public key is empty");
+    }
+
+    let key = if trimmed.contains("-----BEGIN") {
+        PKey::public_key_from_pem(trimmed.as_bytes()).context("not a valid PEM public key")?
+    } else {
+        // Tolerate the line breaks that survive a copy/paste out of JSON.
+        let compact: String = trimmed
+            .chars()
+            .filter(|c| !c.is_ascii_whitespace())
+            .collect();
+        let der = STANDARD
+            .decode(&compact)
+            .context("not valid base64 (expected SubjectPublicKeyInfo DER or a PEM block)")?;
+        PKey::public_key_from_der(&der).context("not a valid SubjectPublicKeyInfo DER key")?
+    };
+
+    canonical_spki(&key)
+}
+
+/// Re-encode a public key to its canonical SPKI DER, rejecting key types no
+/// known client uses.
+fn canonical_spki(key: &PKey<Public>) -> anyhow::Result<Vec<u8>> {
+    // MASQUE clients in this family use secp256r1 exclusively, and accepting
+    // anything else would mean advertising support we cannot test.
+    let ec = key
+        .ec_key()
+        .context("public key is not ECDSA (expected secp256r1 / P-256)")?;
+    match ec.group().curve_name() {
+        Some(Nid::X9_62_PRIME256V1) => {}
+        other => bail!(
+            "public key uses an unsupported curve {:?} (expected secp256r1 / P-256)",
+            other.map_or("unknown", |nid| nid.short_name().unwrap_or("unknown"))
+        ),
+    }
+
+    key.public_key_to_der()
+        .context("failed to encode public key")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boring::asn1::Asn1Time;
+    use boring::bn::BigNum;
+    use boring::ec::{EcGroup, EcKey};
+    use boring::hash::MessageDigest;
+    use boring::pkey::Private;
+    use boring::x509::X509Builder;
+
+    fn p256_key() -> PKey<Private> {
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+    }
+
+    fn public_key_b64(key: &PKey<Private>) -> String {
+        STANDARD.encode(key.public_key_to_der().unwrap())
+    }
+
+    /// A stand-in for what these clients present: self-signed, empty subject,
+    /// serial 0, short validity.
+    fn self_signed_der(key: &PKey<Private>) -> Vec<u8> {
+        let mut builder = X509Builder::new().unwrap();
+        builder.set_version(2).unwrap();
+        builder
+            .set_serial_number(&BigNum::from_u32(0).unwrap().to_asn1_integer().unwrap())
+            .unwrap();
+        builder
+            .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&Asn1Time::days_from_now(1).unwrap())
+            .unwrap();
+        builder.set_pubkey(key).unwrap();
+        builder.sign(key, MessageDigest::sha256()).unwrap();
+        builder.build().to_der().unwrap()
+    }
+
+    fn entry(name: &str, public_key: String) -> ClientEntry {
+        ClientEntry {
+            name: name.into(),
+            public_key,
+            ipv4: None,
+            ipv6: None,
+        }
+    }
+
+    #[test]
+    fn identifies_a_registered_key_from_a_self_signed_certificate() {
+        let key = p256_key();
+        let registry =
+            ClientRegistry::from_config(&[entry("laptop", public_key_b64(&key))]).unwrap();
+
+        let identity = registry.identify(&self_signed_der(&key)).unwrap();
+        assert_eq!(identity.name, "laptop");
+    }
+
+    #[test]
+    fn pem_and_base64_der_spellings_of_one_key_are_the_same_identity() {
+        let key = p256_key();
+        let pem = String::from_utf8(key.public_key_to_pem().unwrap()).unwrap();
+
+        let from_pem = ClientRegistry::from_config(&[entry("a", pem)]).unwrap();
+        let from_der = ClientRegistry::from_config(&[entry("a", public_key_b64(&key))]).unwrap();
+
+        let cert = self_signed_der(&key);
+        assert!(from_pem.identify(&cert).is_ok());
+        assert!(from_der.identify(&cert).is_ok());
+    }
+
+    #[test]
+    fn base64_with_embedded_newlines_still_parses() {
+        let key = p256_key();
+        let wrapped = public_key_b64(&key)
+            .as_bytes()
+            .chunks(24)
+            .map(|chunk| String::from_utf8(chunk.to_vec()).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let registry = ClientRegistry::from_config(&[entry("a", wrapped)]).unwrap();
+        assert!(registry.identify(&self_signed_der(&key)).is_ok());
+    }
+
+    #[test]
+    fn unregistered_key_is_reported_with_its_encoding() {
+        let registered = p256_key();
+        let stranger = p256_key();
+        let registry =
+            ClientRegistry::from_config(&[entry("known", public_key_b64(&registered))]).unwrap();
+
+        match registry.identify(&self_signed_der(&stranger)) {
+            // The reported key has to be directly pasteable into the roster.
+            Err(IdentityError::UnknownKey(key)) => {
+                assert_eq!(key, public_key_b64(&stranger));
+            }
+            other => panic!("expected an unknown-key rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_certificate_is_rejected() {
+        let registry =
+            ClientRegistry::from_config(&[entry("a", public_key_b64(&p256_key()))]).unwrap();
+        assert_eq!(
+            registry.identify(b"not a certificate"),
+            Err(IdentityError::MalformedCertificate)
+        );
+    }
+
+    #[test]
+    fn empty_registry_accepts_nobody() {
+        let registry = ClientRegistry::default();
+        assert!(registry.is_empty());
+        assert!(registry.identify(&self_signed_der(&p256_key())).is_err());
+    }
+
+    #[test]
+    fn rejects_non_p256_keys() {
+        let rsa = PKey::from_rsa(boring::rsa::Rsa::generate(2048).unwrap()).unwrap();
+        let spki = STANDARD.encode(rsa.public_key_to_der().unwrap());
+        let error = ClientRegistry::from_config(&[entry("a", spki)]).unwrap_err();
+        assert!(format!("{error:#}").contains("P-256"), "{error:#}");
+
+        let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
+        let p384 = PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
+        let spki = STANDARD.encode(p384.public_key_to_der().unwrap());
+        let error = ClientRegistry::from_config(&[entry("b", spki)]).unwrap_err();
+        assert!(format!("{error:#}").contains("secp256r1"), "{error:#}");
+    }
+
+    #[test]
+    fn rejects_malformed_roster_entries() {
+        assert!(ClientRegistry::from_config(&[entry("a", String::new())]).is_err());
+        assert!(ClientRegistry::from_config(&[entry("a", "!!not base64!!".into())]).is_err());
+
+        let key = p256_key();
+        let bad_ipv4 = ClientEntry {
+            name: "a".into(),
+            public_key: public_key_b64(&key),
+            ipv4: Some("10.89.0.999".into()),
+            ipv6: None,
+        };
+        assert!(ClientRegistry::from_config(&[bad_ipv4]).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_keys_and_duplicate_pinned_addresses() {
+        let key = p256_key();
+        let duplicate = [
+            entry("a", public_key_b64(&key)),
+            entry("b", public_key_b64(&key)),
+        ];
+        let error = ClientRegistry::from_config(&duplicate).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("same public_key"),
+            "{error:#}"
+        );
+
+        let pinned = |name: &str, key: &PKey<Private>| ClientEntry {
+            name: name.into(),
+            public_key: public_key_b64(key),
+            ipv4: Some("10.89.0.2".into()),
+            ipv6: None,
+        };
+        let clash = [pinned("a", &p256_key()), pinned("b", &p256_key())];
+        let error = ClientRegistry::from_config(&clash).unwrap_err();
+        assert!(format!("{error:#}").contains("pinned to"), "{error:#}");
+    }
+
+    #[test]
+    fn unnamed_entries_are_labelled_by_position() {
+        let error = ClientRegistry::from_config(&[entry("", "!!bad!!".into())]).unwrap_err();
+        assert!(format!("{error:#}").contains("clients[0]"), "{error:#}");
+    }
+
+    #[test]
+    fn static_addresses_are_collected_across_the_roster() {
+        let clients = [
+            ClientEntry {
+                name: "a".into(),
+                public_key: public_key_b64(&p256_key()),
+                ipv4: Some("10.89.0.2".into()),
+                ipv6: Some("fd00:abcd::2".into()),
+            },
+            entry("b", public_key_b64(&p256_key())),
+        ];
+        let registry = ClientRegistry::from_config(&clients).unwrap();
+        assert_eq!(registry.len(), 2);
+
+        let mut addrs: Vec<IpAddr> = registry.static_addresses().collect();
+        addrs.sort();
+        assert_eq!(
+            addrs,
+            vec![
+                "10.89.0.2".parse::<IpAddr>().unwrap(),
+                "fd00:abcd::2".parse::<IpAddr>().unwrap(),
+            ]
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,11 @@ pub struct ServerConfig {
     pub tcp_proxy: TcpProxySection,
     pub udp_proxy: UdpProxySection,
     pub ip_proxy: IpProxySection,
+    /// Pre-registered clients, identified by their TLS client certificate key.
+    ///
+    /// Only consulted when `auth.mode = "client_cert"`. Written as repeated
+    /// `[[clients]]` tables.
+    pub clients: Vec<ClientEntry>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -40,10 +45,27 @@ pub struct TlsSection {
     pub key_path: PathBuf,
 }
 
+/// How clients prove who they are.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthMode {
+    /// RFC 7617 `Proxy-Authorization: Basic`, verified per request.
+    #[default]
+    Basic,
+    /// A TLS client certificate, matched against the `[[clients]]` roster by
+    /// public key during the QUIC handshake.
+    ///
+    /// This is what Cloudflare's WARP MASQUE endpoint does, and what clients
+    /// built against it (usque) expect: they never send `Proxy-Authorization`.
+    ClientCert,
+}
+
 #[derive(Clone, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct AuthSection {
+    /// Master switch. `false` disables authentication whatever `mode` says.
     pub enabled: bool,
+    pub mode: AuthMode,
     pub username: String,
     pub password_hash: String,
 }
@@ -52,6 +74,7 @@ impl std::fmt::Debug for AuthSection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AuthSection")
             .field("enabled", &self.enabled)
+            .field("mode", &self.mode)
             .field("username", &self.username)
             .field(
                 "password_hash",
@@ -63,6 +86,43 @@ impl std::fmt::Debug for AuthSection {
             )
             .finish()
     }
+}
+
+impl AuthSection {
+    /// Whether `Proxy-Authorization` is required on every CONNECT request.
+    pub fn basic_enabled(&self) -> bool {
+        self.enabled && self.mode == AuthMode::Basic
+    }
+
+    /// Whether a client certificate is required to complete the handshake.
+    pub fn client_cert_enabled(&self) -> bool {
+        self.enabled && self.mode == AuthMode::ClientCert
+    }
+}
+
+/// One pre-registered client.
+///
+/// This replaces the vendor enrollment API for self-hosted setups: the
+/// operator generates a key pair, records its public key here, and hands the
+/// private key to the client out of band.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ClientEntry {
+    /// Label used in logs. Optional, but makes the logs readable.
+    pub name: String,
+    /// The client's ECDSA P-256 public key, as base64 SubjectPublicKeyInfo DER
+    /// or a `-----BEGIN PUBLIC KEY-----` PEM block.
+    pub public_key: String,
+    /// Fixed IPv4 handed to this client's CONNECT-IP tunnels. Must fall inside
+    /// `ip_proxy.ipv4_pool`.
+    ///
+    /// Clients that configure their tunnel interface from a vendor API rather
+    /// than from the `ADDRESS_ASSIGN` capsule need the server to assign the
+    /// same address every time, otherwise the two disagree and every packet is
+    /// dropped as spoofed.
+    pub ipv4: Option<String>,
+    /// Fixed IPv6, inside `ip_proxy.ipv6_pool`.
+    pub ipv6: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -131,6 +191,12 @@ pub struct TcpProxySection {
 pub struct IpProxySection {
     pub enabled: bool,
     pub uri_template: String,
+    /// Accepted `:protocol` values for an Extended CONNECT IP request.
+    ///
+    /// RFC 9484 registers `connect-ip`. Cloudflare's endpoint uses
+    /// `cf-connect-ip` instead, and clients written against it send only that,
+    /// so both are accepted by default; an RFC client never sends the latter.
+    pub connect_protocols: Vec<String>,
     pub tun_name: String,
     pub tun_mtu: usize,
     /// Open the TUN device with `IFF_VNET_HDR` so the kernel can hand over a
@@ -149,7 +215,10 @@ impl Default for ServerSection {
     fn default() -> Self {
         Self {
             listen_addr: "0.0.0.0:443".parse().unwrap(),
-            idle_timeout_secs: 30,
+            // Comfortably above the 30s keepalive period MASQUE VPN clients
+            // commonly default to, so a tunnel that is merely quiet does not
+            // race its own keepalive to the timeout.
+            idle_timeout_secs: 60,
             max_connections: 10_000,
             max_tunnels_per_connection: 100,
             // Opt-in: sharding changes how connections are distributed, so an
@@ -175,6 +244,7 @@ impl Default for AuthSection {
             // Fail closed in Server::bind until an operator configures
             // credentials or explicitly opts out for a private test setup.
             enabled: true,
+            mode: AuthMode::Basic,
             username: String::new(),
             password_hash: String::new(),
         }
@@ -251,6 +321,7 @@ impl Default for IpProxySection {
         Self {
             enabled: true,
             uri_template: "/.well-known/masque/ip/{target}/{ipproto}/".into(),
+            connect_protocols: vec!["connect-ip".into(), "cf-connect-ip".into()],
             tun_name: "masque0".into(),
             tun_mtu: 1280,
             tun_offload: true,
@@ -273,10 +344,14 @@ mod tests {
     fn defaults_are_sensible() {
         let cfg = ServerConfig::default();
         assert_eq!(cfg.server.listen_addr.port(), 443);
-        assert_eq!(cfg.server.idle_timeout_secs, 30);
+        assert_eq!(cfg.server.idle_timeout_secs, 60);
         assert!(cfg.auth.enabled);
+        assert_eq!(cfg.auth.mode, AuthMode::Basic);
+        assert!(cfg.auth.basic_enabled());
+        assert!(!cfg.auth.client_cert_enabled());
         assert!(cfg.auth.username.is_empty());
         assert!(cfg.auth.password_hash.is_empty());
+        assert!(cfg.clients.is_empty());
         assert!(cfg.quic.enable_dgram);
         assert!(!cfg.quic.enable_udp_gso);
         assert!(cfg.quic.enable_udp_gro);
@@ -289,6 +364,12 @@ mod tests {
         assert!(cfg.udp_proxy.enabled);
         assert!(cfg.ip_proxy.enabled);
         assert_eq!(cfg.ip_proxy.tun_mtu, 1280);
+        // Cloudflare's non-standard identifier is accepted out of the box; an
+        // RFC 9484 client never sends it, so this costs nothing.
+        assert_eq!(
+            cfg.ip_proxy.connect_protocols,
+            vec!["connect-ip", "cf-connect-ip"]
+        );
     }
 
     #[test]
@@ -339,6 +420,63 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
         let debug = format!("{cfg:?}");
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("$argon2id$"));
+    }
+
+    #[test]
+    fn parse_client_cert_auth_mode_with_roster() {
+        let toml = r#"
+[auth]
+enabled = true
+mode = "client_cert"
+
+[[clients]]
+name = "laptop"
+public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdGVzdA=="
+ipv4 = "10.89.0.2"
+ipv6 = "fd00:abcd::2"
+
+[[clients]]
+name = "phone"
+public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb3RoZXI="
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.auth.mode, AuthMode::ClientCert);
+        assert!(cfg.auth.client_cert_enabled());
+        // The Basic pipeline must stand down, or a client certificate would not
+        // be enough on its own.
+        assert!(!cfg.auth.basic_enabled());
+
+        assert_eq!(cfg.clients.len(), 2);
+        assert_eq!(cfg.clients[0].name, "laptop");
+        assert_eq!(cfg.clients[0].ipv4.as_deref(), Some("10.89.0.2"));
+        assert_eq!(cfg.clients[0].ipv6.as_deref(), Some("fd00:abcd::2"));
+        // A roster entry without fixed addresses falls back to the pool.
+        assert_eq!(cfg.clients[1].ipv4, None);
+        assert_eq!(cfg.clients[1].ipv6, None);
+    }
+
+    #[test]
+    fn disabling_auth_overrides_the_mode() {
+        let cfg = parse_toml("[auth]\nenabled = false\nmode = \"client_cert\"\n").unwrap();
+        assert!(!cfg.auth.client_cert_enabled());
+        assert!(!cfg.auth.basic_enabled());
+    }
+
+    #[test]
+    fn parse_unknown_auth_mode_is_rejected() {
+        // A typo here would otherwise silently fall back to Basic and lock out
+        // every client certificate.
+        assert!(parse_toml("[auth]\nmode = \"mtls\"\n").is_err());
+    }
+
+    #[test]
+    fn parse_custom_connect_protocols() {
+        let toml = r#"
+[ip_proxy]
+connect_protocols = ["connect-ip"]
+"#;
+        let cfg = parse_toml(toml).unwrap();
+        assert_eq!(cfg.ip_proxy.connect_protocols, vec!["connect-ip"]);
     }
 
     #[test]
@@ -442,7 +580,7 @@ ipv6_pool = "fd01::/64"
         let toml = r#"
 [server]
 listen_addr = "0.0.0.0:443"
-idle_timeout_secs = 30
+idle_timeout_secs = 60
 max_connections = 10000
 max_tunnels_per_connection = 100
 
@@ -488,6 +626,7 @@ deny_targets = ["127.0.0.0/8", "10.0.0.0/8", "::1/128"]
 [ip_proxy]
 enabled = true
 uri_template = "/.well-known/masque/ip/{target}/{ipproto}/"
+connect_protocols = ["connect-ip", "cf-connect-ip"]
 tun_name = "masque0"
 tun_mtu = 1280
 ipv4_pool = "10.89.0.0/16"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::client_identity::ClientIdentity;
 use crate::fxhash::FxHashMap;
 use crate::tunnel::ip::IpTunnel;
 use crate::tunnel::tcp::{PendingTcpTunnel, TcpTunnel};
@@ -102,6 +103,13 @@ pub struct ClientConnection {
     /// Dense index for this connection, used as the `conn_id` in
     /// `TunnelOwner` and to address the connection from background tasks.
     pub index: u64,
+    /// The roster entry this connection's TLS client certificate resolved to,
+    /// when client-certificate authentication is in use.
+    ///
+    /// Resolved once at handshake completion: the key cannot change for the
+    /// life of the connection, so re-parsing the certificate per request would
+    /// be wasted work.
+    pub(crate) identity: Option<Arc<ClientIdentity>>,
     /// Packet already emitted by quiche but held until `SendInfo::at`.
     pub(crate) deferred_send: DeferredSend,
     /// The deadline this connection currently holds in the server's timer
@@ -120,6 +128,7 @@ impl ClientConnection {
             ip_tunnels: FxHashMap::default(),
             awaiting_auth: FxHashMap::default(),
             index,
+            identity: None,
             deferred_send: DeferredSend::default(),
             scheduled_deadline: None,
         }

--- a/src/enroll.rs
+++ b/src/enroll.rs
@@ -1,0 +1,568 @@
+//! Client enrollment without an enrollment API.
+//!
+//! Clients in the Cloudflare WARP MASQUE family normally learn their key, their
+//! tunnel addresses, and the endpoint's public key from a vendor registration
+//! service. A self-hosted server has no such service, so the operator plays its
+//! part: generate a key pair, keep the public half in `[[clients]]`, and hand
+//! the private half to the client along with the addresses it was pinned to.
+//!
+//! This module produces both halves of that exchange from one call, so the two
+//! sides cannot drift apart.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::Path;
+
+use anyhow::{Context, bail};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::ec::{EcGroup, EcKey};
+use boring::nid::Nid;
+use boring::x509::X509;
+use zeroize::Zeroize as _;
+
+/// A freshly generated client key pair, in the encodings each side expects.
+pub struct ClientKeyPair {
+    /// SEC1 / RFC 5915 EC private key DER, base64 encoded.
+    ///
+    /// This is the `private_key` form these clients store: they parse it with
+    /// an EC-specific parser, so PKCS#8 — what most tooling emits by default —
+    /// is silently rejected.
+    pub private_key_b64: String,
+    /// SubjectPublicKeyInfo DER, base64 encoded. Goes in `[[clients]]`.
+    pub public_key_b64: String,
+}
+
+impl Drop for ClientKeyPair {
+    fn drop(&mut self) {
+        self.private_key_b64.zeroize();
+    }
+}
+
+/// Generate a P-256 key pair for one client.
+pub fn generate_client_key() -> anyhow::Result<ClientKeyPair> {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)
+        .context("failed to load the P-256 curve")?;
+    let key = EcKey::generate(&group).context("failed to generate a P-256 key")?;
+
+    let private_key_b64 = STANDARD.encode(
+        key.private_key_to_der()
+            .context("failed to encode the private key")?,
+    );
+
+    let public =
+        boring::pkey::PKey::from_ec_key(key).context("failed to wrap the generated key")?;
+    let public_key_b64 = STANDARD.encode(
+        public
+            .public_key_to_der()
+            .context("failed to encode the public key")?,
+    );
+
+    Ok(ClientKeyPair {
+        private_key_b64,
+        public_key_b64,
+    })
+}
+
+/// Read the server certificate's public key as PEM.
+///
+/// These clients do not verify the certificate chain — the SNI they send rarely
+/// matches the endpoint — and pin this key instead, comparing it byte for byte
+/// against the leaf they are offered.
+pub fn server_public_key_pem(cert_path: &Path) -> anyhow::Result<String> {
+    let pem = std::fs::read(cert_path)
+        .with_context(|| format!("failed to read {}", cert_path.display()))?;
+    let cert = X509::from_pem(&pem)
+        .with_context(|| format!("{} is not a PEM certificate", cert_path.display()))?;
+    let key = cert
+        .public_key()
+        .context("server certificate has no public key")?;
+
+    // A client that pins an ECDSA key will refuse anything else outright, so
+    // catch it here rather than at the client's first connection attempt.
+    if key.ec_key().is_err() {
+        bail!(
+            "{} does not use an ECDSA key; regenerate it with an EC key \
+             (scripts/gen-certs.sh does this) or these clients cannot pin it",
+            cert_path.display()
+        );
+    }
+
+    let pem = key
+        .public_key_to_pem()
+        .context("failed to encode the server public key")?;
+    String::from_utf8(pem).context("server public key PEM is not valid UTF-8")
+}
+
+/// Strip the armour from a PEM block, leaving the base64 DER body.
+///
+/// Some clients want the key this way rather than as PEM, and reject a value
+/// that still carries the header lines or embedded newlines.
+pub fn pem_to_base64_der(pem: &str) -> String {
+    pem.lines()
+        .filter(|line| !line.starts_with("-----"))
+        .flat_map(|line| line.chars().filter(|c| !c.is_ascii_whitespace()))
+        .collect()
+}
+
+/// A `proxies:` entry for mihomo-style clients.
+///
+/// Same protocol as the JSON form, different spelling of the same four facts:
+/// the key is base64 DER rather than PEM, the tunnel addresses are CIDR rather
+/// than bare, and the endpoint splits into separate host and port fields.
+pub fn mihomo_proxy_yaml(
+    name: &str,
+    private_key_b64: &str,
+    server_public_key_b64: &str,
+    endpoint: SocketAddr,
+    ipv4: Option<Ipv4Addr>,
+    ipv6: Option<Ipv6Addr>,
+    mtu: usize,
+) -> String {
+    let mut block = String::from("proxies:\n");
+    block.push_str(&format!("  - name: {}\n", yaml_string(name)));
+    block.push_str("    type: masque\n");
+    block.push_str(&format!("    server: {}\n", endpoint.ip()));
+    block.push_str(&format!("    port: {}\n", endpoint.port()));
+    block.push_str(&format!(
+        "    private-key: {}\n",
+        yaml_string(private_key_b64)
+    ));
+    block.push_str(&format!(
+        "    public-key: {}\n",
+        yaml_string(server_public_key_b64)
+    ));
+    // CIDR form, and a single-host prefix: the server assigns exactly this
+    // address, not a subnet the client may pick from.
+    if let Some(ipv4) = ipv4 {
+        block.push_str(&format!("    ip: {ipv4}/32\n"));
+    }
+    if let Some(ipv6) = ipv6 {
+        block.push_str(&format!("    ipv6: {ipv6}/128\n"));
+    }
+    block.push_str(&format!("    mtu: {mtu}\n"));
+    block.push_str("    udp: true\n");
+    block
+}
+
+/// The `[[clients]]` block to append to the server's config file.
+pub fn clients_toml_block(
+    name: &str,
+    public_key_b64: &str,
+    ipv4: Option<Ipv4Addr>,
+    ipv6: Option<Ipv6Addr>,
+) -> String {
+    let mut block = String::from("[[clients]]\n");
+    block.push_str(&format!("name = {}\n", toml_string(name)));
+    block.push_str(&format!("public_key = {}\n", toml_string(public_key_b64)));
+    if let Some(ipv4) = ipv4 {
+        block.push_str(&format!("ipv4 = \"{ipv4}\"\n"));
+    }
+    if let Some(ipv6) = ipv6 {
+        block.push_str(&format!("ipv6 = \"{ipv6}\"\n"));
+    }
+    block
+}
+
+/// Create a new client configuration without exposing or replacing its key.
+///
+/// `create_new` refuses existing paths (including symlinks), avoiding both
+/// accidental key loss and symlink-based clobbering when enrollment is run as
+/// root. On Unix the private-key file is created owner-readable/writable only;
+/// the mode is applied atomically at creation rather than repaired afterwards.
+pub fn write_client_config(path: &Path, contents: &str) -> anyhow::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(path).with_context(|| {
+        format!(
+            "failed to create {} (refusing to overwrite an existing path)",
+            path.display()
+        )
+    })?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync {}", path.display()))?;
+    Ok(())
+}
+
+/// The client-side JSON configuration.
+///
+/// `endpoint_v4` / `endpoint_v6` are bare addresses, not `host:port`: the port
+/// is a separate client-side flag. The `id` and `access_token` fields belong to
+/// the vendor API and are emitted empty so a client that reads them finds
+/// something well formed rather than a missing key.
+pub fn client_config_json(
+    private_key_b64: &str,
+    server_public_key_pem: &str,
+    endpoint: IpAddr,
+    ipv4: Option<Ipv4Addr>,
+    ipv6: Option<Ipv6Addr>,
+) -> String {
+    let (endpoint_v4, endpoint_v6) = match endpoint {
+        IpAddr::V4(v4) => (v4.to_string(), String::new()),
+        IpAddr::V6(v6) => (String::new(), v6.to_string()),
+    };
+
+    let fields = [
+        ("private_key", private_key_b64.to_string()),
+        ("endpoint_v4", endpoint_v4),
+        ("endpoint_v6", endpoint_v6),
+        ("endpoint_pub_key", server_public_key_pem.to_string()),
+        ("id", String::new()),
+        ("access_token", String::new()),
+        ("ipv4", ipv4.map(|ip| ip.to_string()).unwrap_or_default()),
+        ("ipv6", ipv6.map(|ip| ip.to_string()).unwrap_or_default()),
+    ];
+
+    let body = fields
+        .iter()
+        .map(|(key, value)| format!("  \"{key}\": {}", json_string(value)))
+        .collect::<Vec<_>>()
+        .join(",\n");
+
+    format!("{{\n{body}\n}}\n")
+}
+
+/// Quote a value as a TOML basic string.
+fn toml_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Quote a value as a YAML double-quoted scalar.
+///
+/// Base64 can start with characters YAML treats specially, so these values are
+/// always quoted rather than emitted bare.
+fn yaml_string(value: &str) -> String {
+    // YAML's double-quoted style uses the same escapes as JSON for everything
+    // that appears in a key, an address, or a name.
+    json_string(value)
+}
+
+/// Quote a value as a JSON string.
+///
+/// The PEM key carries newlines, so escaping is not optional here.
+fn json_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_identity::{ClientRegistry, spki_from_cert_der};
+    use crate::config::{self, ClientEntry};
+
+    /// A key standing in for the server's, where only its encoding matters.
+    fn throwaway_p256_key() -> boring::pkey::PKey<boring::pkey::Private> {
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        boring::pkey::PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn generated_public_key_is_accepted_by_the_roster_parser() {
+        let pair = generate_client_key().unwrap();
+        let entry = ClientEntry {
+            name: "laptop".into(),
+            public_key: pair.public_key_b64.clone(),
+            ipv4: None,
+            ipv6: None,
+        };
+        // The whole point of the pair: what enrollment prints has to be what
+        // the server accepts, with no reformatting in between.
+        assert!(ClientRegistry::from_config(&[entry]).is_ok());
+    }
+
+    /// The private key must round-trip through the SEC1 parser these clients
+    /// use, and its public half must match what we told the server to expect.
+    #[test]
+    fn private_key_is_sec1_der_matching_the_published_public_key() {
+        let pair = generate_client_key().unwrap();
+        let der = STANDARD.decode(&pair.private_key_b64).unwrap();
+
+        let key = EcKey::private_key_from_der(&der).expect("must parse as a SEC1 EC private key");
+        let public = boring::pkey::PKey::from_ec_key(key).unwrap();
+        assert_eq!(
+            STANDARD.encode(public.public_key_to_der().unwrap()),
+            pair.public_key_b64
+        );
+    }
+
+    #[test]
+    fn each_call_generates_a_distinct_key() {
+        let first = generate_client_key().unwrap();
+        let second = generate_client_key().unwrap();
+        assert_ne!(first.private_key_b64, second.private_key_b64);
+        assert_ne!(first.public_key_b64, second.public_key_b64);
+    }
+
+    #[test]
+    fn clients_block_parses_back_into_the_configured_roster() {
+        let pair = generate_client_key().unwrap();
+        let block = clients_toml_block(
+            "my laptop",
+            &pair.public_key_b64,
+            Some("10.89.0.2".parse().unwrap()),
+            Some("fd00:abcd::2".parse().unwrap()),
+        );
+
+        let parsed = config::parse_toml(&block).unwrap();
+        assert_eq!(parsed.clients.len(), 1);
+        assert_eq!(parsed.clients[0].name, "my laptop");
+        assert_eq!(parsed.clients[0].public_key, pair.public_key_b64);
+        assert_eq!(parsed.clients[0].ipv4.as_deref(), Some("10.89.0.2"));
+        assert_eq!(parsed.clients[0].ipv6.as_deref(), Some("fd00:abcd::2"));
+        assert!(ClientRegistry::from_config(&parsed.clients).is_ok());
+    }
+
+    #[test]
+    fn clients_block_omits_addresses_that_were_not_pinned() {
+        let pair = generate_client_key().unwrap();
+        let block = clients_toml_block("phone", &pair.public_key_b64, None, None);
+        assert!(!block.contains("ipv4"));
+        assert!(!block.contains("ipv6"));
+
+        let parsed = config::parse_toml(&block).unwrap();
+        assert_eq!(parsed.clients[0].ipv4, None);
+        assert_eq!(parsed.clients[0].ipv6, None);
+    }
+
+    #[test]
+    fn client_json_escapes_the_multiline_pem_key() {
+        let json = client_config_json(
+            "cHJpdmF0ZQ==",
+            "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n",
+            "203.0.113.9".parse().unwrap(),
+            Some("10.89.0.2".parse().unwrap()),
+            None,
+        );
+
+        // A raw newline inside a JSON string would make the file unparseable.
+        assert!(json.contains("\\n"));
+        assert!(!json.contains("KEY-----\n-"));
+        assert!(json.contains("\"endpoint_v4\": \"203.0.113.9\""));
+        // The port travels as a client flag, so it must not leak into the field.
+        assert!(!json.contains("203.0.113.9:443"));
+        assert!(json.contains("\"ipv4\": \"10.89.0.2\""));
+        assert!(json.contains("\"ipv6\": \"\""));
+    }
+
+    #[test]
+    fn pem_to_base64_der_strips_armour_and_newlines() {
+        let key = throwaway_p256_key();
+        let pem = String::from_utf8(key.public_key_to_pem().unwrap()).unwrap();
+        let stripped = pem_to_base64_der(&pem);
+
+        assert!(!stripped.contains("-----"));
+        assert!(!stripped.contains('\n'));
+        // Must still be the same key, byte for byte, after the round trip.
+        assert_eq!(stripped, STANDARD.encode(key.public_key_to_der().unwrap()));
+    }
+
+    #[test]
+    fn mihomo_block_carries_cidr_addresses_and_a_split_endpoint() {
+        let pair = generate_client_key().unwrap();
+        let server_key = STANDARD.encode(throwaway_p256_key().public_key_to_der().unwrap());
+        let yaml = mihomo_proxy_yaml(
+            "laptop",
+            &pair.private_key_b64,
+            &server_key,
+            "203.0.113.9:4433".parse().unwrap(),
+            Some("10.89.0.2".parse().unwrap()),
+            Some("fd00:abcd::2".parse().unwrap()),
+            1420,
+        );
+
+        assert!(yaml.contains("type: masque"));
+        // Host and port are separate fields, unlike the JSON form.
+        assert!(yaml.contains("server: 203.0.113.9"));
+        assert!(yaml.contains("port: 4433"));
+        assert!(!yaml.contains("203.0.113.9:4433"));
+        // Addresses are CIDR here, and single-host: the server pins exactly one.
+        assert!(yaml.contains("ip: 10.89.0.2/32"));
+        assert!(yaml.contains("ipv6: fd00:abcd::2/128"));
+        assert!(yaml.contains("mtu: 1420"));
+        // The server key must be bare base64, never PEM.
+        assert!(yaml.contains(&format!("public-key: \"{server_key}\"")));
+        assert!(!yaml.contains("-----BEGIN"));
+    }
+
+    #[test]
+    fn mihomo_block_omits_addresses_that_were_not_pinned() {
+        let pair = generate_client_key().unwrap();
+        let yaml = mihomo_proxy_yaml(
+            "phone",
+            &pair.private_key_b64,
+            "AAAA",
+            "203.0.113.9:443".parse().unwrap(),
+            None,
+            None,
+            1280,
+        );
+        assert!(!yaml.contains("ip:"));
+        assert!(!yaml.contains("ipv6:"));
+    }
+
+    #[test]
+    fn client_json_uses_the_v6_endpoint_field_for_a_v6_address() {
+        let json = client_config_json(
+            "a2V5",
+            "pem",
+            "2001:db8::1".parse().unwrap(),
+            None,
+            Some("fd00:abcd::2".parse().unwrap()),
+        );
+        assert!(json.contains("\"endpoint_v6\": \"2001:db8::1\""));
+        assert!(json.contains("\"endpoint_v4\": \"\""));
+    }
+
+    #[test]
+    fn client_config_file_is_private_and_never_overwritten() {
+        let dir = std::env::temp_dir().join(format!(
+            "masque-enroll-write-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("client.json");
+
+        write_client_config(&path, "first-secret").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first-secret");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+
+        let error = write_client_config(&path, "replacement").unwrap_err();
+        assert!(format!("{error:#}").contains("refusing to overwrite"));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first-secret");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn server_public_key_is_read_from_a_pem_certificate() {
+        // Build a throwaway EC certificate rather than depending on a fixture.
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let key = boring::pkey::PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
+        let mut builder = boring::x509::X509Builder::new().unwrap();
+        builder.set_version(2).unwrap();
+        builder
+            .set_serial_number(
+                &boring::bn::BigNum::from_u32(1)
+                    .unwrap()
+                    .to_asn1_integer()
+                    .unwrap(),
+            )
+            .unwrap();
+        builder
+            .set_not_before(&boring::asn1::Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&boring::asn1::Asn1Time::days_from_now(1).unwrap())
+            .unwrap();
+        builder.set_pubkey(&key).unwrap();
+        builder
+            .sign(&key, boring::hash::MessageDigest::sha256())
+            .unwrap();
+        let cert = builder.build();
+
+        let dir = std::env::temp_dir().join(format!("masque-enroll-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("server.crt");
+        std::fs::write(&path, cert.to_pem().unwrap()).unwrap();
+
+        let pem = server_public_key_pem(&path).unwrap();
+        assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+
+        // The pinned key must be the certificate's own key, or the client would
+        // reject the very server that issued it this config.
+        let from_cert = spki_from_cert_der(&cert.to_der().unwrap()).unwrap();
+        let pinned = boring::pkey::PKey::public_key_from_pem(pem.as_bytes()).unwrap();
+        assert_eq!(pinned.public_key_to_der().unwrap(), from_cert);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn non_ec_server_certificate_is_rejected() {
+        let key = boring::pkey::PKey::from_rsa(boring::rsa::Rsa::generate(2048).unwrap()).unwrap();
+        let mut builder = boring::x509::X509Builder::new().unwrap();
+        builder.set_version(2).unwrap();
+        builder
+            .set_serial_number(
+                &boring::bn::BigNum::from_u32(1)
+                    .unwrap()
+                    .to_asn1_integer()
+                    .unwrap(),
+            )
+            .unwrap();
+        builder
+            .set_not_before(&boring::asn1::Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&boring::asn1::Asn1Time::days_from_now(1).unwrap())
+            .unwrap();
+        builder.set_pubkey(&key).unwrap();
+        builder
+            .sign(&key, boring::hash::MessageDigest::sha256())
+            .unwrap();
+
+        let dir = std::env::temp_dir().join(format!("masque-enroll-rsa-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("rsa.crt");
+        std::fs::write(&path, builder.build().to_pem().unwrap()).unwrap();
+
+        let error = server_public_key_pem(&path).unwrap_err();
+        assert!(format!("{error:#}").contains("ECDSA"), "{error:#}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn missing_certificate_is_reported_with_its_path() {
+        let error = server_public_key_pem(Path::new("/nonexistent/masque/server.crt")).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("/nonexistent/masque/server.crt"),
+            "{error:#}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod address_pool;
 pub mod auth;
 pub mod capsule;
+pub mod client_identity;
 pub mod config;
 pub mod connection;
 pub mod datagram;
+pub mod enroll;
 pub mod error;
 pub mod fxhash;
 pub mod ip_packet;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
-use std::path::PathBuf;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use tracing::info;
@@ -8,11 +9,12 @@ use zeroize::Zeroizing;
 
 use masque::auth;
 use masque::config::{self, ServerConfig};
+use masque::enroll;
 use masque::server::Server;
 
 /// MASQUE proxy server (CONNECT / CONNECT-UDP / CONNECT-IP over HTTP/3).
 #[derive(Parser)]
-#[command(name = "masque-server")]
+#[command(name = "masque-server", version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -42,6 +44,117 @@ struct Cli {
 enum Command {
     /// Read a password from standard input and print an Argon2id PHC hash.
     HashPassword,
+    /// Generate a client key pair for `auth.mode = "client_cert"`.
+    ///
+    /// Prints the `[[clients]]` block to add to the server config, and the JSON
+    /// configuration for the client. Nothing is written to the server config
+    /// automatically: enrolling a client is a deliberate act.
+    EnrollClient {
+        /// Label for this client, used in the server's logs.
+        #[arg(long)]
+        name: String,
+
+        /// Address:port clients dial. The IP is written to JSON; the port is
+        /// printed as the client's --connect-port argument.
+        #[arg(long)]
+        endpoint: SocketAddr,
+
+        /// Fixed tunnel IPv4 for this client, inside `ip_proxy.ipv4_pool`.
+        ///
+        /// Required for clients that configure their own tunnel interface
+        /// instead of reading the `ADDRESS_ASSIGN` capsule.
+        #[arg(long)]
+        ipv4: Option<Ipv4Addr>,
+
+        /// Fixed tunnel IPv6 for this client, inside `ip_proxy.ipv6_pool`.
+        #[arg(long)]
+        ipv6: Option<Ipv6Addr>,
+
+        /// Write the client JSON here instead of printing it.
+        #[arg(long, short)]
+        out: Option<PathBuf>,
+    },
+}
+
+fn usque_port_instruction(port: u16) -> String {
+    format!("# Start usque with --connect-port {port} (short form: -P {port}).")
+}
+
+/// Generate and print one client enrollment.
+fn enroll_client(
+    cert_path: &Path,
+    name: &str,
+    endpoint: SocketAddr,
+    ipv4: Option<Ipv4Addr>,
+    ipv6: Option<Ipv6Addr>,
+    tun_mtu: usize,
+    out: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let pair = enroll::generate_client_key()?;
+    let server_key = enroll::server_public_key_pem(cert_path)?;
+
+    let client_json = Zeroizing::new(enroll::client_config_json(
+        &pair.private_key_b64,
+        &server_key,
+        endpoint.ip(),
+        ipv4,
+        ipv6,
+    ));
+
+    println!("# Add to the server config, then reload or restart the server:\n");
+    print!(
+        "{}",
+        enroll::clients_toml_block(name, &pair.public_key_b64, ipv4, ipv6)
+    );
+
+    match out {
+        Some(path) => {
+            enroll::write_client_config(&path, client_json.as_str())?;
+            println!("\n# Client configuration written to {}", path.display());
+        }
+        None => {
+            println!("\n# Client configuration (contains the private key — treat as a secret):\n");
+            print!("{}", client_json.as_str());
+        }
+    }
+
+    // usque's JSON schema stores only the endpoint IP; its connection port is
+    // a launch flag. Always print it so a non-443 deployment cannot silently
+    // fall back to the client's default port.
+    println!("\n{}", usque_port_instruction(endpoint.port()));
+
+    // The same enrollment, spelled for mihomo-style clients. Emitted alongside
+    // rather than behind a flag: the encodings differ in ways that are easy to
+    // get subtly wrong by hand, and a wrong key only shows up as a handshake
+    // failure much later.
+    println!(
+        "\n# Or, for a mihomo-style client, add to its config.yaml \
+         (also contains the private key):\n"
+    );
+    print!(
+        "{}",
+        Zeroizing::new(enroll::mihomo_proxy_yaml(
+            name,
+            &pair.private_key_b64,
+            &enroll::pem_to_base64_der(&server_key),
+            endpoint,
+            ipv4,
+            ipv6,
+            tun_mtu,
+        ))
+        .as_str()
+    );
+
+    if ipv4.is_none() && ipv6.is_none() {
+        eprintln!(
+            "\nwarning: no fixed address was pinned. Clients that configure their tunnel \
+             interface from this file rather than from the ADDRESS_ASSIGN capsule need \
+             --ipv4 and/or --ipv6, or the two sides will disagree and every packet will \
+             be dropped."
+        );
+    }
+
+    Ok(())
 }
 
 #[tokio::main]
@@ -96,8 +209,55 @@ async fn main() -> anyhow::Result<()> {
         cfg.tls.key_path = key;
     }
 
+    // Enrollment only needs the server certificate, so it runs off the same
+    // config the server would use rather than asking for the path again.
+    if let Some(Command::EnrollClient {
+        name,
+        endpoint,
+        ipv4,
+        ipv6,
+        out,
+    }) = cli.command
+    {
+        return enroll_client(
+            &cfg.tls.cert_path,
+            &name,
+            endpoint,
+            ipv4,
+            ipv6,
+            cfg.ip_proxy.tun_mtu,
+            out,
+        );
+    }
+
     info!(?cfg, "configuration loaded");
 
-    let mut server = Server::bind(cfg).await?;
+    // Pass the path so SIGHUP can re-read the [[clients]] roster. Only a
+    // config that was actually loaded from disk is reloadable; defaults have
+    // no file to re-read.
+    let reload_path = cli.config.exists().then_some(cli.config);
+    let mut server = Server::bind_with_reload(cfg, reload_path).await?;
     server.run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory as _;
+
+    use super::{Cli, usque_port_instruction};
+
+    #[test]
+    fn cli_reports_the_package_version() {
+        assert_eq!(
+            Cli::command().get_version(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[test]
+    fn enrollment_preserves_a_non_default_endpoint_port_as_a_client_flag() {
+        let instruction = usque_port_instruction(8449);
+        assert!(instruction.contains("--connect-port 8449"));
+        assert!(instruction.contains("-P 8449"));
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use std::sync::{Mutex, RwLock};
 
+use anyhow::Context as _;
 use tokio::sync::Semaphore;
 
 use tokio::net::UdpSocket;
@@ -18,10 +19,11 @@ use tracing::{debug, error, info, warn};
 
 use self::authentication::AuthOutcome;
 use self::request::{PendingAuth, PendingConnectSetups, RequestContext};
-use crate::address_pool::AddressPool;
+use crate::address_pool::{AddressPool, PoolError};
 use crate::auth::BasicAuthenticator;
 use crate::capsule;
 use crate::capsule::{AssignedAddress, CapsuleFrame, IpAddress, IpAddressRange};
+use crate::client_identity::{ClientIdentity, ClientRegistry, IdentityError, SharedRoster};
 use crate::config::ServerConfig;
 use crate::connection::{AwaitingAuth, ClientConnection};
 use crate::datagram::{self, DatagramHeader};
@@ -127,14 +129,72 @@ pub struct Server {
     shards: Vec<Shard>,
 }
 
+/// Build only the roster selected by the active authentication mode.
+///
+/// Keeping this decision separate from binding makes the "ignored outside
+/// client_cert" contract testable without opening sockets or loading TLS keys.
+fn active_client_registry(config: &ServerConfig) -> anyhow::Result<ClientRegistry> {
+    if !config.auth.client_cert_enabled() {
+        return Ok(ClientRegistry::default());
+    }
+
+    let clients = ClientRegistry::from_config(&config.clients)?;
+    if clients.is_empty() {
+        anyhow::bail!(
+            "auth.mode = \"client_cert\" needs at least one [[clients]] entry; \
+             run `masque-server enroll-client` to create one"
+        );
+    }
+    Ok(clients)
+}
+
+/// Capture only the startup state that a roster reload is allowed to use.
+fn roster_reload_settings(
+    config: &ServerConfig,
+    config_path: Option<std::path::PathBuf>,
+) -> Option<RosterReload> {
+    config_path.map(|path| RosterReload {
+        path,
+        client_cert_enabled: config.auth.client_cert_enabled(),
+        ip_proxy_enabled: config.ip_proxy.enabled,
+    })
+}
+
 impl Server {
     /// Create a new server bound to the configured address.
     pub async fn bind(config: ServerConfig) -> anyhow::Result<Self> {
-        if config.auth.enabled {
-            // Surface a bad credential configuration once, before any shard
-            // binds the listen port.
+        Self::bind_with_reload(config, None).await
+    }
+
+    /// Bind, and allow `SIGHUP` to re-read the `[[clients]]` roster from
+    /// `config_path`.
+    ///
+    /// Revoking a client otherwise costs a restart, which drops every other
+    /// client's tunnel to remove one.
+    pub async fn bind_with_reload(
+        config: ServerConfig,
+        config_path: Option<std::path::PathBuf>,
+    ) -> anyhow::Result<Self> {
+        // Surface a bad credential or active roster configuration once, before
+        // any shard binds the listen port. A roster outside client-cert mode is
+        // deliberately not parsed or allowed to reserve pool addresses: the
+        // configuration contract says it is ignored in that mode.
+        let clients = active_client_registry(&config)?;
+        if config.auth.client_cert_enabled() {
+            info!(
+                clients = clients.len(),
+                "client certificate authentication enabled"
+            );
+        } else if !config.clients.is_empty() {
+            warn!(
+                "[[clients]] entries are ignored unless auth.mode = \"client_cert\" \
+                 and auth.enabled = true"
+            );
+        }
+
+        if config.auth.basic_enabled() {
             BasicAuthenticator::new(&config.auth.username, &config.auth.password_hash)?;
-        } else {
+        } else if !config.auth.client_cert_enabled() {
             warn!("proxy authentication is disabled");
         }
 
@@ -169,8 +229,24 @@ impl Server {
             );
         }
 
-        let address_pool = AddressPool::new(&config.ip_proxy.ipv4_pool, &config.ip_proxy.ipv6_pool)
-            .map_err(|e| anyhow::anyhow!("address pool: {e}"))?;
+        let mut address_pool =
+            AddressPool::new(&config.ip_proxy.ipv4_pool, &config.ip_proxy.ipv6_pool)
+                .map_err(|e| anyhow::anyhow!("address pool: {e}"))?;
+
+        // Withhold every pinned address from dynamic allocation up front, so a
+        // client that connects while a pinned peer is offline cannot take the
+        // address that peer needs.
+        if config.ip_proxy.enabled {
+            for (addr, owner) in clients.static_reservations() {
+                address_pool.reserve_static(addr, owner).map_err(|e| {
+                    anyhow::anyhow!(
+                        "client address {addr} cannot be reserved ({e}); pinned addresses \
+                         must lie inside ip_proxy.ipv4_pool / ipv6_pool and must not be the \
+                         pool's gateway address"
+                    )
+                })?;
+            }
+        }
 
         let tun = build_tun(&config)?;
 
@@ -193,6 +269,11 @@ impl Server {
             tun_rx.push(rx);
         }
 
+        // A live switch from Basic to client-certificate authentication is not
+        // possible: the TLS context is fixed when each shard binds. Capture the
+        // startup mode so SIGHUP can be consumed safely but cannot fake a switch.
+        let roster_reload = roster_reload_settings(&config, config_path);
+
         let shared = Arc::new(Shared {
             address_pool: Mutex::new(address_pool),
             routing_table: RwLock::new(RoutingTable::new()),
@@ -205,6 +286,8 @@ impl Server {
             tun_tx,
             auth_permits: Arc::new(Semaphore::new(auth_concurrency(shard_count))),
             auth_queue_slots: Arc::new(Semaphore::new(MAX_PENDING_AUTH_GLOBAL)),
+            clients: Arc::new(SharedRoster::new(clients)),
+            roster_reload,
         });
 
         let mut shards = Vec::with_capacity(shard_count);
@@ -226,8 +309,51 @@ impl Server {
         Ok(Self { shards })
     }
 
+    /// Reload the roster whenever `SIGHUP` arrives.
+    ///
+    /// One task for the whole server rather than one per shard: the roster is
+    /// shared, so reloading it once is enough, and the shards pick the change
+    /// up through its generation counter on their next sweep.
+    #[cfg(unix)]
+    fn spawn_roster_reloader(shared: Arc<Shared>) {
+        if shared.roster_reload.is_none() {
+            return;
+        }
+
+        tokio::spawn(async move {
+            let mut sighup =
+                match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup()) {
+                    Ok(signal) => signal,
+                    Err(e) => {
+                        warn!(%e, "cannot listen for SIGHUP; roster reload is unavailable");
+                        return;
+                    }
+                };
+
+            while sighup.recv().await.is_some() {
+                // A failed reload leaves the running roster untouched, so the
+                // server keeps serving the clients it already admitted.
+                match reload_roster(&shared) {
+                    Ok((generation, clients)) => {
+                        info!(generation, clients, "roster reloaded")
+                    }
+                    Err(e) => {
+                        warn!(error = %format!("{e:#}"), "roster reload failed, keeping the previous one")
+                    }
+                }
+            }
+        });
+    }
+
+    #[cfg(not(unix))]
+    fn spawn_roster_reloader(_shared: Arc<Shared>) {}
+
     /// Run every shard until they all stop.
     pub async fn run(&mut self) -> anyhow::Result<()> {
+        if let Some(shard) = self.shards.first() {
+            Self::spawn_roster_reloader(Arc::clone(&shard.shared));
+        }
+
         // A single shard keeps the current behaviour of running on the caller's
         // task, which keeps the common case free of a spawn and a join.
         if self.shards.len() == 1 {
@@ -277,6 +403,189 @@ fn resolve_shard_count(configured: usize) -> usize {
         .map(|count| count.get())
         .unwrap_or(1)
         .min(MAX_SHARDS)
+}
+
+/// Re-read the `[[clients]]` roster from disk and install it.
+///
+/// Only the roster is reloaded. Everything else — listen address, TLS key,
+/// pools, tuning — is fixed at bind time, and pretending otherwise would make
+/// a reload's effect depend on which fields happened to be reloadable.
+///
+/// Nothing is changed unless the whole new roster validates, so a typo leaves
+/// the running server exactly as it was.
+fn reload_roster(shared: &Shared) -> anyhow::Result<(u64, usize)> {
+    let Some(reload) = shared.roster_reload.as_ref() else {
+        anyhow::bail!("no configuration file to reload");
+    };
+    if !reload.client_cert_enabled {
+        anyhow::bail!(
+            "roster reload is unavailable because the server did not start in client_cert mode"
+        );
+    }
+
+    let text = std::fs::read_to_string(&reload.path)
+        .with_context(|| format!("failed to read {}", reload.path.display()))?;
+    let config = crate::config::parse_toml(&text)
+        .with_context(|| format!("failed to parse {}", reload.path.display()))?;
+
+    if !config.auth.client_cert_enabled() {
+        anyhow::bail!(
+            "refusing to reload: auth.mode is no longer \"client_cert\", which cannot be \
+             changed without a restart"
+        );
+    }
+
+    let registry = active_client_registry(&config)?;
+
+    // Reservations are recomputed before the swap: if a pinned address became
+    // invalid, the roster is rejected rather than half-applied.
+    if reload.ip_proxy_enabled {
+        shared
+            .address_pool
+            .lock()
+            .expect("address pool poisoned")
+            .set_static_reservations(registry.static_reservations())
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "refusing to reload: a pinned client address cannot be reserved ({e})"
+                )
+            })?;
+    }
+
+    let count = registry.len();
+    Ok((shared.clients.replace(registry), count))
+}
+
+/// Take every address pinned to `identity`, or none of them.
+///
+/// All or nothing: a client configured for dual stack that came up with only
+/// half its addresses would silently lose one family, which is harder to
+/// diagnose than a refused tunnel.
+fn claim_static_addresses(
+    shared: &Shared,
+    identity: &ClientIdentity,
+) -> Result<Vec<IpAddr>, PoolError> {
+    let mut pool = shared.address_pool.lock().expect("address pool poisoned");
+    let mut claimed = Vec::new();
+
+    for addr in identity.static_addresses() {
+        if let Err(e) = pool.claim(addr, &identity.key) {
+            pool.release_all(&claimed);
+            return Err(e);
+        }
+        claimed.push(addr);
+    }
+
+    Ok(claimed)
+}
+
+/// Take one address per configured family from the dynamic pool.
+///
+/// A family whose pool is absent or exhausted is skipped: a v4-only pool should
+/// still produce a working v4 tunnel.
+fn allocate_pool_addresses(shared: &Shared) -> Vec<IpAddr> {
+    let mut pool = shared.address_pool.lock().expect("address pool poisoned");
+    let mut addresses = Vec::with_capacity(2);
+
+    if let Ok(v4) = pool.allocate_v4() {
+        addresses.push(IpAddr::V4(v4));
+    }
+    if let Ok(v6) = pool.allocate_v6() {
+        addresses.push(IpAddr::V6(v6));
+    }
+
+    addresses
+}
+
+/// Build a QUIC config that demands a client certificate and admits only keys
+/// on the roster.
+///
+/// quiche's own `Config` cannot express this. Its `verify_peer(true)` asks
+/// BoringSSL to validate the chain, which these certificates always fail: they
+/// are self-signed, minted fresh per connection, and carry an empty subject.
+/// `verify_peer(false)` on a server does not ask for a certificate at all. So
+/// the TLS context is built by hand, with a callback that ignores the chain and
+/// checks the key instead.
+///
+/// Rejecting inside the callback means an unregistered client is turned away
+/// with a TLS alert during the handshake, before it can open a stream — the
+/// same shape of failure the Cloudflare endpoint produces for an unenrolled
+/// key.
+fn build_client_cert_quic_config(
+    config: &ServerConfig,
+    roster: Arc<SharedRoster>,
+) -> anyhow::Result<quiche::Config> {
+    let mut builder = boring::ssl::SslContextBuilder::new(boring::ssl::SslMethod::tls())
+        .map_err(|e| anyhow::anyhow!("failed to create TLS context: {e}"))?;
+
+    builder
+        .set_certificate_chain_file(&config.tls.cert_path)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to load tls.cert_path {}: {e}",
+                config.tls.cert_path.display()
+            )
+        })?;
+    builder
+        .set_private_key_file(&config.tls.key_path, boring::ssl::SslFiletype::PEM)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to load tls.key_path {}: {e}",
+                config.tls.key_path.display()
+            )
+        })?;
+
+    // PEER asks for the certificate; FAIL_IF_NO_PEER_CERT makes it mandatory.
+    // Without the second flag a client that simply omits its certificate would
+    // complete the handshake and reach the request path with no identity.
+    //
+    // This is the *custom* verify hook, not the legacy `SSL_CTX_set_verify`
+    // callback: the legacy one runs as a step inside BoringSSL's X.509 chain
+    // verification, which never happens here because no CA store is configured,
+    // so it is simply never consulted. `SSL_CTX_set_custom_verify` replaces
+    // chain verification outright and is always called.
+    let mode = boring::ssl::SslVerifyMode::PEER | boring::ssl::SslVerifyMode::FAIL_IF_NO_PEER_CERT;
+    builder.set_custom_verify_callback(mode, move |ssl| {
+        // ACCESS_DENIED rather than a certificate-specific alert: the
+        // certificate is structurally fine, it is the identity behind it that
+        // is not authorized. Clients in this family surface that alert as a
+        // login failure, which is the right thing to tell the operator.
+        let denied = Err(boring::ssl::SslVerifyError::Invalid(
+            boring::ssl::SslAlert::ACCESS_DENIED,
+        ));
+
+        let Some(cert) = ssl.peer_certificate() else {
+            warn!("rejecting client that presented no certificate");
+            return denied;
+        };
+        let Ok(der) = cert.to_der() else {
+            warn!("rejecting client certificate that could not be re-encoded");
+            return denied;
+        };
+
+        match roster.load().identify(&der) {
+            Ok(identity) => {
+                debug!(client = %identity.name, "client certificate accepted");
+                Ok(())
+            }
+            Err(IdentityError::UnknownKey(key)) => {
+                // Logged in full so an operator can enroll the client by
+                // pasting this straight into a `[[clients]]` entry.
+                warn!(
+                    public_key = %key,
+                    "rejecting client: public key is not in the [[clients]] roster"
+                );
+                denied
+            }
+            Err(e) => {
+                warn!(%e, "rejecting client certificate");
+                denied
+            }
+        }
+    });
+
+    quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, builder)
+        .map_err(|e| anyhow::anyhow!("failed to build QUIC config: {e}"))
 }
 
 /// Create the TUN device if the IP proxy is enabled.
@@ -360,6 +669,16 @@ struct ForwardedPacket {
     from: SocketAddr,
 }
 
+/// Immutable facts needed to reload only the client roster.
+struct RosterReload {
+    path: std::path::PathBuf,
+    /// Whether the bound TLS context actually requests client certificates.
+    client_cert_enabled: bool,
+    /// The IP proxy state this process actually bound with. The value in a
+    /// subsequently edited file is intentionally ignored until restart.
+    ip_proxy_enabled: bool,
+}
+
 /// State every shard shares.
 ///
 /// None of it is on the per-packet path: the pool and routing table are touched
@@ -402,6 +721,14 @@ struct Shared {
     auth_permits: Arc<Semaphore>,
     /// Bounds both queued and running password verifications across all shards.
     auth_queue_slots: Arc<Semaphore>,
+    /// Pre-registered client identities, shared by every shard's TLS context.
+    ///
+    /// Replaceable at runtime so a client can be revoked without restarting
+    /// the process and dropping every other client's tunnel.
+    clients: Arc<SharedRoster>,
+    /// Present when the server started from a config file. The captured startup
+    /// mode prevents SIGHUP from pretending to change the bound TLS context.
+    roster_reload: Option<RosterReload>,
 }
 
 /// One shard: an independent event loop over its own share of connections.
@@ -413,6 +740,12 @@ struct Shard {
     h3_config: quiche::h3::Config,
     connections: FxHashMap<quiche::ConnectionId<'static>, ClientConnection>,
     auth: Option<Arc<BasicAuthenticator>>,
+    /// Set when clients authenticate with a certificate instead of credentials.
+    ///
+    /// The TLS context already refuses unregistered keys, so this exists to
+    /// attach the resolved identity to the connection and as a second check
+    /// that no connection slips through without one.
+    client_certs: Option<Arc<SharedRoster>>,
     tcp_policy: TargetPolicy,
     udp_policy: TargetPolicy,
     config: ServerConfig,
@@ -443,7 +776,7 @@ impl Shard {
         forward_rx: mpsc::Receiver<ForwardedPacket>,
         tun_rx: mpsc::Receiver<Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        let auth = if config.auth.enabled {
+        let auth = if config.auth.basic_enabled() {
             Some(BasicAuthenticator::new(
                 &config.auth.username,
                 &config.auth.password_hash,
@@ -468,11 +801,23 @@ impl Shard {
             "listening"
         );
 
-        let mut quic_config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
+        let client_certs = if config.auth.client_cert_enabled() {
+            Some(Arc::clone(&shared.clients))
+        } else {
+            None
+        };
 
-        // TLS
-        quic_config.load_cert_chain_from_pem_file(config.tls.cert_path.to_str().unwrap_or(""))?;
-        quic_config.load_priv_key_from_pem_file(config.tls.key_path.to_str().unwrap_or(""))?;
+        let mut quic_config = match &client_certs {
+            Some(registry) => build_client_cert_quic_config(&config, Arc::clone(registry))?,
+            None => {
+                let mut quic_config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
+                quic_config
+                    .load_cert_chain_from_pem_file(config.tls.cert_path.to_str().unwrap_or(""))?;
+                quic_config
+                    .load_priv_key_from_pem_file(config.tls.key_path.to_str().unwrap_or(""))?;
+                quic_config
+            }
+        };
 
         quic_config.set_application_protos(quiche::h3::APPLICATION_PROTOCOL)?;
 
@@ -537,6 +882,7 @@ impl Shard {
             h3_config,
             connections: FxHashMap::default(),
             auth: auth.map(Arc::new),
+            client_certs,
             tcp_policy,
             udp_policy,
             config,
@@ -575,6 +921,8 @@ impl Shard {
         let mut drain_deadline: Option<Instant> = None;
         const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
         let mut next_idle_sweep = Instant::now() + IDLE_SWEEP_INTERVAL;
+        // The roster generation this shard has already enforced.
+        let mut applied_roster_generation = self.shared.clients.generation();
         // The connections serviced in the current round. Held across
         // iterations so its allocation is reused.
         let mut serviced: Vec<u64> = Vec::new();
@@ -759,6 +1107,13 @@ impl Shard {
             if now >= next_idle_sweep {
                 next_idle_sweep = now + IDLE_SWEEP_INTERVAL;
                 if !shutting_down {
+                    // Cheap in the common case: one atomic read, and a scan
+                    // only when the roster actually changed.
+                    let generation = self.shared.clients.generation();
+                    if generation != applied_roster_generation {
+                        applied_roster_generation = generation;
+                        self.enforce_roster();
+                    }
                     self.cleanup_idle_tunnels(idle_timeout);
                     // The sweep writes to the connections it closes tunnels on,
                     // so pick up any it just marked.
@@ -994,6 +1349,39 @@ impl Shard {
         if let Err(e) = client.quic.recv(buf, recv_info) {
             debug!(%e, "quiche recv error");
             return;
+        }
+
+        // Resolve the client's certificate to a roster entry once, at the
+        // handshake boundary. The TLS callback has already refused unknown
+        // keys, so this is about attaching the identity that later decides
+        // which addresses the tunnel gets — and about refusing to serve a
+        // connection whose identity we somehow cannot name.
+        if let Some(registry) = &self.client_certs
+            && client.identity.is_none()
+            && client.quic.is_established()
+        {
+            match client
+                .quic
+                .peer_cert()
+                .map(|der| registry.load().identify(der))
+            {
+                Some(Ok(identity)) => {
+                    info!(client = %identity.name, %from, "client authenticated by certificate");
+                    client.identity = Some(identity);
+                }
+                other => {
+                    match other {
+                        Some(Err(e)) => warn!(%e, "closing connection with unusable certificate"),
+                        // Unreachable while the context sets
+                        // FAIL_IF_NO_PEER_CERT, but the cost of being wrong is
+                        // an unauthenticated tunnel.
+                        None => warn!("closing connection that presented no certificate"),
+                        Some(Ok(_)) => unreachable!(),
+                    }
+                    let _ = client.quic.close(false, 0x0100, b"unauthorized");
+                    return;
+                }
+            }
         }
 
         // Upgrade to HTTP/3 once QUIC handshake completes.
@@ -1378,13 +1766,35 @@ impl Shard {
     ) {
         let mut tunnel = IpTunnel::new(stream_id);
 
-        // Allocate an IPv4 address if the pool has one.
-        let (v4_result, v6_result) = {
-            let mut address_pool = shared.address_pool.lock().expect("address pool poisoned");
-            (address_pool.allocate_v4(), address_pool.allocate_v6())
+        // A client pinned to fixed addresses gets exactly those, and nothing
+        // from the pool: its tunnel interface is configured out of band with
+        // the same values, so an extra dynamic address would be advertised to a
+        // client that has no interface to receive it on.
+        let pinned = client
+            .identity
+            .as_ref()
+            .filter(|identity| identity.has_static_addresses());
+
+        let addresses = match pinned {
+            Some(identity) => match claim_static_addresses(shared, identity) {
+                Ok(addresses) => addresses,
+                Err(e) => {
+                    warn!(
+                        stream_id,
+                        client = %identity.name,
+                        %e,
+                        "cannot attach IP tunnel to this client's fixed addresses"
+                    );
+                    if let Some(h3) = &mut client.h3 {
+                        Self::send_error_response(h3, &mut client.quic, stream_id, 503);
+                    }
+                    return;
+                }
+            },
+            None => allocate_pool_addresses(shared),
         };
 
-        if v4_result.is_err() && v6_result.is_err() {
+        if addresses.is_empty() {
             warn!(stream_id, "address pool exhausted for IP tunnel");
             if let Some(h3) = &mut client.h3 {
                 Self::send_error_response(h3, &mut client.quic, stream_id, 503);
@@ -1392,50 +1802,69 @@ impl Shard {
             return;
         }
 
-        let mut assigned = Vec::new();
-
-        if let Ok(v4_addr) = v4_result {
-            let ip = IpAddr::V4(v4_addr);
-            tunnel.assigned_addrs.push(ip);
-            shared
-                .routing_table
-                .write()
-                .expect("routing table poisoned")
-                .insert(
-                    ip,
-                    TunnelOwner {
-                        conn_id: conn_idx,
-                        stream_id,
-                    },
-                );
-            assigned.push(AssignedAddress {
-                request_id: 0,
-                ip: IpAddress::V4(v4_addr),
-                prefix_len: 32,
+        let mut assigned = Vec::with_capacity(addresses.len());
+        for ip in &addresses {
+            tunnel.assigned_addrs.push(*ip);
+            assigned.push(match *ip {
+                IpAddr::V4(v4) => AssignedAddress {
+                    request_id: 0,
+                    ip: IpAddress::V4(v4),
+                    prefix_len: 32,
+                },
+                IpAddr::V6(v6) => AssignedAddress {
+                    request_id: 0,
+                    ip: IpAddress::V6(v6),
+                    prefix_len: 128,
+                },
             });
-            info!(stream_id, addr = %v4_addr, "assigned IPv4 to IP tunnel");
         }
 
-        if let Ok(v6_addr) = v6_result {
-            let ip = IpAddr::V6(v6_addr);
-            tunnel.assigned_addrs.push(ip);
+        // Do not acknowledge the CONNECT until every address has been leased.
+        // HTTP/3 permits only one response header block, so a 200 sent before
+        // allocation cannot later be corrected to a 503.
+        let headers = [
+            quiche::h3::Header::new(b":status", b"200"),
+            quiche::h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        let Some(h3) = &mut client.h3 else {
+            shared
+                .address_pool
+                .lock()
+                .expect("address pool poisoned")
+                .release_all(&addresses);
+            warn!(
+                stream_id,
+                "HTTP/3 state disappeared during CONNECT-IP setup"
+            );
+            return;
+        };
+        if let Err(e) = h3.send_response(&mut client.quic, stream_id, &headers, false) {
+            shared
+                .address_pool
+                .lock()
+                .expect("address pool poisoned")
+                .release_all(&addresses);
+            warn!(stream_id, %e, "failed to send CONNECT-IP 200");
+            return;
+        }
+
+        // A reconnect using the same registered key may briefly overlap its
+        // stale predecessor. Inserting replaces the return route atomically;
+        // remove_owned() prevents the predecessor's later cleanup from deleting
+        // this newer route.
+        for ip in &addresses {
             shared
                 .routing_table
                 .write()
                 .expect("routing table poisoned")
                 .insert(
-                    ip,
+                    *ip,
                     TunnelOwner {
                         conn_id: conn_idx,
                         stream_id,
                     },
                 );
-            assigned.push(AssignedAddress {
-                request_id: 0,
-                ip: IpAddress::V6(v6_addr),
-                prefix_len: 128,
-            });
-            info!(stream_id, addr = %v6_addr, "assigned IPv6 to IP tunnel");
+            info!(stream_id, addr = %ip, pinned = pinned.is_some(), "assigned address to IP tunnel");
         }
 
         // Send ADDRESS_ASSIGN and ROUTE_ADVERTISEMENT back to back: one buffer,
@@ -1461,9 +1890,7 @@ impl Shard {
             &mut capsules,
         );
 
-        if let Some(h3) = &mut client.h3
-            && let Err(e) = h3.send_body(&mut client.quic, stream_id, &capsules, false)
-        {
+        if let Err(e) = h3.send_body(&mut client.quic, stream_id, &capsules, false) {
             warn!(stream_id, %e, "failed to send CONNECT-IP capsules");
         }
 
@@ -2040,6 +2467,40 @@ impl Shard {
     }
 
     /// Close tunnels that have been idle too long.
+    /// Disconnect connections whose roster entry was removed or changed.
+    ///
+    /// A revoked client keeping its tunnel until it happens to reconnect would
+    /// make revocation meaningless, so the connection is closed rather than
+    /// merely barred from opening new streams. An entry that was edited counts
+    /// as revoked too: its pinned addresses were decided at setup time, so the
+    /// client has to come back to pick up the new ones.
+    fn enforce_roster(&mut self) {
+        let Some(roster) = self.client_certs.as_ref() else {
+            return;
+        };
+        let current = roster.load();
+
+        let mut revoked: Vec<quiche::ConnectionId<'static>> = Vec::new();
+        for (conn_id, client) in &self.connections {
+            let Some(identity) = client.identity.as_deref() else {
+                continue;
+            };
+            if !current.still_authorizes(identity) {
+                info!(client = %identity.name, "disconnecting client removed from the roster");
+                revoked.push(conn_id.clone());
+            }
+        }
+
+        for conn_id in revoked {
+            if let Some(client) = self.connections.get_mut(&conn_id) {
+                // A local close; the teardown that frees addresses and routes
+                // runs from the normal closed-connection path.
+                let _ = client.quic.close(true, 0x0100, b"revoked");
+                self.dirty.mark(client.index);
+            }
+        }
+    }
+
     fn cleanup_idle_tunnels(&mut self, timeout: Duration) {
         // Collect idle IP tunnel info so we can clean up after the loop.
         let mut idle_ip_tunnels: Vec<(quiche::ConnectionId<'static>, u64, u64)> = Vec::new();
@@ -2059,6 +2520,7 @@ impl Shard {
                 awaiting_auth: _,
                 deferred_send: _,
                 scheduled_deadline: _,
+                identity: _,
             } = client;
 
             // Closing a tunnel writes a response or a FIN to the connection,
@@ -2286,7 +2748,60 @@ impl Shard {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::ServerConfig;
+    use crate::config::{AuthMode, ClientEntry, ServerConfig};
+
+    fn invalid_roster_entry() -> ClientEntry {
+        ClientEntry {
+            name: "unused".into(),
+            public_key: "not-a-public-key".into(),
+            ipv4: Some("not-an-ip".into()),
+            ipv6: None,
+        }
+    }
+
+    #[test]
+    fn roster_is_not_parsed_outside_client_certificate_mode() {
+        let mut config = ServerConfig::default();
+        config.auth.mode = AuthMode::Basic;
+        config.clients.push(invalid_roster_entry());
+        assert!(super::active_client_registry(&config).unwrap().is_empty());
+
+        config.auth.enabled = false;
+        config.auth.mode = AuthMode::ClientCert;
+        assert!(super::active_client_registry(&config).unwrap().is_empty());
+    }
+
+    #[test]
+    fn active_client_certificate_roster_is_fail_closed() {
+        let mut config = ServerConfig::default();
+        config.auth.mode = AuthMode::ClientCert;
+        assert!(super::active_client_registry(&config).is_err());
+
+        config.clients.push(invalid_roster_entry());
+        assert!(super::active_client_registry(&config).is_err());
+    }
+
+    #[test]
+    fn roster_reload_uses_the_auth_and_ip_proxy_state_from_startup() {
+        let path = std::path::PathBuf::from("masque.toml");
+        let mut config = ServerConfig::default();
+
+        // Basic mode still consumes HUP safely (the systemd unit always exposes
+        // ExecReload), but the captured startup bit prevents an edited file from
+        // pretending the already-bound TLS context switched modes.
+        let reload = super::roster_reload_settings(&config, Some(path.clone())).unwrap();
+        assert!(!reload.client_cert_enabled);
+
+        config.auth.mode = AuthMode::ClientCert;
+        config.ip_proxy.enabled = false;
+        let reload = super::roster_reload_settings(&config, Some(path.clone())).unwrap();
+        assert_eq!(reload.path, path);
+        assert!(reload.client_cert_enabled);
+        assert!(!reload.ip_proxy_enabled);
+
+        // Programmatic servers have no source file to re-read.
+        assert!(super::roster_reload_settings(&config, None).is_none());
+    }
 
     /// The default algorithm name is only validated when a server starts, and
     /// a quiche rename would turn that into a startup failure in production.

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -41,6 +41,22 @@ impl PendingConnectSetups {
     }
 }
 
+/// Whether `protocol` names CONNECT-IP according to the configured list.
+///
+/// RFC 9484 registers `connect-ip`, but Cloudflare's endpoint uses
+/// `cf-connect-ip`, and clients written against it send only that. The value is
+/// compared case-sensitively: `:protocol` is a registered token, not a header
+/// name.
+///
+/// An empty `protocol` never matches, however the list is configured, because
+/// that is a standard CONNECT and belongs to the TCP path.
+fn accepts_connect_ip(configured: &[String], protocol: &[u8]) -> bool {
+    !protocol.is_empty()
+        && configured
+            .iter()
+            .any(|accepted| accepted.as_bytes() == protocol)
+}
+
 /// Shared request dependencies passed together to keep dispatch APIs focused.
 pub(super) struct RequestContext<'a> {
     pub(super) config: &'a ServerConfig,
@@ -102,7 +118,9 @@ impl Shard {
                 Some(ConnectRequest::Udp {
                     path: String::from_utf8_lossy(path).into_owned(),
                 })
-            } else if protocol == b"connect-ip" && context.config.ip_proxy.enabled {
+            } else if context.config.ip_proxy.enabled
+                && accepts_connect_ip(&context.config.ip_proxy.connect_protocols, protocol)
+            {
                 Some(ConnectRequest::Ip)
             } else {
                 None
@@ -181,31 +199,14 @@ impl Shard {
                 );
             }
             ConnectRequest::Ip => {
-                Self::handle_connect_ip_response(h3, quic, stream_id, &mut pending.ip);
+                // Address allocation can fail (pool exhaustion, bad fixed
+                // lease), so defer the response with the setup. Sending 200
+                // here would make a later 503 both illegal and invisible to
+                // the client.
+                info!(stream_id, "CONNECT-IP request accepted for setup");
+                pending.ip.push(stream_id);
             }
         }
-    }
-
-    /// Send 200 OK for CONNECT-IP and defer address allocation.
-    fn handle_connect_ip_response(
-        h3: &mut quiche::h3::Connection,
-        quic: &mut quiche::Connection,
-        stream_id: u64,
-        pending_ip_setups: &mut Vec<u64>,
-    ) {
-        info!(stream_id, "CONNECT-IP request accepted");
-
-        let headers = vec![
-            quiche::h3::Header::new(b":status", b"200"),
-            quiche::h3::Header::new(b"capsule-protocol", b"?1"),
-        ];
-
-        if let Err(e) = h3.send_response(quic, stream_id, &headers, false) {
-            warn!(stream_id, %e, "failed to send CONNECT-IP 200");
-            return;
-        }
-
-        pending_ip_setups.push(stream_id);
     }
 
     /// Parse and authorize CONNECT-UDP, respond, then defer socket creation.
@@ -255,5 +256,55 @@ impl Shard {
         }
 
         pending_udp_setups.push((stream_id, target));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::accepts_connect_ip;
+    use crate::config::IpProxySection;
+
+    fn defaults() -> Vec<String> {
+        IpProxySection::default().connect_protocols
+    }
+
+    #[test]
+    fn default_list_accepts_both_the_registered_and_cloudflare_identifiers() {
+        assert!(accepts_connect_ip(&defaults(), b"connect-ip"));
+        assert!(accepts_connect_ip(&defaults(), b"cf-connect-ip"));
+    }
+
+    #[test]
+    fn other_protocols_are_not_treated_as_connect_ip() {
+        assert!(!accepts_connect_ip(&defaults(), b"connect-udp"));
+        assert!(!accepts_connect_ip(&defaults(), b"websocket"));
+        // A prefix or suffix of an accepted token must not match.
+        assert!(!accepts_connect_ip(&defaults(), b"connect"));
+        assert!(!accepts_connect_ip(&defaults(), b"cf-connect-ip-v2"));
+    }
+
+    #[test]
+    fn absent_protocol_stays_with_the_tcp_path() {
+        // An empty `:protocol` is a standard CONNECT; claiming it here would
+        // divert every plain CONNECT into the IP tunnel.
+        assert!(!accepts_connect_ip(&defaults(), b""));
+        assert!(!accepts_connect_ip(&[String::new()], b""));
+    }
+
+    #[test]
+    fn matching_is_case_sensitive() {
+        // `:protocol` carries a registered token, not a header name.
+        assert!(!accepts_connect_ip(&defaults(), b"CONNECT-IP"));
+        assert!(!accepts_connect_ip(&defaults(), b"CF-Connect-IP"));
+    }
+
+    #[test]
+    fn an_operator_can_narrow_the_list() {
+        let strict = vec!["connect-ip".to_string()];
+        assert!(accepts_connect_ip(&strict, b"connect-ip"));
+        assert!(!accepts_connect_ip(&strict, b"cf-connect-ip"));
+
+        // Or drop CONNECT-IP support without disabling the proxy section.
+        assert!(!accepts_connect_ip(&[], b"connect-ip"));
     }
 }

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -1,0 +1,1062 @@
+//! End-to-end coverage for the Cloudflare-compatible CONNECT-IP path.
+//!
+//! These tests drive a real QUIC client against a real server, because the
+//! parts that were most likely to be wrong are the parts unit tests cannot
+//! reach: whether BoringSSL actually asks for a client certificate when the
+//! chain is unverifiable, and whether a request shaped the way Cloudflare's
+//! clients shape it survives quiche's HTTP/3 layer.
+//!
+//! The client is deliberately built to mimic that family of clients rather than
+//! an RFC 9484 one: a self-signed certificate with an empty subject, serial 0,
+//! and 24 hours of validity; `:protocol: cf-connect-ip`; a hardcoded authority;
+//! and `:path: /`.
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::asn1::Asn1Time;
+use boring::bn::BigNum;
+use boring::ec::{EcGroup, EcKey};
+use boring::hash::MessageDigest;
+use boring::nid::Nid;
+use boring::pkey::{PKey, Private};
+use boring::x509::{X509, X509Builder, X509NameBuilder};
+use quiche::h3::NameValue as _;
+
+use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
+use masque::capsule::{CapsuleFrame, IpAddress};
+use masque::config::{AuthMode, ClientEntry, ServerConfig};
+use masque::datagram::DatagramHeader;
+use masque::server::Server;
+
+const MAX_DATAGRAM_SIZE: usize = 1350;
+const CLIENT_IPV4: &str = "10.89.0.2";
+const CLIENT_IPV6: &str = "fd00:abcd::2";
+
+/// QUIC maps a TLS alert to `CRYPTO_ERROR` (0x100) plus the alert number.
+/// Alert 49 is `access_denied`.
+const ACCESS_DENIED_CRYPTO_ERROR: u64 = 0x100 + 49;
+
+/// The tunnel MTU these clients use, matching `ip_proxy.tun_mtu`.
+const TUN_MTU: usize = 1280;
+
+/// Connection ID length this client uses, matching what these clients set.
+/// It is also QUIC's maximum, which makes it the tightest case for datagram
+/// sizing.
+const CLIENT_CONN_ID_LEN: usize = quiche::MAX_CONN_ID_LEN;
+
+/// Connection ID length the server issues (`server::CONN_ID_LEN`).
+const SERVER_CONN_ID_LEN: usize = 16;
+
+// ── Key and certificate material ─────────────────────────────────────
+
+fn p256_key() -> PKey<Private> {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+}
+
+fn public_key_b64(key: &PKey<Private>) -> String {
+    STANDARD.encode(key.public_key_to_der().unwrap())
+}
+
+/// A self-signed certificate. `subject` empty reproduces what these clients
+/// present: no distinguished name at all, so only the key identifies them.
+fn self_signed(key: &PKey<Private>, subject: Option<&str>) -> X509 {
+    let mut builder = X509Builder::new().unwrap();
+    builder.set_version(2).unwrap();
+    builder
+        .set_serial_number(&BigNum::from_u32(0).unwrap().to_asn1_integer().unwrap())
+        .unwrap();
+    if let Some(cn) = subject {
+        let mut name = X509NameBuilder::new().unwrap();
+        name.append_entry_by_text("CN", cn).unwrap();
+        let name = name.build();
+        builder.set_subject_name(&name).unwrap();
+        builder.set_issuer_name(&name).unwrap();
+    }
+    builder
+        .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .unwrap();
+    builder
+        .set_not_after(&Asn1Time::days_from_now(1).unwrap())
+        .unwrap();
+    builder.set_pubkey(key).unwrap();
+    builder.sign(key, MessageDigest::sha256()).unwrap();
+    builder.build()
+}
+
+/// Write a key pair out as the PEM files quiche loads.
+fn write_pem(dir: &Path, stem: &str, key: &PKey<Private>, cert: &X509) -> (PathBuf, PathBuf) {
+    let cert_path = dir.join(format!("{stem}.crt"));
+    let key_path = dir.join(format!("{stem}.key"));
+    std::fs::write(&cert_path, cert.to_pem().unwrap()).unwrap();
+    // SEC1 ("EC PRIVATE KEY"), which is what BoringSSL expects here.
+    std::fs::write(
+        &key_path,
+        key.ec_key().unwrap().private_key_to_pem().unwrap(),
+    )
+    .unwrap();
+    (cert_path, key_path)
+}
+
+/// A scratch directory removed when the test ends.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "masque-it-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+// ── Server under test ────────────────────────────────────────────────
+
+/// Reserve a loopback UDP port and release it for the server to take.
+///
+/// `Server::bind` does not report the port it landed on, so the port has to be
+/// chosen before it starts.
+fn free_port() -> u16 {
+    UdpSocket::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn server_config(
+    cert: PathBuf,
+    key: PathBuf,
+    port: u16,
+    clients: Vec<ClientEntry>,
+) -> ServerConfig {
+    let mut config = ServerConfig::default();
+    config.server.listen_addr = SocketAddr::from(([127, 0, 0, 1], port));
+    config.server.shards = 1;
+    config.tls.cert_path = cert;
+    config.tls.key_path = key;
+    config.auth.enabled = true;
+    config.auth.mode = AuthMode::ClientCert;
+    config.clients = clients;
+    // The tunnels under test are CONNECT-IP only, and the TCP and UDP paths
+    // would otherwise resolve and dial real targets.
+    config.tcp_proxy.enabled = false;
+    config.udp_proxy.enabled = false;
+    config
+}
+
+/// Run a server on its own runtime thread for the duration of the test.
+///
+/// The thread is detached: the runtime is dropped when the process exits, and
+/// the OS reclaims the port.
+fn spawn_server(config: ServerConfig) {
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            match Server::bind(config).await {
+                Ok(mut server) => {
+                    let _ = server.run().await;
+                }
+                Err(e) => panic!("server failed to bind: {e:#}"),
+            }
+        });
+    });
+}
+
+// ── Client ───────────────────────────────────────────────────────────
+
+struct Client {
+    socket: UdpSocket,
+    quic: quiche::Connection,
+    h3: Option<quiche::h3::Connection>,
+}
+
+impl Client {
+    /// Connect with a client certificate, the way these clients authenticate.
+    ///
+    /// `verify_peer(false)` mirrors them too: the SNI they send does not match
+    /// the endpoint, so they skip chain validation and pin the server's public
+    /// key instead.
+    fn connect(peer: SocketAddr, cert: &Path, key: &Path) -> anyhow::Result<Self> {
+        let socket = UdpSocket::bind("127.0.0.1:0")?;
+        socket.connect(peer)?;
+        socket.set_read_timeout(Some(Duration::from_millis(50)))?;
+        let local = socket.local_addr()?;
+
+        let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
+        config.verify_peer(false);
+        config.load_cert_chain_from_pem_file(cert.to_str().unwrap())?;
+        config.load_priv_key_from_pem_file(key.to_str().unwrap())?;
+        config.set_application_protos(quiche::h3::APPLICATION_PROTOCOL)?;
+        config.set_max_idle_timeout(10_000);
+        config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
+        config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
+        config.set_initial_max_data(1_048_576);
+        config.set_initial_max_stream_data_bidi_local(262_144);
+        config.set_initial_max_stream_data_bidi_remote(262_144);
+        config.set_initial_max_stream_data_uni(262_144);
+        config.set_initial_max_streams_bidi(16);
+        config.set_initial_max_streams_uni(16);
+        config.enable_dgram(true, 256, 256);
+
+        let mut scid = [0u8; quiche::MAX_CONN_ID_LEN];
+        ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut scid)
+            .map_err(|_| anyhow::anyhow!("RNG failed"))?;
+
+        // The SNI these clients send names the vendor's endpoint rather than
+        // this server, which is exactly why they cannot verify the chain.
+        let quic = quiche::connect(
+            Some("consumer-masque.cloudflareclient.com"),
+            &quiche::ConnectionId::from_ref(&scid),
+            local,
+            peer,
+            &mut config,
+        )?;
+
+        Ok(Self {
+            socket,
+            quic,
+            h3: None,
+        })
+    }
+
+    fn flush(&mut self) -> anyhow::Result<()> {
+        let mut out = [0u8; MAX_DATAGRAM_SIZE];
+        loop {
+            match self.quic.send(&mut out) {
+                Ok((len, _)) => {
+                    self.socket.send(&out[..len])?;
+                }
+                Err(quiche::Error::Done) => return Ok(()),
+                Err(e) => anyhow::bail!("QUIC send: {e}"),
+            }
+        }
+    }
+
+    fn recv_once(&mut self) -> anyhow::Result<()> {
+        let mut buf = [0u8; 65535];
+        let len = match self.socket.recv(&mut buf) {
+            Ok(len) => len,
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+        let info = quiche::RecvInfo {
+            from: self.socket.peer_addr()?,
+            to: self.socket.local_addr()?,
+        };
+        match self.quic.recv(&mut buf[..len], info) {
+            Ok(_) | Err(quiche::Error::Done) => Ok(()),
+            Err(e) => anyhow::bail!("QUIC recv: {e}"),
+        }
+    }
+
+    fn drive(&mut self) -> anyhow::Result<()> {
+        self.flush()?;
+        self.recv_once()?;
+        self.flush()
+    }
+
+    fn handshake(&mut self, timeout: Duration) -> anyhow::Result<()> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            self.drive()?;
+            if self.quic.is_established() {
+                return Ok(());
+            }
+            if self.quic.is_closed() {
+                anyhow::bail!("connection closed during handshake");
+            }
+        }
+        anyhow::bail!("handshake timed out")
+    }
+
+    /// Drive until the peer tears the connection down, or give up.
+    ///
+    /// A rejected client cannot be detected at `is_established()`: under TLS
+    /// 1.3 the server sends its own Finished before it has seen the client's
+    /// certificate, so the client reaches "established" and only then receives
+    /// the alert. What matters is that the connection does not survive.
+    fn wait_for_close(&mut self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if self.quic.is_closed() || self.quic.peer_error().is_some() {
+                return true;
+            }
+            if self.drive().is_err() {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn init_h3(&mut self) -> anyhow::Result<()> {
+        let mut config = quiche::h3::Config::new()?;
+        config.enable_extended_connect(true);
+        self.h3 = Some(quiche::h3::Connection::with_transport(
+            &mut self.quic,
+            &config,
+        )?);
+        Ok(())
+    }
+
+    /// Send the CONNECT-IP request exactly as Cloudflare's clients send it.
+    fn send_connect_ip(&mut self, protocol: &str) -> anyhow::Result<u64> {
+        let headers = [
+            quiche::h3::Header::new(b":method", b"CONNECT"),
+            quiche::h3::Header::new(b":protocol", protocol.as_bytes()),
+            quiche::h3::Header::new(b":scheme", b"https"),
+            quiche::h3::Header::new(b":authority", b"cloudflareaccess.com"),
+            quiche::h3::Header::new(b":path", b"/"),
+            quiche::h3::Header::new(b"capsule-protocol", b"?1"),
+            // These clients send an empty User-Agent, which has to survive
+            // QPACK and the server's header scan.
+            quiche::h3::Header::new(b"user-agent", b""),
+        ];
+
+        let h3 = self.h3.as_mut().unwrap();
+        let stream_id = h3.send_request(&mut self.quic, &headers, false)?;
+        self.flush()?;
+        Ok(stream_id)
+    }
+
+    /// Wait for the response status on `stream_id`.
+    fn response_status(&mut self, stream_id: u64, timeout: Duration) -> anyhow::Result<u16> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            loop {
+                let h3 = self.h3.as_mut().unwrap();
+                match h3.poll(&mut self.quic) {
+                    Ok((sid, quiche::h3::Event::Headers { list, .. })) if sid == stream_id => {
+                        for header in &list {
+                            if header.name() == b":status" {
+                                let status = std::str::from_utf8(header.value())?;
+                                return Ok(status.parse()?);
+                            }
+                        }
+                        anyhow::bail!("response had no :status");
+                    }
+                    Ok(_) => continue,
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(e) => anyhow::bail!("H3 poll: {e}"),
+                }
+            }
+            self.drive()?;
+        }
+        anyhow::bail!("no response within {timeout:?}")
+    }
+
+    /// Collect capsules from the response body until `wanted` of them arrive.
+    fn capsules(&mut self, stream_id: u64, wanted: usize, timeout: Duration) -> Vec<CapsuleFrame> {
+        let deadline = Instant::now() + timeout;
+        let mut decoder = CapsuleDecoder::new();
+        let mut frames = Vec::new();
+        let mut buf = [0u8; 4096];
+
+        while Instant::now() < deadline && frames.len() < wanted {
+            loop {
+                let h3 = self.h3.as_mut().unwrap();
+                match h3.poll(&mut self.quic) {
+                    Ok(_) => continue,
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(_) => break,
+                }
+            }
+            loop {
+                let h3 = self.h3.as_mut().unwrap();
+                match h3.recv_body(&mut self.quic, stream_id, &mut buf) {
+                    Ok(len) => match decoder.decode(&buf[..len]) {
+                        Ok(mut decoded) => frames.append(&mut decoded),
+                        Err(DecodeError::Incomplete) => {}
+                        Err(e) => panic!("capsule decode failed: {e:?}"),
+                    },
+                    Err(_) => break,
+                }
+            }
+            let _ = self.drive();
+        }
+
+        frames
+    }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+/// A running server plus everything a client needs to reach it.
+struct Fixture {
+    _dir: TempDir,
+    peer: SocketAddr,
+    client_cert: PathBuf,
+    client_key: PathBuf,
+    stranger_cert: PathBuf,
+    stranger_key: PathBuf,
+}
+
+/// Start a server that knows one client, pinned to fixed addresses, and mint a
+/// second unregistered key pair to test rejection with.
+fn fixture(tag: &str) -> Fixture {
+    let dir = TempDir::new(tag);
+
+    let server_key = p256_key();
+    let (cert_path, key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+
+    let client_key = p256_key();
+    let (client_cert, client_key_path) = write_pem(
+        dir.path(),
+        "client",
+        &client_key,
+        &self_signed(&client_key, None),
+    );
+
+    let stranger_key = p256_key();
+    let (stranger_cert, stranger_key_path) = write_pem(
+        dir.path(),
+        "stranger",
+        &stranger_key,
+        &self_signed(&stranger_key, None),
+    );
+
+    let port = free_port();
+    spawn_server(server_config(
+        cert_path,
+        key_path,
+        port,
+        vec![ClientEntry {
+            name: "laptop".into(),
+            public_key: public_key_b64(&client_key),
+            ipv4: Some(CLIENT_IPV4.into()),
+            ipv6: Some(CLIENT_IPV6.into()),
+        }],
+    ));
+
+    let peer = SocketAddr::from(([127, 0, 0, 1], port));
+    // The server binds on another thread; give it a moment to take the port.
+    std::thread::sleep(Duration::from_millis(300));
+
+    Fixture {
+        _dir: dir,
+        peer,
+        client_cert,
+        client_key: client_key_path,
+        stranger_cert,
+        stranger_key: stranger_key_path,
+    }
+}
+
+// ── Roster reload fixture ────────────────────────────────────────────
+
+/// Render a server configuration file with the given roster entries.
+fn server_config_file(cert: &Path, key: &Path, port: u16, clients: &[(&str, &str)]) -> String {
+    let mut text = format!(
+        "[server]\nlisten_addr = \"127.0.0.1:{port}\"\nshards = 1\n\n\
+         [tls]\ncert_path = \"{}\"\nkey_path = \"{}\"\n\n\
+         [auth]\nenabled = true\nmode = \"client_cert\"\n\n\
+         [tcp_proxy]\nenabled = false\n\n[udp_proxy]\nenabled = false\n\n\
+         [ip_proxy]\nenabled = true\nipv4_pool = \"10.89.0.0/24\"\n\
+         ipv6_pool = \"fd00:abcd::/64\"\n",
+        cert.display(),
+        key.display()
+    );
+    for (name, public_key) in clients {
+        text.push_str(&format!(
+            "\n[[clients]]\nname = \"{name}\"\npublic_key = \"{public_key}\"\n"
+        ));
+    }
+    text
+}
+
+/// Ask this process to reload, the way an operator would.
+fn raise_sighup() {
+    let status = std::process::Command::new("kill")
+        .args(["-HUP", &std::process::id().to_string()])
+        .status()
+        .expect("failed to send SIGHUP");
+    assert!(status.success(), "kill -HUP failed");
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+/// Revoking a client must drop the tunnel it already holds, without restarting
+/// the server and without disturbing anyone else.
+///
+/// Removing an entry only from future handshakes would leave the revoked client
+/// connected for as long as it cared to stay, which is not revocation at all.
+#[test]
+fn revoked_client_is_disconnected_on_reload_while_others_keep_running() {
+    let dir = TempDir::new("revoke");
+
+    let server_key = p256_key();
+    let (cert_path, key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+
+    let doomed_key = p256_key();
+    let (doomed_cert, doomed_key_path) = write_pem(
+        dir.path(),
+        "doomed",
+        &doomed_key,
+        &self_signed(&doomed_key, None),
+    );
+    let keeper_key = p256_key();
+    let (keeper_cert, keeper_key_path) = write_pem(
+        dir.path(),
+        "keeper",
+        &keeper_key,
+        &self_signed(&keeper_key, None),
+    );
+
+    let port = free_port();
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        server_config_file(
+            &cert_path,
+            &key_path,
+            port,
+            &[
+                ("doomed", &public_key_b64(&doomed_key)),
+                ("keeper", &public_key_b64(&keeper_key)),
+            ],
+        ),
+    )
+    .unwrap();
+
+    let config =
+        masque::config::parse_toml(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    let reload_path = config_path.clone();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let mut server = Server::bind_with_reload(config, Some(reload_path))
+                .await
+                .expect("server failed to bind");
+            let _ = server.run().await;
+        });
+    });
+    // Let the server bind and install its signal handler before raising one.
+    std::thread::sleep(Duration::from_millis(600));
+
+    let peer = SocketAddr::from(([127, 0, 0, 1], port));
+    let mut doomed = Client::connect(peer, &doomed_cert, &doomed_key_path).unwrap();
+    doomed.handshake(Duration::from_secs(5)).unwrap();
+    doomed.init_h3().unwrap();
+    let doomed_stream = doomed.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        doomed
+            .response_status(doomed_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    let mut keeper = Client::connect(peer, &keeper_cert, &keeper_key_path).unwrap();
+    keeper.handshake(Duration::from_secs(5)).unwrap();
+    keeper.init_h3().unwrap();
+    let keeper_stream = keeper.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        keeper
+            .response_status(keeper_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    // Revoke one client and reload.
+    std::fs::write(
+        &config_path,
+        server_config_file(
+            &cert_path,
+            &key_path,
+            port,
+            &[("keeper", &public_key_b64(&keeper_key))],
+        ),
+    )
+    .unwrap();
+    raise_sighup();
+
+    assert!(
+        doomed.wait_for_close(Duration::from_secs(10)),
+        "a revoked client must lose the tunnel it already holds"
+    );
+
+    // The other client must be untouched: revocation is targeted, not a
+    // restart in disguise.
+    assert!(
+        !keeper.wait_for_close(Duration::from_secs(2)),
+        "revoking one client must not disturb the others"
+    );
+    assert!(!keeper.quic.is_closed());
+}
+
+/// A reload that does not validate must leave the running roster in force
+/// rather than locking everyone out.
+#[test]
+fn a_broken_reload_keeps_the_previous_roster() {
+    let dir = TempDir::new("badreload");
+
+    let server_key = p256_key();
+    let (cert_path, key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+    let client_key = p256_key();
+    let (client_cert, client_key_path) = write_pem(
+        dir.path(),
+        "client",
+        &client_key,
+        &self_signed(&client_key, None),
+    );
+
+    let port = free_port();
+    let config_path = dir.path().join("masque.toml");
+    let good = server_config_file(
+        &cert_path,
+        &key_path,
+        port,
+        &[("laptop", &public_key_b64(&client_key))],
+    );
+    std::fs::write(&config_path, &good).unwrap();
+
+    let config = masque::config::parse_toml(&good).unwrap();
+    let reload_path = config_path.clone();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let mut server = Server::bind_with_reload(config, Some(reload_path))
+                .await
+                .expect("server failed to bind");
+            let _ = server.run().await;
+        });
+    });
+    std::thread::sleep(Duration::from_millis(600));
+
+    let peer = SocketAddr::from(([127, 0, 0, 1], port));
+    let mut client = Client::connect(peer, &client_cert, &client_key_path).unwrap();
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+    let stream = client.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    // An unparseable public key: the roster must be rejected as a whole.
+    std::fs::write(
+        &config_path,
+        server_config_file(&cert_path, &key_path, port, &[("laptop", "!!not base64!!")]),
+    )
+    .unwrap();
+    raise_sighup();
+
+    assert!(
+        !client.wait_for_close(Duration::from_secs(3)),
+        "a rejected reload must not disconnect an authorized client"
+    );
+
+    // And a client presenting the still-valid key is still admitted.
+    let mut second = Client::connect(peer, &client_cert, &client_key_path).unwrap();
+    second.handshake(Duration::from_secs(5)).unwrap();
+    second.init_h3().unwrap();
+    let stream = second.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        second
+            .response_status(stream, Duration::from_secs(5))
+            .unwrap(),
+        200,
+        "the previous roster must still be in force after a failed reload"
+    );
+}
+
+/// The whole point of the exercise: a client that authenticates with a
+/// certificate and asks for `cf-connect-ip` gets a working tunnel, assigned the
+/// addresses its roster entry pins it to.
+#[test]
+fn registered_client_gets_its_pinned_addresses_over_cf_connect_ip() {
+    let fixture = fixture("happy");
+    let mut client =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+
+    let stream_id = client.send_connect_ip("cf-connect-ip").unwrap();
+    let status = client
+        .response_status(stream_id, Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(status, 200, "cf-connect-ip must be accepted");
+
+    let capsules = client.capsules(stream_id, 2, Duration::from_secs(5));
+    let assigned = capsules
+        .iter()
+        .find_map(|frame| match frame {
+            CapsuleFrame::AddressAssign(addrs) => Some(addrs),
+            _ => None,
+        })
+        .expect("server must send ADDRESS_ASSIGN");
+
+    // Pinned, not pool-allocated: a client that configures its interface out of
+    // band only works if the server hands back the same addresses every time.
+    let addresses: Vec<IpAddress> = assigned.iter().map(|a| a.ip.clone()).collect();
+    assert!(
+        addresses.contains(&IpAddress::V4(CLIENT_IPV4.parse::<Ipv4Addr>().unwrap())),
+        "expected the pinned IPv4, got {addresses:?}"
+    );
+    assert!(
+        addresses.contains(&IpAddress::V6(CLIENT_IPV6.parse::<Ipv6Addr>().unwrap())),
+        "expected the pinned IPv6, got {addresses:?}"
+    );
+
+    // The default route tells the client it may send everything through here.
+    assert!(
+        capsules
+            .iter()
+            .any(|frame| matches!(frame, CapsuleFrame::RouteAdvertisement(_))),
+        "expected ROUTE_ADVERTISEMENT, got {capsules:?}"
+    );
+}
+
+/// The registered `connect-ip` spelling has to keep working: accepting
+/// Cloudflare's identifier must not come at the cost of RFC 9484 clients.
+#[test]
+fn registered_client_may_also_use_the_rfc_protocol_identifier() {
+    let fixture = fixture("rfc");
+    let mut client =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+
+    let stream_id = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+}
+
+/// A full-MTU IP packet must fit into a single QUIC DATAGRAM.
+///
+/// These clients run a 1280-byte tunnel MTU and disable path-MTU discovery, so
+/// they will emit 1280-byte packets from the first moment. If the framed packet
+/// does not fit, pings and handshakes still work while bulk traffic silently
+/// disappears — the hardest possible failure mode to attribute.
+///
+/// The margin is tighter than it looks: QUIC subtracts the peer's connection ID
+/// from every packet's payload budget, and these clients use a 20-byte
+/// connection ID, which is the largest QUIC allows.
+#[test]
+fn a_full_mtu_ip_packet_fits_in_one_datagram() {
+    let fixture = fixture("mtu");
+    let mut client =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+    let stream_id = client.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    // Frame a packet the size of the configured tunnel MTU, the way the client
+    // would: quarter stream ID, context ID 0, then the raw IP packet.
+    let packet = vec![0x45u8; TUN_MTU];
+    let framed = DatagramHeader::new(stream_id).unwrap().encode(&packet);
+    assert!(framed.len() > TUN_MTU, "framing must add the header");
+
+    let writable = client
+        .quic
+        .dgram_max_writable_len()
+        .expect("server must advertise DATAGRAM support");
+
+    // The client's own budget is measured against the server's 16-byte
+    // connection ID, while the server's return path is measured against this
+    // client's 20-byte one. Requiring the difference as headroom means the
+    // assertion covers both directions, not just the roomier one.
+    let return_path_headroom = CLIENT_CONN_ID_LEN - SERVER_CONN_ID_LEN;
+    assert!(
+        writable >= framed.len() + return_path_headroom,
+        "a {TUN_MTU}-byte packet frames to {} bytes but only {writable} are writable \
+         ({return_path_headroom} of which the tighter return path needs); raise \
+         quic.max_datagram_size or lower ip_proxy.tun_mtu",
+        framed.len()
+    );
+
+    // Budget arithmetic is one thing; quiche actually accepting the write is
+    // the behaviour that matters.
+    client
+        .quic
+        .dgram_send(&framed)
+        .expect("a full-MTU packet must be sendable as one datagram");
+    client.flush().unwrap();
+}
+
+/// A network change often makes the replacement QUIC connection arrive before
+/// the dead one reaches its idle timeout. Because both connections prove
+/// possession of the same enrolled key, the replacement must be allowed to
+/// take over the pinned return route immediately rather than waiting up to a
+/// minute for the stale lease to disappear.
+#[test]
+fn registered_client_can_reconnect_while_the_old_tunnel_is_still_present() {
+    let fixture = fixture("reconnect");
+
+    let mut old = Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+    old.handshake(Duration::from_secs(5)).unwrap();
+    old.init_h3().unwrap();
+    let old_stream = old.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        old.response_status(old_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    // Keep `old` alive while a second connection using the same enrolled key
+    // claims exactly the same fixed addresses.
+    let mut replacement =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+    replacement.handshake(Duration::from_secs(5)).unwrap();
+    replacement.init_h3().unwrap();
+    let stream_id = replacement.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        replacement
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    let capsules = replacement.capsules(stream_id, 2, Duration::from_secs(5));
+    let assigned = capsules
+        .iter()
+        .find_map(|frame| match frame {
+            CapsuleFrame::AddressAssign(addrs) => Some(addrs),
+            _ => None,
+        })
+        .expect("replacement tunnel must receive its fixed addresses");
+    assert!(
+        assigned
+            .iter()
+            .any(|addr| { addr.ip == IpAddress::V4(CLIENT_IPV4.parse::<Ipv4Addr>().unwrap()) })
+    );
+
+    // Prevent an over-eager optimizer from ending the old connection's lifetime
+    // before the replacement has completed.
+    assert!(!old.quic.is_closed());
+}
+
+/// Address exhaustion must be decided before the success response. The old
+/// ordering sent 200 first and then attempted an impossible second 503 header
+/// block, leaving the caller with a successful but unusable tunnel.
+#[test]
+fn exhausted_address_pool_returns_503_instead_of_an_early_200() {
+    let dir = TempDir::new("exhausted");
+
+    let server_key = p256_key();
+    let (server_cert, server_key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+
+    let first_key = p256_key();
+    let (first_cert, first_key_path) = write_pem(
+        dir.path(),
+        "first",
+        &first_key,
+        &self_signed(&first_key, None),
+    );
+    let second_key = p256_key();
+    let (second_cert, second_key_path) = write_pem(
+        dir.path(),
+        "second",
+        &second_key,
+        &self_signed(&second_key, None),
+    );
+
+    let port = free_port();
+    let mut config = server_config(
+        server_cert,
+        server_key_path,
+        port,
+        vec![
+            ClientEntry {
+                name: "first".into(),
+                public_key: public_key_b64(&first_key),
+                ipv4: None,
+                ipv6: None,
+            },
+            ClientEntry {
+                name: "second".into(),
+                public_key: public_key_b64(&second_key),
+                ipv4: None,
+                ipv6: None,
+            },
+        ],
+    );
+    // network=.0, TUN gateway=.1, and the sole client address=.2.
+    config.ip_proxy.ipv4_pool = "10.89.0.0/30".into();
+    config.ip_proxy.ipv6_pool.clear();
+    spawn_server(config);
+    let peer = SocketAddr::from(([127, 0, 0, 1], port));
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mut first = Client::connect(peer, &first_cert, &first_key_path).unwrap();
+    first.handshake(Duration::from_secs(5)).unwrap();
+    first.init_h3().unwrap();
+    let first_stream = first.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        first
+            .response_status(first_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+    let capsules = first.capsules(first_stream, 2, Duration::from_secs(5));
+    let assigned = capsules
+        .iter()
+        .find_map(|frame| match frame {
+            CapsuleFrame::AddressAssign(addrs) => Some(addrs),
+            _ => None,
+        })
+        .unwrap();
+    assert!(
+        assigned
+            .iter()
+            .any(|addr| { addr.ip == IpAddress::V4("10.89.0.2".parse::<Ipv4Addr>().unwrap()) })
+    );
+
+    let mut second = Client::connect(peer, &second_cert, &second_key_path).unwrap();
+    second.handshake(Duration::from_secs(5)).unwrap();
+    second.init_h3().unwrap();
+    let second_stream = second.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        second
+            .response_status(second_stream, Duration::from_secs(5))
+            .unwrap(),
+        503
+    );
+
+    assert!(!first.quic.is_closed());
+}
+
+/// An unregistered key must never get a tunnel. The rejection lands as a TLS
+/// alert, so the connection is torn down rather than answering the request.
+#[test]
+fn unregistered_client_certificate_is_refused() {
+    let fixture = fixture("stranger");
+    let mut client =
+        Client::connect(fixture.peer, &fixture.stranger_cert, &fixture.stranger_key).unwrap();
+
+    // The handshake may reach "established" locally before the alert arrives,
+    // so its result is not the thing under test.
+    let _ = client.handshake(Duration::from_secs(2));
+    assert!(
+        client.wait_for_close(Duration::from_secs(5)),
+        "a key outside the roster must not keep a usable connection"
+    );
+
+    // The rejection has to come from TLS, not from the server's own
+    // belt-and-braces check after the handshake: only a TLS alert stops the
+    // client before it can open a stream, and only `access_denied` tells the
+    // operator their key is not enrolled rather than that TLS itself is broken.
+    assert_eq!(
+        client.quic.peer_error().map(|e| (e.is_app, e.error_code)),
+        Some((false, ACCESS_DENIED_CRYPTO_ERROR)),
+        "expected a CRYPTO_ERROR carrying TLS alert access_denied"
+    );
+}
+
+/// A client that offers no certificate at all must be refused too — the
+/// `FAIL_IF_NO_PEER_CERT` half of the verify mode. Without it, omitting the
+/// certificate would skip the verify callback entirely and reach the request
+/// path with no identity.
+#[test]
+fn client_without_a_certificate_is_refused() {
+    let fixture = fixture("nocert");
+
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    socket.connect(fixture.peer).unwrap();
+    socket
+        .set_read_timeout(Some(Duration::from_millis(50)))
+        .unwrap();
+    let local = socket.local_addr().unwrap();
+
+    let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .unwrap();
+    config.set_max_idle_timeout(10_000);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_initial_max_data(1_048_576);
+    config.set_initial_max_stream_data_bidi_local(262_144);
+    config.set_initial_max_streams_bidi(16);
+
+    let mut scid = [0u8; quiche::MAX_CONN_ID_LEN];
+    ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut scid).unwrap();
+    let quic = quiche::connect(
+        Some("consumer-masque.cloudflareclient.com"),
+        &quiche::ConnectionId::from_ref(&scid),
+        local,
+        fixture.peer,
+        &mut config,
+    )
+    .unwrap();
+
+    let mut client = Client {
+        socket,
+        quic,
+        h3: None,
+    };
+    let _ = client.handshake(Duration::from_secs(2));
+    assert!(
+        client.wait_for_close(Duration::from_secs(5)),
+        "a client with no certificate must not keep a usable connection"
+    );
+}


### PR DESCRIPTION
## Summary

- add Cloudflare-style cf-connect-ip alongside RFC CONNECT-IP
- add TLS client-certificate roster authentication with pinned client addresses
- add client enrollment output for usque and mihomo
- add atomic SIGHUP roster reload and immediate revocation handling
- update deployment configuration, documentation, and package version to 0.2.0

## Review hardening

- bind static reservations and overlapping reconnect leases to the authenticated public key
- preserve startup authentication and IP-proxy state during roster reload
- return 503 before a successful CONNECT-IP response when allocation or setup fails
- generate mihomo MTU from the active server configuration
- keep client enrollment files private and refuse accidental overwrite

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --locked
- cargo test --workspace --release --locked
- cargo +1.88.0 check --workspace --all-targets --locked
- shellcheck deploy/install.sh scripts/*.sh tests/e2e/*.sh
- real Linux client connectivity verified by the operator