### PR TITLE
feat: support multiple authentication listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ pre-1.0.
   IPv4 as well, since whether it does is the kernel's `IPV6_V6ONLY` default.
   Addresses are compared in canonical form, so an IPv4-mapped spelling such as
   `[::ffff:127.0.0.1]` cannot present itself as a different address from the
-  IPv4 one it resolves to.
+  IPv4 one it resolves to, and the error names which conflict it found rather
+  than blaming a wildcard that may not be involved. Port `0` is exempt: it asks
+  the kernel for whichever port is free, so several listeners may use it.
 - `check-config` prints the resolved listeners, their shard counts, and the
   authentication each one demands, so the deployed modes can be read without
   re-deriving them from the TOML. Shard counts are the resolved ones, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-18
+
+### Added
+
+- `[[listeners]]` runs several listening sockets from one process, each with
+  its own `listen_addr`, `shards`, and authentication mode. This is what allows
+  one server to accept both standards-compliant MASQUE clients, which send
+  `Proxy-Authorization`, and Cloudflare-style clients, which authenticate with
+  a TLS client certificate: `auth.mode` decides which TLS context a socket is
+  bound with, so the two modes cannot share a socket. They do share everything
+  behind them — one `[[clients]]` roster, one TUN device, one CONNECT-IP
+  address pool, one routing table — which two processes could not.
+- Startup and `check-config` reject two listeners on one address. A listener
+  with more than one shard binds with `SO_REUSEPORT`, so a second listener on
+  that address would join the load-balancing group and be handed connections
+  meant for the other authentication mode.
+
+### Changed
+
+- Shards are numbered across the whole server rather than within a listener,
+  and the 32-shard cap now applies to that total. `shards = 0` (one per core)
+  is rejected when more than one listener is configured.
+- The `[[clients]]` roster and its `SIGHUP` reload follow "any listener uses
+  `client_cert`" rather than the single `auth.mode`.
+- Configurations without `[[listeners]]` are unchanged: `[server]` and `[auth]`
+  still describe one listener, and `[server].listen_addr` and `[server].shards`
+  are ignored only when `[[listeners]]` names sockets itself.
+
 ## 0.2.0 - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,19 @@ pre-1.0.
   bound with, so the two modes cannot share a socket. They do share everything
   behind them — one `[[clients]]` roster, one TUN device, one CONNECT-IP
   address pool, one routing table — which two processes could not.
-- Startup and `check-config` reject two listeners on one address. A listener
-  with more than one shard binds with `SO_REUSEPORT`, so a second listener on
-  that address would join the load-balancing group and be handed connections
-  meant for the other authentication mode.
+- Startup and `check-config` reject two listeners that contend for one address.
+  A listener with more than one shard binds with `SO_REUSEPORT`, so a second
+  listener on that address would join the load-balancing group and be handed
+  connections meant for the other authentication mode. Wildcards count:
+  `0.0.0.0` claims every IPv4 address on its port, and `::` is assumed to claim
+  IPv4 as well, since whether it does is the kernel's `IPV6_V6ONLY` default.
+- `check-config` prints the resolved listeners and the authentication each one
+  demands, so the deployed modes can be read without re-deriving them from the
+  TOML.
+- The installer offers a `dual` authentication mode that writes a two-listener
+  configuration, generating Basic credentials for one port and enrolling the
+  first certificate client on the other. It reports the modes of an existing
+  multi-listener configuration correctly on upgrade.
 
 ### Changed
 
@@ -31,6 +40,12 @@ pre-1.0.
   is rejected when more than one listener is configured.
 - The `[[clients]]` roster and its `SIGHUP` reload follow "any listener uses
   `client_cert`" rather than the single `auth.mode`.
+- The concurrent password-verification budget is sized from the shards that
+  verify passwords rather than from every shard, so a client-certificate
+  listener cannot widen what unauthenticated callers may demand of a Basic one.
+- `--listen` is refused against a `[[listeners]]` configuration, which does not
+  use `[server].listen_addr`. Silently ignoring it would leave the configured
+  listeners bound when the flag was reached for to narrow exposure.
 - Configurations without `[[listeners]]` are unchanged: `[server]` and `[auth]`
   still describe one listener, and `[server].listen_addr` and `[server].shards`
   are ignored only when `[[listeners]]` names sockets itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ pre-1.0.
 
 ### Added
 
-- `[[listeners]]` runs several listening sockets from one process, each with
+- `[[listeners]]` runs one or more listening sockets from one process, each with
   its own `listen_addr`, `shards`, and authentication mode. This is what allows
   one server to accept both standards-compliant MASQUE clients, which send
   `Proxy-Authorization`, and Cloudflare-style clients, which authenticate with
@@ -28,8 +28,11 @@ pre-1.0.
   Addresses are compared in canonical form, so an IPv4-mapped spelling such as
   `[::ffff:127.0.0.1]` cannot present itself as a different address from the
   IPv4 one it resolves to, and the error names which conflict it found rather
-  than blaming a wildcard that may not be involved. Port `0` is exempt: it asks
-  the kernel for whichever port is free, so several listeners may use it.
+  than blaming a wildcard that may not be involved. Non-zero link-local IPv6
+  scope IDs remain part of the interface identity. Port `0` is exempt: it asks
+  the kernel for whichever port is free, so several listeners may use it; all
+  shards of one listener share the selected port, and startup prevents that port
+  from joining another listener's `SO_REUSEPORT` group.
 - `check-config` prints the resolved listeners, their shard counts, and the
   authentication each one demands, so the deployed modes can be read without
   re-deriving them from the TOML. Shard counts are the resolved ones, so
@@ -50,12 +53,11 @@ pre-1.0.
 - The concurrent password-verification budget is sized from the shards that
   verify passwords rather than from every shard, so a client-certificate
   listener cannot widen what unauthenticated callers may demand of a Basic one.
-- `--listen` is refused against a `[[listeners]]` configuration, which does not
-  use `[server].listen_addr`. Silently ignoring it would leave the configured
-  listeners bound when the flag was reached for to narrow exposure.
-- Configurations without `[[listeners]]` are unchanged: `[server]` and `[auth]`
-  still describe one listener, and `[server].listen_addr` and `[server].shards`
-  are ignored only when `[[listeners]]` names sockets itself.
+- **Breaking:** every configuration must define at least one `[[listeners]]`
+  entry with its own `[listeners.auth]`. Top-level `[auth]`,
+  `[server].listen_addr`, and `[server].shards` are rejected, and the `--listen`
+  override has been removed. The installer deliberately does not migrate 0.2
+  files; convert and validate them explicitly before upgrading.
 
 ## 0.2.0 - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,18 @@ pre-1.0.
   connections meant for the other authentication mode. Wildcards count:
   `0.0.0.0` claims every IPv4 address on its port, and `::` is assumed to claim
   IPv4 as well, since whether it does is the kernel's `IPV6_V6ONLY` default.
-- `check-config` prints the resolved listeners and the authentication each one
-  demands, so the deployed modes can be read without re-deriving them from the
-  TOML.
+  Addresses are compared in canonical form, so an IPv4-mapped spelling such as
+  `[::ffff:127.0.0.1]` cannot present itself as a different address from the
+  IPv4 one it resolves to.
+- `check-config` prints the resolved listeners, their shard counts, and the
+  authentication each one demands, so the deployed modes can be read without
+  re-deriving them from the TOML. Shard counts are the resolved ones, so
+  `shards = 0` reports the per-core count rather than zero.
 - The installer offers a `dual` authentication mode that writes a two-listener
   configuration, generating Basic credentials for one port and enrolling the
-  first certificate client on the other. It reports the modes of an existing
-  multi-listener configuration correctly on upgrade.
+  first certificate client on the other. On upgrade it reports every mode an
+  existing configuration runs, `disabled` included, so a server that
+  authenticates on one port and not another cannot read as if it did both.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ target/release/masque-server --config ./masque.toml enroll-client \
 Append the generated `[[clients]]` block to the server configuration, then
 reload or restart the service. The generated client configuration contains a
 private key and must be handled as a secret. Basic and client-certificate
-authentication are mutually exclusive within one server instance; see
-[Authentication](docs/configuration.md#authentication) for the complete setup.
+authentication are mutually exclusive on one socket, because the mode decides
+what the TLS handshake demands. To serve both kinds of client, give each mode
+its own `[[listeners]]` entry in the same process; see
+[Authentication](docs/configuration.md#authentication) and
+[Multiple listeners](docs/configuration.md#multiple-listeners).
 
 ## One-command Linux install
 
@@ -69,11 +72,13 @@ On Linux x86_64, download, verify, and install the latest stable release with:
 curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/install-latest.sh | sudo sh
 ```
 
-For a new configuration the installer prompts for `basic` or `client_cert`
-authentication and optional TLS file locations. Basic mode generates a random
-password when none is supplied. Client-certificate mode enrolls the first
+For a new configuration the installer prompts for `basic`, `client_cert`, or
+`dual` authentication and optional TLS file locations. Basic mode generates a
+random password when none is supplied. Client-certificate mode enrolls the first
 client, adds its `[[clients]]` entry, writes its secret JSON as mode `0600`, and
-prints the matching usque and mihomo configuration. At the end it prints the
+prints the matching usque and mihomo configuration. Dual mode does both, writing
+a two-listener configuration that serves credentials on one port and
+certificates on another. At the end it prints the
 installed version, service state, and effective server configuration with the
 password hash redacted.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ a staging environment.
 - CONNECT-IP ([RFC 9484]) with Linux TUN integration
 - HTTP Basic authentication with Argon2id password verification, or TLS client
   certificate authentication against a public-key roster
+- Multiple listeners in one process, each with its own Basic or client-certificate
+  authentication mode while sharing proxy policies, client roster, and TUN state
 - CIDR allow and deny policies for TCP and UDP targets
 - Bounded queues and backpressure across authentication and tunnel I/O
 - Linux `recvmmsg`/`sendmmsg`, UDP GRO, optional UDP GSO, and TUN offload
@@ -28,8 +30,8 @@ Build the server:
 cargo build --release --bin masque-server
 ```
 
-Authentication is enabled by default. For the default `basic` mode, generate an
-Argon2id password hash:
+Each `[[listeners]]` entry has an explicit `[listeners.auth]` table. For a
+`basic` listener, generate an Argon2id password hash:
 
 ```sh
 printf '%s' 'replace-this-password' | \
@@ -46,8 +48,9 @@ target/release/masque-server --config ./masque.toml
 Authentication is fail-closed. In `basic` mode the server refuses to start until
 a valid username and Argon2id hash are configured.
 
-Alternatively, set `auth.mode = "client_cert"` to authenticate clients during
-the TLS handshake. Generate each client's P-256 key and configuration with:
+Alternatively, set `mode = "client_cert"` in `[listeners.auth]` to authenticate
+clients during the TLS handshake. Generate each client's P-256 key and
+configuration with:
 
 ```sh
 target/release/masque-server --config ./masque.toml enroll-client \
@@ -62,7 +65,7 @@ authentication are mutually exclusive on one socket, because the mode decides
 what the TLS handshake demands. To serve both kinds of client, give each mode
 its own `[[listeners]]` entry in the same process; see
 [Authentication](docs/configuration.md#authentication) and
-[Multiple listeners](docs/configuration.md#multiple-listeners).
+[Listeners](docs/configuration.md#listeners).
 
 ## One-command Linux install
 
@@ -90,6 +93,11 @@ incompatible configuration aborts before replacement; a failed service restart
 restores the prior binary, unit, and service state. See
 [Deployment](docs/deployment.md#one-command-install) for non-interactive
 variables, certificate requirements, and installing a specific release.
+
+The 0.3 configuration format is intentionally not compatible with 0.2. Convert
+old `[auth]` and `[server]` listener keys into explicit `[[listeners]]` and
+`[listeners.auth]` entries before rerunning the installer; it does not migrate
+them automatically.
 
 ## Install a downloaded release on Linux
 

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -24,6 +24,9 @@ enabled = true
 # Pick "client_cert" for VPN-style clients modelled on Cloudflare WARP MASQUE
 # (for example usque): they authenticate during the QUIC handshake and never
 # send Proxy-Authorization, so they cannot work against "basic".
+#
+# To serve both kinds of client, give each mode its own listener — see the
+# [[listeners]] block at the end of this file.
 mode = "basic"
 username = "__MASQUE_AUTH_USERNAME__"
 password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"
@@ -127,3 +130,44 @@ tun_mtu = 1280
 tun_offload = true
 ipv4_pool = "10.89.0.0/16"
 ipv6_pool = "fd00:abcd::/64"
+
+# ── Multiple listeners ───────────────────────────────────────────────
+#
+# One socket can serve only one authentication mode: auth.mode decides which
+# TLS context the socket is bound with, and that is settled before any client
+# connects. [[listeners]] gives each mode its own socket in the same process.
+#
+# This is the whole list of listeners, not an addition to the one above:
+# uncommenting it makes [server].listen_addr and [server].shards ignored, and
+# [auth] becomes the default that a listener without its own [listeners.auth]
+# inherits. Everything behind the sockets stays shared — one [[clients]]
+# roster, one TUN device, one CONNECT-IP address pool, one routing table.
+# That is the reason to do this in one process: two processes would need two
+# TUN devices and two pools, and overlapping pools hand the same tunnel address
+# to two clients.
+#
+# Two listeners may not name the same address. That is refused at startup
+# rather than left to the kernel: a listener with shards > 1 binds with
+# SO_REUSEPORT, so a second listener on that address would join its
+# load-balancing group and be handed connections meant for the other mode.
+#
+# Move the username and password_hash from [auth] above into the Basic
+# listener, then run `masque-server --config <this file> check-config`.
+#
+# [[listeners]]
+# listen_addr = "0.0.0.0:443"
+# shards = 1
+#
+# [listeners.auth]
+# enabled = true
+# mode = "basic"
+# username = "proxy-user"
+# password_hash = "$argon2id$v=19$m=19456,t=2,p=1$..."
+#
+# [[listeners]]
+# listen_addr = "0.0.0.0:4443"
+# shards = 1
+#
+# [listeners.auth]
+# enabled = true
+# mode = "client_cert"

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -1,22 +1,24 @@
 [server]
-listen_addr = "0.0.0.0:443"
 # Keep this above the client's keepalive period. VPN-style MASQUE clients
 # commonly default to 30s, and matching that exactly makes a quiet tunnel race
 # its own keepalive against the timeout.
 idle_timeout_secs = 60
 max_connections = 10000
 max_tunnels_per_connection = 100
-# Independent event loops, each with its own SO_REUSEPORT socket and its own
-# share of the connections. A connection is always handled by one loop, so this
-# is what lets a CPU-bound server use more than one core. 0 = one per core.
-# Linux only; measure before raising it.
-shards = 1
 
 [tls]
 cert_path = "/etc/masque/certs/server.crt"
 key_path = "/etc/masque/certs/server.key"
 
-[auth]
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+# Independent event loops, each with its own SO_REUSEPORT socket and its own
+# share of the connections. A connection is always handled by one loop, so this
+# is what lets a CPU-bound server use more than one core. 0 = one per core for a
+# single listener. Linux only; measure before raising it.
+shards = 1
+
+[listeners.auth]
 enabled = true
 # "basic"       — RFC 7617 Proxy-Authorization, checked per request.
 # "client_cert" — a TLS client certificate, matched against [[clients]] below.
@@ -25,8 +27,8 @@ enabled = true
 # (for example usque): they authenticate during the QUIC handshake and never
 # send Proxy-Authorization, so they cannot work against "basic".
 #
-# To serve both kinds of client, give each mode its own listener — see the
-# [[listeners]] block at the end of this file.
+# To serve both kinds of client, add the second listener shown at the end of
+# this file. Every listener has its own explicit authentication table.
 mode = "basic"
 username = "__MASQUE_AUTH_USERNAME__"
 password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"
@@ -131,20 +133,13 @@ tun_offload = true
 ipv4_pool = "10.89.0.0/16"
 ipv6_pool = "fd00:abcd::/64"
 
-# ── Multiple listeners ───────────────────────────────────────────────
+# ── Additional listener ─────────────────────────────────────────────
 #
 # One socket can serve only one authentication mode: auth.mode decides which
-# TLS context the socket is bound with, and that is settled before any client
-# connects. [[listeners]] gives each mode its own socket in the same process.
-#
-# This is the whole list of listeners, not an addition to the one above:
-# uncommenting it makes [server].listen_addr and [server].shards ignored, and
-# [auth] becomes the default that a listener without its own [listeners.auth]
-# inherits. Everything behind the sockets stays shared — one [[clients]]
-# roster, one TUN device, one CONNECT-IP address pool, one routing table.
-# That is the reason to do this in one process: two processes would need two
-# TUN devices and two pools, and overlapping pools hand the same tunnel address
-# to two clients.
+# TLS context is built before clients connect. Add another [[listeners]] entry
+# to serve another mode in the same process. Everything behind the sockets stays
+# shared — TLS files, proxy policies, one [[clients]] roster, one TUN device,
+# one CONNECT-IP address pool, and one routing table.
 #
 # Two listeners may not contend for the same address. That is refused at startup
 # rather than left to the kernel: a listener with shards > 1 binds with
@@ -152,22 +147,6 @@ ipv6_pool = "fd00:abcd::/64"
 # load-balancing group and be handed connections meant for the other mode.
 # Wildcards count — 0.0.0.0 claims every IPv4 address on its port, and :: is
 # assumed to claim IPv4 too, since IPV6_V6ONLY is the kernel's to decide.
-#
-# Also delete listen_addr and shards from [server] above: [[listeners]] names
-# the sockets, so those two settings no longer do anything.
-#
-# Move the username and password_hash from [auth] above into the Basic
-# listener, then run `masque-server --config <this file> check-config`.
-#
-# [[listeners]]
-# listen_addr = "0.0.0.0:443"
-# shards = 1
-#
-# [listeners.auth]
-# enabled = true
-# mode = "basic"
-# username = "proxy-user"
-# password_hash = "$argon2id$v=19$m=19456,t=2,p=1$..."
 #
 # [[listeners]]
 # listen_addr = "0.0.0.0:4443"

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -146,10 +146,15 @@ ipv6_pool = "fd00:abcd::/64"
 # TUN devices and two pools, and overlapping pools hand the same tunnel address
 # to two clients.
 #
-# Two listeners may not name the same address. That is refused at startup
+# Two listeners may not contend for the same address. That is refused at startup
 # rather than left to the kernel: a listener with shards > 1 binds with
 # SO_REUSEPORT, so a second listener on that address would join its
 # load-balancing group and be handed connections meant for the other mode.
+# Wildcards count — 0.0.0.0 claims every IPv4 address on its port, and :: is
+# assumed to claim IPv4 too, since IPV6_V6ONLY is the kernel's to decide.
+#
+# Also delete listen_addr and shards from [server] above: [[listeners]] names
+# the sockets, so those two settings no longer do anything.
 #
 # Move the username and password_hash from [auth] above into the Basic
 # listener, then run `masque-server --config <this file> check-config`.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -22,6 +22,7 @@ CONFIG_CHANGED=0
 FRESH_CONFIG=0
 CONFIG_TMP=
 CONFIG_REWRITE_TMP=
+CHECK_CONFIG_OUTPUT=
 ENROLL_OUTPUT=
 CLIENT_BLOCK_TMP=
 CLIENT_CONFIG_OUT=
@@ -158,10 +159,24 @@ normalize_auth_mode() {
         2|cert|certs|client-cert|client_cert)
             printf '%s\n' client_cert
             ;;
+        3|dual|both)
+            printf '%s\n' dual
+            ;;
         *)
-            die "authentication mode must be 'basic' or 'client_cert'"
+            die "authentication mode must be 'basic', 'client_cert', or 'dual'"
             ;;
     esac
+}
+
+# Whether this mode enrolls a certificate client and therefore needs the server
+# TLS material at install time.
+mode_uses_client_certs() {
+    [ "$AUTH_MODE" = client_cert ] || [ "$AUTH_MODE" = dual ]
+}
+
+# Whether this mode issues Basic credentials.
+mode_uses_basic() {
+    [ "$AUTH_MODE" = basic ] || [ "$AUTH_MODE" = dual ]
 }
 
 choose_auth_mode() {
@@ -173,6 +188,7 @@ choose_auth_mode() {
                 echo "Choose an authentication mode:"
                 echo "  1) Basic          username and password on every CONNECT request"
                 echo "  2) Client cert    TLS client certificate for usque/mihomo-style clients"
+                echo "  3) Dual           both, on two ports of one server"
             } >/dev/tty
             requested_mode=$(prompt_value "Authentication mode" 1)
         else
@@ -182,40 +198,40 @@ choose_auth_mode() {
     AUTH_MODE=$(normalize_auth_mode "$requested_mode")
 }
 
+# Report what the deployed configuration actually authenticates with.
+#
+# Taken from `check-config`, which resolves the listeners the same way the
+# server does, rather than read out of the TOML here. `[auth]` is only the
+# default a `[[listeners]]` entry may inherit, so reading that section alone
+# would describe one mode for a server that runs two — and re-deriving the
+# resolution in shell would be a second implementation to keep in step.
 detect_existing_auth_mode() {
-    detected_enabled=$(awk '
-        /^[[:space:]]*\[/ {
-            in_auth = ($0 ~ /^[[:space:]]*\[auth\][[:space:]]*(#.*)?$/)
-            next
-        }
-        in_auth && /^[[:space:]]*enabled[[:space:]]*=/ {
-            line = $0
-            sub(/^[^=]*=[[:space:]]*/, "", line)
-            sub(/[[:space:]]*(#.*)?$/, "", line)
-            print line
-            exit
-        }
-    ' "$CONFIG_PATH")
-    if [ "$detected_enabled" = false ]; then
-        AUTH_MODE=disabled
+    detected_modes=$(printf '%s\n' "$CHECK_CONFIG_OUTPUT" |
+        sed -n 's/^listener [^ ]* auth=\([a-z_]*\) .*$/\1/p' | sort -u)
+
+    if [ -z "$detected_modes" ]; then
+        AUTH_MODE=unknown
         return
     fi
 
-    detected_mode=$(awk '
-        /^[[:space:]]*\[/ {
-            in_auth = ($0 ~ /^[[:space:]]*\[auth\][[:space:]]*(#.*)?$/)
-            next
-        }
-        in_auth && /^[[:space:]]*mode[[:space:]]*=/ {
-            line = $0
-            sub(/^[^=]*=[[:space:]]*/, "", line)
-            sub(/[[:space:]]*(#.*)?$/, "", line)
-            gsub(/"/, "", line)
-            print line
-            exit
-        }
-    ' "$CONFIG_PATH")
-    AUTH_MODE=$(normalize_auth_mode "${detected_mode:-basic}")
+    detected_basic=0
+    detected_cert=0
+    for detected_mode in $detected_modes; do
+        case "$detected_mode" in
+            basic) detected_basic=1 ;;
+            client_cert) detected_cert=1 ;;
+        esac
+    done
+
+    if [ "$detected_basic" -eq 1 ] && [ "$detected_cert" -eq 1 ]; then
+        AUTH_MODE=dual
+    elif [ "$detected_cert" -eq 1 ]; then
+        AUTH_MODE=client_cert
+    elif [ "$detected_basic" -eq 1 ]; then
+        AUTH_MODE=basic
+    else
+        AUTH_MODE=disabled
+    fi
 }
 
 generate_auth_credentials() {
@@ -256,7 +272,7 @@ install_tls_material() {
     if [ "$prompt_for_tls" -eq 1 ] && [ -z "$cert_source" ] &&
         { [ ! -r "$TLS_CERT_PATH" ] || [ ! -r "$TLS_KEY_PATH" ]; } &&
         can_prompt; then
-        if [ "$AUTH_MODE" = client_cert ]; then
+        if mode_uses_client_certs; then
             echo "Client-certificate enrollment needs the server certificate now." \
                 >/dev/tty
             cert_source=$(prompt_value "PEM full-chain certificate path" "")
@@ -280,9 +296,9 @@ install_tls_material() {
         fi
     fi
 
-    if [ "$prompt_for_tls" -eq 1 ] && [ "$AUTH_MODE" = client_cert ] &&
+    if [ "$prompt_for_tls" -eq 1 ] && mode_uses_client_certs &&
         { [ ! -r "$TLS_CERT_PATH" ] || [ ! -r "$TLS_KEY_PATH" ]; }; then
-        die "client_cert requires $TLS_CERT_PATH and $TLS_KEY_PATH; set MASQUE_TLS_CERT and MASQUE_TLS_KEY"
+        die "$AUTH_MODE requires $TLS_CERT_PATH and $TLS_KEY_PATH; set MASQUE_TLS_CERT and MASQUE_TLS_KEY"
     fi
 }
 
@@ -308,26 +324,86 @@ render_new_config() {
                 -e '/^password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"$/d' \
                 "$PACKAGE_DIR/config/masque.toml" >"$CONFIG_TMP"
             ;;
+        dual)
+            # [auth] keeps the generated Basic credentials and becomes the
+            # default the Basic listener inherits; the certificate listener
+            # overrides it. [server].listen_addr and [server].shards are dropped
+            # because [[listeners]] names the sockets instead, and leaving them
+            # would have the server warn about ignored settings on every start.
+            generate_auth_credentials
+            sed \
+                -e "s|__MASQUE_AUTH_USERNAME__|$AUTH_USERNAME|" \
+                -e "s|__MASQUE_AUTH_PASSWORD_HASH__|$AUTH_PASSWORD_HASH|" \
+                -e '/^listen_addr = "0.0.0.0:443"$/d' \
+                -e '/^shards = 1$/d' \
+                "$PACKAGE_DIR/config/masque.toml" >"$CONFIG_TMP"
+            ;;
     esac
     if grep -q '__MASQUE_AUTH_' "$CONFIG_TMP"; then
         die "failed to render authentication configuration"
     fi
 }
 
-configure_fresh_listen_port() {
-    listen_port=${MASQUE_LISTEN_PORT:-}
-    if [ -z "$listen_port" ]; then
+# Append the two listener blocks a dual configuration runs.
+append_dual_listeners() {
+    basic_port=$1
+    cert_port=$2
+
+    cat >>"$CONFIG_TMP" <<EOF
+
+# Basic credentials on one socket, TLS client certificates on the other. The
+# authentication mode fixes what the TLS handshake demands, so the two cannot
+# share a socket; everything behind them — the client roster, the TUN device,
+# the CONNECT-IP address pool — is shared by the one process.
+[[listeners]]
+listen_addr = "0.0.0.0:$basic_port"
+shards = 1
+
+[[listeners]]
+listen_addr = "0.0.0.0:$cert_port"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "client_cert"
+EOF
+}
+
+# Read and validate one UDP port.
+choose_listen_port() {
+    port_prompt=$1
+    port_default=$2
+    port_value=$3
+
+    if [ -z "$port_value" ]; then
         if can_prompt; then
-            listen_port=$(prompt_value "Public UDP listen port" 443)
+            port_value=$(prompt_value "$port_prompt" "$port_default")
         else
-            listen_port=443
+            port_value=$port_default
         fi
     fi
-    case "$listen_port" in
-        ""|*[!0-9]*) die "MASQUE_LISTEN_PORT must be an integer from 1 to 65535" ;;
+    case "$port_value" in
+        ""|*[!0-9]*) die "$port_prompt must be an integer from 1 to 65535" ;;
     esac
-    if [ "$listen_port" -lt 1 ] || [ "$listen_port" -gt 65535 ]; then
-        die "MASQUE_LISTEN_PORT must be an integer from 1 to 65535"
+    if [ "$port_value" -lt 1 ] || [ "$port_value" -gt 65535 ]; then
+        die "$port_prompt must be an integer from 1 to 65535"
+    fi
+    printf '%s\n' "$port_value"
+}
+
+configure_fresh_listen_port() {
+    listen_port=$(choose_listen_port "Public UDP listen port" 443 \
+        "${MASQUE_LISTEN_PORT:-}")
+
+    if [ "$AUTH_MODE" = dual ]; then
+        cert_listen_port=$(choose_listen_port \
+            "Public UDP listen port for certificate clients" 4443 \
+            "${MASQUE_CERT_LISTEN_PORT:-}")
+        if [ "$cert_listen_port" = "$listen_port" ]; then
+            die "the two listeners need different ports; both asked for $listen_port"
+        fi
+        append_dual_listeners "$listen_port" "$cert_listen_port"
+        return
     fi
 
     CONFIG_REWRITE_TMP=$(mktemp /etc/masque/.masque-listen.XXXXXX)
@@ -445,13 +521,19 @@ print_redacted_config() {
     echo "--- end configuration ---"
 }
 
+# Preflight a configuration with the candidate binary.
+#
+# The output is kept in CHECK_CONFIG_OUTPUT as well as shown: it carries the
+# resolved listener list, which is where the deployed authentication modes are
+# read from rather than re-derived from the TOML.
 check_config_compatibility() {
     config_to_check=$1
     candidate_version=$("$CANDIDATE_BIN" --version)
     echo "Checking configuration compatibility with $candidate_version ..."
-    if ! "$CANDIDATE_BIN" --config "$config_to_check" check-config; then
+    if ! CHECK_CONFIG_OUTPUT=$("$CANDIDATE_BIN" --config "$config_to_check" check-config); then
         die "configuration compatibility check failed; no binary or systemd unit was replaced"
     fi
+    printf '%s\n' "$CHECK_CONFIG_OUTPUT"
 }
 
 snapshot_installed_files() {
@@ -535,7 +617,7 @@ if [ "$FRESH_CONFIG" -eq 1 ]; then
     render_new_config
     configure_fresh_listen_port
 
-    if [ "$AUTH_MODE" = client_cert ]; then
+    if mode_uses_client_certs; then
         enroll_first_client
     fi
 
@@ -560,7 +642,7 @@ echo "  Authentication: $AUTH_MODE"
 echo "  Service:        $SERVICE_RESULT"
 echo "  Logs:           journalctl -u masque -f"
 
-if [ "$AUTH_MODE" = basic ] && [ "$CONFIG_CHANGED" -eq 1 ]; then
+if mode_uses_basic && [ "$CONFIG_CHANGED" -eq 1 ]; then
     echo
     echo "Basic client credentials:"
     echo "  Username: $AUTH_USERNAME"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -205,33 +205,23 @@ choose_auth_mode() {
 # default a `[[listeners]]` entry may inherit, so reading that section alone
 # would describe one mode for a server that runs two — and re-deriving the
 # resolution in shell would be a second implementation to keep in step.
+# Every distinct mode is reported, `disabled` included. Summarising a
+# basic + disabled server as "basic" would tell an administrator that every port
+# demands credentials when one of them accepts anyone, which is the reading that
+# leaves an open proxy in place.
 detect_existing_auth_mode() {
     detected_modes=$(printf '%s\n' "$CHECK_CONFIG_OUTPUT" |
         sed -n 's/^listener [^ ]* auth=\([a-z_]*\) .*$/\1/p' | sort -u)
 
-    if [ -z "$detected_modes" ]; then
-        AUTH_MODE=unknown
-        return
-    fi
-
-    detected_basic=0
-    detected_cert=0
+    AUTH_MODE=
     for detected_mode in $detected_modes; do
-        case "$detected_mode" in
-            basic) detected_basic=1 ;;
-            client_cert) detected_cert=1 ;;
-        esac
+        if [ -z "$AUTH_MODE" ]; then
+            AUTH_MODE=$detected_mode
+        else
+            AUTH_MODE="$AUTH_MODE + $detected_mode"
+        fi
     done
-
-    if [ "$detected_basic" -eq 1 ] && [ "$detected_cert" -eq 1 ]; then
-        AUTH_MODE=dual
-    elif [ "$detected_cert" -eq 1 ]; then
-        AUTH_MODE=client_cert
-    elif [ "$detected_basic" -eq 1 ]; then
-        AUTH_MODE=basic
-    else
-        AUTH_MODE=disabled
-    fi
+    [ -n "$AUTH_MODE" ] || AUTH_MODE=unknown
 }
 
 generate_auth_credentials() {
@@ -642,7 +632,19 @@ echo "  Authentication: $AUTH_MODE"
 echo "  Service:        $SERVICE_RESULT"
 echo "  Logs:           journalctl -u masque -f"
 
-if mode_uses_basic && [ "$CONFIG_CHANGED" -eq 1 ]; then
+# The per-socket truth behind the summary line above, so a server that
+# authenticates on one port and not another cannot read as if it did both.
+listener_summary=$(printf '%s\n' "$CHECK_CONFIG_OUTPUT" | sed -n 's/^listener /  /p')
+if [ -n "$listener_summary" ]; then
+    echo
+    echo "Listeners:"
+    printf '%s\n' "$listener_summary"
+fi
+
+# CONFIG_CHANGED first: only a freshly rendered configuration has credentials to
+# print, and on an upgrade AUTH_MODE is a summary of what was found rather than
+# one of the modes this installer writes.
+if [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
     echo
     echo "Basic client credentials:"
     echo "  Username: $AUTH_USERNAME"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -200,11 +200,8 @@ choose_auth_mode() {
 
 # Report what the deployed configuration actually authenticates with.
 #
-# Taken from `check-config`, which resolves the listeners the same way the
-# server does, rather than read out of the TOML here. `[auth]` is only the
-# default a `[[listeners]]` entry may inherit, so reading that section alone
-# would describe one mode for a server that runs two — and re-deriving the
-# resolution in shell would be a second implementation to keep in step.
+# Taken from `check-config`, which validates and resolves the listeners the same
+# way the server does, rather than reimplement that logic in shell.
 # Every distinct mode is reported, `disabled` included. Summarising a
 # basic + disabled server as "basic" would tell an administrator that every port
 # demands credentials when one of them accepts anyone, which is the reading that
@@ -300,7 +297,7 @@ create_config_tmp() {
 render_new_config() {
     create_config_tmp
     case "$AUTH_MODE" in
-        basic)
+        basic|dual)
             generate_auth_credentials
             sed \
                 -e "s|__MASQUE_AUTH_USERNAME__|$AUTH_USERNAME|" \
@@ -314,41 +311,23 @@ render_new_config() {
                 -e '/^password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"$/d' \
                 "$PACKAGE_DIR/config/masque.toml" >"$CONFIG_TMP"
             ;;
-        dual)
-            # [auth] keeps the generated Basic credentials and becomes the
-            # default the Basic listener inherits; the certificate listener
-            # overrides it. [server].listen_addr and [server].shards are dropped
-            # because [[listeners]] names the sockets instead, and leaving them
-            # would have the server warn about ignored settings on every start.
-            generate_auth_credentials
-            sed \
-                -e "s|__MASQUE_AUTH_USERNAME__|$AUTH_USERNAME|" \
-                -e "s|__MASQUE_AUTH_PASSWORD_HASH__|$AUTH_PASSWORD_HASH|" \
-                -e '/^listen_addr = "0.0.0.0:443"$/d' \
-                -e '/^shards = 1$/d' \
-                "$PACKAGE_DIR/config/masque.toml" >"$CONFIG_TMP"
-            ;;
     esac
     if grep -q '__MASQUE_AUTH_' "$CONFIG_TMP"; then
         die "failed to render authentication configuration"
     fi
 }
 
-# Append the two listener blocks a dual configuration runs.
-append_dual_listeners() {
-    basic_port=$1
-    cert_port=$2
+# Append the certificate listener to the Basic listener already rendered from
+# the package template.
+append_certificate_listener() {
+    cert_port=$1
 
     cat >>"$CONFIG_TMP" <<EOF
 
-# Basic credentials on one socket, TLS client certificates on the other. The
+# TLS client certificates on this socket, Basic credentials on the first. The
 # authentication mode fixes what the TLS handshake demands, so the two cannot
 # share a socket; everything behind them — the client roster, the TUN device,
 # the CONNECT-IP address pool — is shared by the one process.
-[[listeners]]
-listen_addr = "0.0.0.0:$basic_port"
-shards = 1
-
 [[listeners]]
 listen_addr = "0.0.0.0:$cert_port"
 shards = 1
@@ -385,17 +364,6 @@ configure_fresh_listen_port() {
     listen_port=$(choose_listen_port "Public UDP listen port" 443 \
         "${MASQUE_LISTEN_PORT:-}")
 
-    if [ "$AUTH_MODE" = dual ]; then
-        cert_listen_port=$(choose_listen_port \
-            "Public UDP listen port for certificate clients" 4443 \
-            "${MASQUE_CERT_LISTEN_PORT:-}")
-        if [ "$cert_listen_port" = "$listen_port" ]; then
-            die "the two listeners need different ports; both asked for $listen_port"
-        fi
-        append_dual_listeners "$listen_port" "$cert_listen_port"
-        return
-    fi
-
     CONFIG_REWRITE_TMP=$(mktemp /etc/masque/.masque-listen.XXXXXX)
     chmod 0600 "$CONFIG_REWRITE_TMP"
     sed "s|^listen_addr = \"0.0.0.0:443\"$|listen_addr = \"0.0.0.0:$listen_port\"|" \
@@ -406,6 +374,16 @@ configure_fresh_listen_port() {
     fi
     mv -- "$CONFIG_REWRITE_TMP" "$CONFIG_TMP"
     CONFIG_REWRITE_TMP=
+
+    if [ "$AUTH_MODE" = dual ]; then
+        cert_listen_port=$(choose_listen_port \
+            "Public UDP listen port for certificate clients" 4443 \
+            "${MASQUE_CERT_LISTEN_PORT:-}")
+        if [ "$cert_listen_port" = "$listen_port" ]; then
+            die "the two listeners need different ports; both asked for $listen_port"
+        fi
+        append_certificate_listener "$cert_listen_port"
+    fi
 }
 
 normalize_optional_address() {

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -130,7 +130,11 @@ parse_start_requested() {
 }
 
 can_prompt() {
-    [ -r /dev/tty ] && [ -w /dev/tty ]
+    # Device-node permissions alone are not enough: CI containers often expose
+    # /dev/tty without giving the process a controlling terminal. Actually open
+    # it so a non-interactive install falls back to defaults instead of failing
+    # on the first prompt.
+    (: </dev/tty >/dev/tty) 2>/dev/null
 }
 
 prompt_value() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,12 +107,13 @@ without dropping legitimate migration traffic.
 One connection still uses one shard. Sharding improves aggregate throughput
 across multiple connections; it cannot parallelize a single QUIC connection.
 
-`[[listeners]]` runs several listeners in one process. Each is materialized
-into its own `ServerConfig`, so a shard reads one listener's settings and never
-has to know it is one listener among several; the multi-listener change does
-not reach the request or packet paths. The authentication mode is the reason
-this exists: `auth.mode` decides which TLS context `build_quic_config` returns,
-and that is fixed when the socket binds.
+`[[listeners]]` runs one or more listeners in one process. Startup resolves each
+entry into a small listener plan containing its address, shard count, and
+authentication. Every shard also references the same process-wide
+`ServerConfig`, so proxy policies, QUIC/TLS tuning, limits, and CONNECT-IP state
+are shared rather than copied per listener. The authentication mode decides
+which TLS context `build_quic_config` returns, and that is fixed when the socket
+binds.
 
 Shards are numbered across the whole server rather than within a listener,
 which is what lets the cross-shard queues, the connection-ID registry, and the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,8 @@ TUN packet ----------->|                       |
 `Server` validates configuration, creates shared policy and routing state, and
 starts one or more `Shard` instances. A shard owns:
 
-- one `SO_REUSEPORT` QUIC UDP socket;
+- one QUIC UDP socket, bound with `SO_REUSEPORT` when its listener has more
+  than one shard;
 - its QUIC and HTTP/3 connections;
 - tunnel state for those connections;
 - connection and pacing timers; and
@@ -91,10 +92,11 @@ When work arrives, only affected connections enter the dirty set. The shard
 drives those connections, stages output using quiche's send quantum, emits a
 bounded UDP batch, and reschedules their next deadlines.
 
-## Sharding
+## Listeners and sharding
 
-`server.shards = N` creates N independent listeners on the same address using
-`SO_REUSEPORT`. The kernel normally keeps a client 4-tuple on one listener.
+`shards = N` on a listener creates N independent event loops on that listener's
+address using `SO_REUSEPORT`. The kernel normally keeps a client 4-tuple on one
+of them.
 
 QUIC permits address migration, so a packet can arrive on a shard that does
 not own its connection. A shared connection-ID registry identifies the owner,
@@ -104,6 +106,26 @@ without dropping legitimate migration traffic.
 
 One connection still uses one shard. Sharding improves aggregate throughput
 across multiple connections; it cannot parallelize a single QUIC connection.
+
+`[[listeners]]` runs several listeners in one process. Each is materialized
+into its own `ServerConfig`, so a shard reads one listener's settings and never
+has to know it is one listener among several; the multi-listener change does
+not reach the request or packet paths. The authentication mode is the reason
+this exists: `auth.mode` decides which TLS context `build_quic_config` returns,
+and that is fixed when the socket binds.
+
+Shards are numbered across the whole server rather than within a listener,
+which is what lets the cross-shard queues, the connection-ID registry, and the
+TUN ownership map stay single and listener-agnostic. Everything in `Shared` is
+server-wide: the address pool, the routing table, the TUN device, the client
+roster, and the credential-verification budget. A forwarded packet is re-handled
+by its owner using that shard's own local address, so a reply always leaves the
+socket the connection actually lives on — including when the owner belongs to a
+different listener.
+
+One shard reads the TUN device and distributes packets to the connections that
+own their addresses. Shard 0 is an arbitrary but stable choice, unrelated to
+which listener it serves.
 
 ## Authentication pipeline
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,18 +235,36 @@ listeners in one process rather than two processes — two processes would need
 two TUN devices and two address pools, and overlapping pools hand the same
 tunnel address to two clients.
 
-The server refuses to start when two listeners name the same address. This is
-not left to the kernel to report: a listener with more than one shard opens its
-socket with `SO_REUSEPORT`, so a second listener on that address would join the
-load-balancing group and be handed connections meant for the other
+The server refuses to start when two listeners contend for the same address.
+This is not left to the kernel to report: a listener with more than one shard
+opens its socket with `SO_REUSEPORT`, so a second listener on that address would
+join the load-balancing group and be handed connections meant for the other
 authentication mode.
 
+Wildcards count as contention. `0.0.0.0` claims every IPv4 address on its port,
+so it conflicts with `127.0.0.1` on that port. `::` is treated as claiming IPv4
+as well, because whether it really does is the kernel's `IPV6_V6ONLY` default —
+`0` on Linux unless `net.ipv6.bindv6only` says otherwise. Nothing here sets that
+option, so `[::]:443` beside `0.0.0.0:443` is refused everywhere rather than
+binding on some hosts and failing on others.
+
 `shards = 0` (one per core) is rejected when more than one listener is
-configured; give each listener an explicit count. The `MAX_SHARDS` cap of 32
-applies to the server's total, not to any one listener.
+configured; give each listener an explicit count. The 32-shard cap applies to
+the server's total, not to any one listener. The budget for concurrent password
+verification is sized from the Basic listeners' shards alone, so adding a
+certificate listener does not widen what unauthenticated callers can demand.
+
+`--listen` overrides `[server].listen_addr`, which this form does not use, so
+it is refused rather than silently ignored when `[[listeners]]` is present.
 
 Run `masque-server --config masque.toml check-config` to validate a
-multi-listener file before restarting.
+multi-listener file before restarting. It prints the resolved listeners:
+
+```
+configuration is compatible with masque-server 0.3.0: /etc/masque/masque.toml
+listener 0.0.0.0:443 auth=basic shards=1
+listener 0.0.0.0:4443 auth=client_cert shards=1
+```
 
 The usque JSON schema stores the endpoint IP but not its port, so enrollment
 also prints the matching launch argument — `--connect-port 443` for the example

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,11 @@ as well, because whether it really does is the kernel's `IPV6_V6ONLY` default �
 option, so `[::]:443` beside `0.0.0.0:443` is refused everywhere rather than
 binding on some hosts and failing on others.
 
+Addresses are compared in canonical form, so `[::ffff:127.0.0.1]:443` and
+`127.0.0.1:443` are recognised as the same interface rather than passing the
+check and then failing to bind — or, under `SO_REUSEPORT`, binding successfully
+and leaving one listener shadowing the other's traffic.
+
 `shards = 0` (one per core) is rejected when more than one listener is
 configured; give each listener an explicit count. The 32-shard cap applies to
 the server's total, not to any one listener. The budget for concurrent password
@@ -258,7 +263,9 @@ certificate listener does not widen what unauthenticated callers can demand.
 it is refused rather than silently ignored when `[[listeners]]` is present.
 
 Run `masque-server --config masque.toml check-config` to validate a
-multi-listener file before restarting. It prints the resolved listeners:
+multi-listener file before restarting. It prints the resolved listeners, with
+the shard counts the server will actually run rather than the ones written down
+— `shards = 0` expanded to one per core, and any excess capped:
 
 ```
 configuration is compatible with masque-server 0.3.0: /etc/masque/masque.toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,10 @@
 # Configuration
 
-The server reads TOML from `--config` (default `masque.toml`). Missing sections
-use defaults, but authentication is deliberately fail-closed: the default
-configuration cannot start until credentials are set or authentication is
-explicitly disabled.
+The server reads TOML from `--config` (default `masque.toml`). Global sections
+may use defaults, but every file must explicitly define at least one
+`[[listeners]]` entry and its `[listeners.auth]` table. Authentication is
+deliberately fail-closed: a Basic listener cannot start until valid credentials
+are set. Unknown keys are rejected rather than silently ignored.
 
 Start from [`deploy/config/masque.toml`](../deploy/config/masque.toml). That
 file is the canonical deployable example and is tested by the release flow.
@@ -17,7 +18,6 @@ masque-server --config <PATH> check-config
 masque-server enroll-client [OPTIONS] --name <NAME> --endpoint <ADDR:PORT>
 
   -c, --config <PATH>       Config file [default: masque.toml]
-  -l, --listen <ADDR>       Override server.listen_addr
       --cert <PATH>         Override tls.cert_path
       --key <PATH>          Override tls.key_path
   -v, --verbose             Increase verbosity; repeat for trace logging
@@ -30,9 +30,9 @@ creating a TUN device. It is suitable for upgrade preflight, but cannot detect
 runtime conditions such as an occupied port or unavailable kernel device.
 
 `hash-password` reads a password on stdin and prints an Argon2id hash for
-`auth.password_hash`. `enroll-client` generates a client key pair for
-`auth.mode = "client_cert"`; it reads `tls.cert_path` from `--config`, so pass
-the same config the server uses. Both are described under
+`listeners.auth.password_hash`. `enroll-client` generates a client key pair for
+a listener using `auth.mode = "client_cert"`; it reads `tls.cert_path` from
+`--config`, so pass the same config the server uses. Both are described under
 [Authentication](#authentication).
 
 ```text
@@ -50,27 +50,19 @@ enroll-client options:
 
 ```toml
 [server]
-listen_addr = "0.0.0.0:443"
 idle_timeout_secs = 60
 max_connections = 10000
 max_tunnels_per_connection = 100
-shards = 1
 ```
 
 | Key | Meaning |
 | --- | --- |
-| `listen_addr` | UDP address used for QUIC and HTTP/3 |
 | `idle_timeout_secs` | Inactive tunnel lifetime |
 | `max_connections` | Per-shard connection cap |
 | `max_tunnels_per_connection` | CONNECT streams retained per connection |
-| `shards` | Linux event loops/listeners; `0` selects one per available core |
 
-Use one shard until a benchmark shows one event loop is CPU-bound. Memory and
-the effective connection capacity increase with the shard count.
-
-`listen_addr` and `shards` describe the single listener this section implies.
-A configuration that uses [`[[listeners]]`](#multiple-listeners) names its
-sockets there instead, and these two keys are then ignored.
+This section contains process-wide connection limits only. Socket addresses and
+shard counts belong to [`[[listeners]]`](#listeners).
 
 ## TLS
 
@@ -85,11 +77,10 @@ as group `masque`; install both files as `root:masque` with mode `0640`.
 
 ## Authentication
 
-`auth.mode` selects how clients prove who they are. The two modes are mutually
-exclusive *on one socket* — `client_cert` makes the TLS handshake demand a
-certificate, so a credential-based client cannot even connect, and vice versa.
-To serve both kinds of client, give each mode its own listener; see
-[Multiple listeners](#multiple-listeners).
+Each `[listeners.auth]` selects how clients prove who they are on that socket.
+The two modes are mutually exclusive *on one socket* — `client_cert` makes the
+TLS handshake demand a certificate, so a credential-based client cannot even
+connect, and vice versa. To serve both kinds of client, define two listeners.
 
 | Key | Meaning |
 | --- | --- |
@@ -110,7 +101,11 @@ Credentials are checked on every CONNECT request, so one authorized tunnel does
 not authorize later streams that omit the header.
 
 ```toml
-[auth]
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+shards = 1
+
+[listeners.auth]
 enabled = true
 mode = "basic"
 username = "proxy-user"
@@ -140,7 +135,11 @@ if their sections are enabled — the mode changes who may connect, not what the
 may ask for.
 
 ```toml
-[auth]
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+shards = 1
+
+[listeners.auth]
 enabled = true
 mode = "client_cert"
 
@@ -191,13 +190,11 @@ existing path is never overwritten. Without it the JSON goes to the terminal.
 Nothing is written to the server configuration automatically. Append the
 `[[clients]]` block yourself, then run `systemctl reload masque` or restart.
 
-## Multiple listeners
+## Listeners
 
-`[[listeners]]` gives each socket its own authentication mode, which is what
-lets one process serve both kinds of client. It is the whole list of listeners,
-not an addition to `[server].listen_addr`: naming any listener here stops the
-server deriving one from `[server]`, and `[server].listen_addr` and
-`[server].shards` are then ignored.
+`[[listeners]]` is the required, complete list of sockets. Each entry owns its
+address, shard count, and authentication mode. There is no top-level `[auth]`
+and `[server]` does not contain listener settings.
 
 ```toml
 [[listeners]]
@@ -223,17 +220,17 @@ mode = "client_cert"
 | --- | --- |
 | `listen_addr` | Required; there is no default, so a typo cannot silently land on someone else's port |
 | `shards` | Event loops for this listener; defaults to `1` |
-| `[listeners.auth]` | Optional; omitted means the top-level `[auth]` |
+| `[listeners.auth]` | Required; authentication is always explicit per socket |
 
-A `[listeners.auth]` table replaces `[auth]` outright rather than merging field
-by field, so the username from a Basic `[auth]` does not follow a listener that
-switched to `client_cert`.
-
-Everything else stays server-wide: one `[[clients]]` roster, one TUN device, one
-CONNECT-IP address pool, one routing table. That is the reason to run two
+Everything else stays server-wide: TLS and QUIC settings, TCP/UDP target
+policies, connection limits, one `[[clients]]` roster, one TUN device, one
+CONNECT-IP address pool, and one routing table. That is the reason to run two
 listeners in one process rather than two processes — two processes would need
 two TUN devices and two address pools, and overlapping pools hand the same
 tunnel address to two clients.
+
+Use one shard until a benchmark shows one event loop is CPU-bound. Memory and
+the effective connection capacity increase with the shard count.
 
 The server refuses to start when two listeners contend for the same address.
 This is not left to the kernel to report: a listener with more than one shard
@@ -256,8 +253,10 @@ the three it found: the same address twice, one address written two ways, or a
 wildcard covering another.
 
 Port `0` is exempt. It asks the kernel for whichever port is free, so several
-listeners may use it; `check-config` and the `listening` log lines report the
-ports they were given.
+listeners may use it. Every shard of one listener shares the same selected port,
+and the live `listening` log lines report that address. `check-config` is
+side-effect-free and therefore reports the configured `:0`; no port has been
+selected until the server binds.
 
 `shards = 0` (one per core) is rejected when more than one listener is
 configured; give each listener an explicit count. The 32-shard cap applies to
@@ -265,12 +264,9 @@ the server's total, not to any one listener. The budget for concurrent password
 verification is sized from the Basic listeners' shards alone, so adding a
 certificate listener does not widen what unauthenticated callers can demand.
 
-`--listen` overrides `[server].listen_addr`, which this form does not use, so
-it is refused rather than silently ignored when `[[listeners]]` is present.
-
-Run `masque-server --config masque.toml check-config` to validate a
-multi-listener file before restarting. It prints the resolved listeners, with
-the shard counts the server will actually run rather than the ones written down
+Run `masque-server --config masque.toml check-config` to validate a listener
+file before restarting. It prints the resolved listeners, with the shard counts
+the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
@@ -335,8 +331,8 @@ client can be re-enrolled without a restart either.
 
 Only the roster is reloaded. Listen address, TLS material, pools, and tuning are
 fixed at bind time; changing those still needs a restart. A reload that does not
-validate — an unparseable key, a pinned address outside the pool, `auth.mode` no
-longer `client_cert` — is rejected as a whole and the running roster stays in
+validate — an unparseable key, a pinned address outside the pool, no listener
+using `auth.mode = "client_cert"` — is rejected as a whole and the running roster stays in
 force, so a typo cannot lock everyone out.
 
 Editing an existing entry counts as revocation: the client is disconnected and
@@ -363,7 +359,8 @@ and produce a startup warning.
 
 ### Disabling authentication
 
-`auth.enabled = false` turns off both modes and logs a warning. This is only
+`listeners.auth.enabled = false` turns off authentication on that listener and
+logs a warning. This is only
 appropriate in an isolated test environment or behind another trusted
 authentication boundary.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,7 +251,13 @@ binding on some hosts and failing on others.
 Addresses are compared in canonical form, so `[::ffff:127.0.0.1]:443` and
 `127.0.0.1:443` are recognised as the same interface rather than passing the
 check and then failing to bind — or, under `SO_REUSEPORT`, binding successfully
-and leaving one listener shadowing the other's traffic.
+and leaving one listener shadowing the other's traffic. The error names which of
+the three it found: the same address twice, one address written two ways, or a
+wildcard covering another.
+
+Port `0` is exempt. It asks the kernel for whichever port is free, so several
+listeners may use it; `check-config` and the `listening` log lines report the
+ports they were given.
 
 `shards = 0` (one per core) is rejected when more than one listener is
 configured; give each listener an explicit count. The 32-shard cap applies to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,10 @@ shards = 1
 Use one shard until a benchmark shows one event loop is CPU-bound. Memory and
 the effective connection capacity increase with the shard count.
 
+`listen_addr` and `shards` describe the single listener this section implies.
+A configuration that uses [`[[listeners]]`](#multiple-listeners) names its
+sockets there instead, and these two keys are then ignored.
+
 ## TLS
 
 ```toml
@@ -82,9 +86,10 @@ as group `masque`; install both files as `root:masque` with mode `0640`.
 ## Authentication
 
 `auth.mode` selects how clients prove who they are. The two modes are mutually
-exclusive — `client_cert` makes the TLS handshake demand a certificate, so a
-credential-based client cannot even connect, and vice versa. Serving both kinds
-of client requires two server instances.
+exclusive *on one socket* — `client_cert` makes the TLS handshake demand a
+certificate, so a credential-based client cannot even connect, and vice versa.
+To serve both kinds of client, give each mode its own listener; see
+[Multiple listeners](#multiple-listeners).
 
 | Key | Meaning |
 | --- | --- |
@@ -185,6 +190,63 @@ existing path is never overwritten. Without it the JSON goes to the terminal.
 
 Nothing is written to the server configuration automatically. Append the
 `[[clients]]` block yourself, then run `systemctl reload masque` or restart.
+
+## Multiple listeners
+
+`[[listeners]]` gives each socket its own authentication mode, which is what
+lets one process serve both kinds of client. It is the whole list of listeners,
+not an addition to `[server].listen_addr`: naming any listener here stops the
+server deriving one from `[server]`, and `[server].listen_addr` and
+`[server].shards` are then ignored.
+
+```toml
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "basic"
+username = "proxy-user"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$..."
+
+[[listeners]]
+listen_addr = "0.0.0.0:4443"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "client_cert"
+```
+
+| `[[listeners]]` key | Meaning |
+| --- | --- |
+| `listen_addr` | Required; there is no default, so a typo cannot silently land on someone else's port |
+| `shards` | Event loops for this listener; defaults to `1` |
+| `[listeners.auth]` | Optional; omitted means the top-level `[auth]` |
+
+A `[listeners.auth]` table replaces `[auth]` outright rather than merging field
+by field, so the username from a Basic `[auth]` does not follow a listener that
+switched to `client_cert`.
+
+Everything else stays server-wide: one `[[clients]]` roster, one TUN device, one
+CONNECT-IP address pool, one routing table. That is the reason to run two
+listeners in one process rather than two processes — two processes would need
+two TUN devices and two address pools, and overlapping pools hand the same
+tunnel address to two clients.
+
+The server refuses to start when two listeners name the same address. This is
+not left to the kernel to report: a listener with more than one shard opens its
+socket with `SO_REUSEPORT`, so a second listener on that address would join the
+load-balancing group and be handed connections meant for the other
+authentication mode.
+
+`shards = 0` (one per core) is rejected when more than one listener is
+configured; give each listener an explicit count. The `MAX_SHARDS` cap of 32
+applies to the server's total, not to any one listener.
+
+Run `masque-server --config masque.toml check-config` to validate a
+multi-listener file before restarting.
 
 The usque JSON schema stores the endpoint IP but not its port, so enrollment
 also prints the matching launch argument — `--connect-port 443` for the example

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,13 +36,12 @@ from `/dev/tty`. A new installation offers three modes:
 - `client_cert` enrolls the first client, appends the generated `[[clients]]`
   entry, writes the usque JSON to a new `0600` file, and prints the mihomo block;
 - `dual` does both, writing a
-  [two-listener configuration](configuration.md#multiple-listeners) that serves
+  [two-listener configuration](configuration.md#listeners) that serves
   credentials on one port and certificates on another. The authentication mode
   decides what the TLS handshake demands, so the two cannot share a socket.
 
-Dual mode asks for a second port, defaulting to `4443`, and removes
-`[server].listen_addr` and `[server].shards` from the written file because
-`[[listeners]]` names the sockets instead.
+Dual mode asks for a second port, defaulting to `4443`, and writes two explicit
+`[[listeners]]` entries, each with its own `[listeners.auth]` table.
 
 Client-certificate enrollment needs the server's ECDSA certificate immediately
 because the generated client configuration pins its public key, so `client_cert`
@@ -91,7 +90,7 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
     sh
 ```
 
-`MASQUE_VERSION=0.2.0` selects `v0.2.0`. This is also how to install a
+`MASQUE_VERSION=0.3.0` selects `v0.3.0`. This is also how to install a
 prerelease explicitly; automatic resolution deliberately chooses only GitHub's
 latest stable release. Authentication, listen, TLS-source, and client
 provisioning variables apply only when `/etc/masque/masque.toml` does not yet
@@ -105,6 +104,11 @@ On success, only the binary and packaged systemd unit are upgraded; the TOML
 and every TLS path it references remain unchanged. If the requested service
 restart then fails, the installer restores the previous binary, unit, enabled
 state, and active state.
+
+Version 0.3 does not migrate the 0.2 single-listener format. Before upgrading,
+move every socket into `[[listeners]]` with an explicit `[listeners.auth]` and
+remove top-level `[auth]`, `[server].listen_addr`, and `[server].shards`. The
+candidate rejects an old file and exits before replacing anything.
 
 ## Install a downloaded archive
 
@@ -206,8 +210,8 @@ The candidate first runs the equivalent of:
 masque-server --config /etc/masque/masque.toml check-config
 ```
 
-This validates the parts of startup that do not need live resources. A legacy
-configuration that no longer satisfies fail-closed authentication, a bad
+This validates the parts of startup that do not need live resources. A 0.2
+configuration, a file that no longer satisfies fail-closed authentication, a bad
 certificate/key pair, an unsupported QUIC setting, or an invalid client/address
 pool therefore stops the upgrade before replacement. Edit and validate such a
 configuration deliberately; the installer never migrates it automatically.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,21 +29,31 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
 ```
 
 Although the script arrives on standard input, interactive answers are read
-from `/dev/tty`. A new installation offers two mutually exclusive modes:
+from `/dev/tty`. A new installation offers three modes:
 
 - `basic` generates a high-entropy password unless one is provided and prints
   the credentials once;
 - `client_cert` enrolls the first client, appends the generated `[[clients]]`
-  entry, writes the usque JSON to a new `0600` file, and prints the mihomo block.
+  entry, writes the usque JSON to a new `0600` file, and prints the mihomo block;
+- `dual` does both, writing a
+  [two-listener configuration](configuration.md#multiple-listeners) that serves
+  credentials on one port and certificates on another. The authentication mode
+  decides what the TLS handshake demands, so the two cannot share a socket.
+
+Dual mode asks for a second port, defaulting to `4443`, and removes
+`[server].listen_addr` and `[server].shards` from the written file because
+`[[listeners]]` names the sockets instead.
 
 Client-certificate enrollment needs the server's ECDSA certificate immediately
-because the generated client configuration pins its public key. Supply the PEM
-full chain and unencrypted private key when prompted. Basic mode may defer TLS
-installation, but the service cannot start until both files exist.
+because the generated client configuration pins its public key, so `client_cert`
+and `dual` both require it. Supply the PEM full chain and unencrypted private
+key when prompted. Basic mode may defer TLS installation, but the service cannot
+start until both files exist.
 
 The final output includes the installed version, authentication mode, service
-state, and complete effective TOML with the password hash redacted. It also
-includes a generated Basic password or, in `client_cert` mode, client private
+state, the resolved listeners with the authentication each demands, and the
+complete effective TOML with the password hash redacted. It also includes a
+generated Basic password or, in `client_cert` and `dual` modes, client private
 key material. Treat the terminal output as a secret and do not capture it in a
 public provisioning log.
 
@@ -52,10 +62,11 @@ The following environment variables make provisioning non-interactive:
 | Variable | Meaning |
 | --- | --- |
 | `MASQUE_VERSION` | Exact published version/tag instead of the latest stable release |
-| `MASQUE_AUTH_MODE` | `basic` or `client_cert` |
+| `MASQUE_AUTH_MODE` | `basic`, `client_cert`, or `dual` |
 | `MASQUE_AUTH_USERNAME` | Basic username; defaults to `masque` |
 | `MASQUE_AUTH_PASSWORD` | Basic password; random when omitted |
 | `MASQUE_LISTEN_PORT` | Public UDP listen port; defaults to `443` |
+| `MASQUE_CERT_LISTEN_PORT` | `dual` only; certificate listener port, defaults to `4443` |
 | `MASQUE_TLS_CERT` / `MASQUE_TLS_KEY` | Source PEM certificate and key copied into `/etc/masque/certs` |
 | `MASQUE_CLIENT_NAME` | First certificate-authenticated client label |
 | `MASQUE_CLIENT_ENDPOINT` | Required public server endpoint in `IP:port` form |
@@ -115,7 +126,7 @@ If no password is supplied, the installer creates a random one and displays it
 once. Store it immediately in a password manager.
 
 For an interactive new installation, `sudo ./install.sh` asks whether to use
-Basic or client-certificate authentication. The package installer enables but
+Basic, client-certificate, or dual authentication. The package installer enables but
 does not start the service unless `MASQUE_START_SERVICE=1`; the bootstrap above
 sets it to `1` by default.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -63,7 +63,7 @@ Important settings:
 
 | Setting | Effect |
 | --- | --- |
-| `server.shards` | Aggregate multi-connection CPU parallelism |
+| `listeners[].shards` | Aggregate multi-connection CPU parallelism for that listener |
 | `quic.enable_udp_gso` | QUIC send syscall and per-packet overhead |
 | `quic.enable_udp_gro` | QUIC receive syscall overhead |
 | `quic.max_datagram_size` | Packet size and PMTU ceiling |

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -143,7 +143,10 @@ apply to these clients.
 **Authentication is a TLS client certificate.** No `Proxy-Authorization` is
 ever sent, so `auth.mode = "basic"` refuses these clients with `407`. Use
 `auth.mode = "client_cert"` and enroll each client's public key; see
-[Authentication](configuration.md#authentication).
+[Authentication](configuration.md#authentication). To keep serving
+standards-compliant clients at the same time, give each mode its own
+[listener](configuration.md#multiple-listeners) — the mode fixes the TLS
+context, so the two cannot share a socket, but they can share a process.
 
 **Extended CONNECT is not required of the server.** Cloudflare does not
 advertise `SETTINGS_ENABLE_CONNECT_PROTOCOL`, and these clients tolerate its

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -16,7 +16,7 @@ Extended CONNECT are advertised during connection setup.
 
 ## Authentication
 
-With `auth.mode = "basic"` (the default), every CONNECT form passes through the
+With a listener's `auth.mode = "basic"`, every CONNECT form passes through the
 same proxy authentication pipeline. The client supplies:
 
 ```text
@@ -34,7 +34,7 @@ proxy-authenticate: Basic realm="masque", charset="UTF-8"
 Authentication is per request, so one authenticated tunnel does not authorize
 later streams that omit the header.
 
-With `auth.mode = "client_cert"` there is no per-request step: the client is
+With a listener's `auth.mode = "client_cert"` there is no per-request step: the client is
 identified once, from its TLS client certificate, during the QUIC handshake. An
 unregistered key never reaches the request path — it is refused with a TLS
 `access_denied` alert. See
@@ -141,11 +141,11 @@ variables. The CONNECT-IP path ignores both, so `ip_proxy.uri_template` does not
 apply to these clients.
 
 **Authentication is a TLS client certificate.** No `Proxy-Authorization` is
-ever sent, so `auth.mode = "basic"` refuses these clients with `407`. Use
-`auth.mode = "client_cert"` and enroll each client's public key; see
+ever sent, so a listener using `auth.mode = "basic"` refuses these clients with
+`407`. Use `auth.mode = "client_cert"` on that listener and enroll each client's public key; see
 [Authentication](configuration.md#authentication). To keep serving
 standards-compliant clients at the same time, give each mode its own
-[listener](configuration.md#multiple-listeners) — the mode fixes the TLS
+[listener](configuration.md#listeners) — the mode fixes the TLS
 context, so the two cannot share a socket, but they can share a process.
 
 **Extended CONNECT is not required of the server.** Cloudflare does not

--- a/docs/security.md
+++ b/docs/security.md
@@ -32,7 +32,7 @@ Use a unique, high-entropy password. Basic credentials are protected by QUIC
 TLS in transit but are reusable bearer secrets at the HTTP layer. Rotate them
 after suspected client or log compromise.
 
-With `auth.mode = "client_cert"` the cost profile is different: identity is
+With a listener's `auth.mode = "client_cert"` the cost profile is different: identity is
 established once during the handshake, by public key, so there is no per-request
 verification to bound and no password to brute-force. An unenrolled key is
 refused with a TLS alert before it can open a stream, which keeps unauthorized
@@ -80,12 +80,12 @@ packet loss into seconds of latency and make memory exhaustion easier.
 The right server certificate depends on the authentication mode, because the
 two modes establish server identity in completely different ways.
 
-### With `auth.mode = "basic"`
+### With listener `auth.mode = "basic"`
 
 Clients validate the certificate normally. Use one trusted by them and covering
 the exact proxy hostname, and renew it before expiry as usual.
 
-### With `auth.mode = "client_cert"`
+### With listener `auth.mode = "client_cert"`
 
 Clients in this family skip chain validation entirely — the SNI they send names
 a vendor endpoint rather than this server — and instead pin the leaf public key

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,8 @@
 | Microbenchmark | `cargo bench --bench core` | Codec, routing, and allocation regressions |
 | Network benchmark | `scripts/network-bench.sh` | Local direct-vs-MASQUE throughput and RTT |
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
-| Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth and CONNECT-IP setup |
+| Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth, CONNECT-IP setup, and both authentication modes served from one process |
+| Config preflight | `cargo test --test check_config` | `check-config` accepts what a server accepts, including multi-listener files |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
 
 ## Local tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -101,22 +101,23 @@ addresses — so use the generated blocks rather than transcribing.
 git clone https://github.com/Diniboy1123/usque && cd usque && go build .
 ```
 
-**2. Configure the server.** `auth.mode = "client_cert"`, and a certificate with
-an ECDSA key so the client can pin it:
+**2. Configure the server.** Use `auth.mode = "client_cert"` on its listener,
+and a certificate with an ECDSA key so the client can pin it:
 
 ```sh
 scripts/gen-certs.sh certs
 ```
 
 ```toml
-[server]
-listen_addr = "0.0.0.0:4433"
-
 [tls]
 cert_path = "certs/server.crt"
 key_path = "certs/server.key"
 
-[auth]
+[[listeners]]
+listen_addr = "0.0.0.0:4433"
+shards = 1
+
+[listeners.auth]
 enabled = true
 mode = "client_cert"
 

--- a/scripts/network-bench.sh
+++ b/scripts/network-bench.sh
@@ -29,14 +29,16 @@ bash scripts/gen-certs.sh "$BENCH_DIR/certs"
 
 cat >"$BENCH_DIR/masque.toml" <<EOF
 [server]
-listen_addr = "127.0.0.1:4433"
 idle_timeout_secs = 30
 
 [tls]
 cert_path = "$BENCH_DIR/certs/server.crt"
 key_path = "$BENCH_DIR/certs/server.key"
 
-[auth]
+[[listeners]]
+listen_addr = "127.0.0.1:4433"
+
+[listeners.auth]
 enabled = true
 username = "test"
 password_hash = "\$argon2id\$v=19\$m=19456,t=2,p=1\$1xNVXhqKU7jJ6cqTBJKphQ\$GXXAINVTW1qhloFtN1IR8lSr7pI7QEY79fq4K6d8scQ"

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,18 @@ pub struct ServerConfig {
     /// Only consulted when `auth.mode = "client_cert"`. Written as repeated
     /// `[[clients]]` tables.
     pub clients: Vec<ClientEntry>,
+    /// Every socket this server listens on, written as repeated `[[listeners]]`
+    /// tables.
+    ///
+    /// This is the whole list, not an addition to `[server].listen_addr`: a
+    /// configuration that names any listener here stops deriving one from
+    /// `[server]`. Leaving it empty keeps the single-listener form, which is
+    /// what every configuration written before this existed uses.
+    ///
+    /// Separate listeners are what allow one process to serve two
+    /// authentication modes at once — `auth.mode` fixes the TLS context, so a
+    /// Basic listener and a client-certificate listener cannot share a socket.
+    pub listeners: Vec<ListenerSection>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -97,6 +109,68 @@ impl AuthSection {
     /// Whether a client certificate is required to complete the handshake.
     pub fn client_cert_enabled(&self) -> bool {
         self.enabled && self.mode == AuthMode::ClientCert
+    }
+}
+
+/// One listening socket.
+///
+/// `listen_addr` has no default on purpose: an omitted address would otherwise
+/// silently become `0.0.0.0:443` and collide with whichever listener meant to
+/// take that port.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ListenerSection {
+    pub listen_addr: SocketAddr,
+    /// Independent event loops for this listener. See [`ServerSection::shards`].
+    #[serde(default = "default_listener_shards")]
+    pub shards: usize,
+    /// Authentication for this listener. Omitted means the top-level `[auth]`.
+    ///
+    /// An override replaces `[auth]` outright rather than merging field by
+    /// field: half-inherited credentials would be an authentication decision
+    /// assembled from two places, which is not something to leave implicit.
+    #[serde(default)]
+    pub auth: Option<AuthSection>,
+}
+
+fn default_listener_shards() -> usize {
+    1
+}
+
+/// A listener whose authentication has been resolved against the top-level
+/// `[auth]` default.
+///
+/// Distinct from [`ListenerSection`] so the inheritance happens exactly once,
+/// where it can be tested, rather than at each place that reads a listener.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedListener {
+    pub listen_addr: SocketAddr,
+    pub shards: usize,
+    pub auth: AuthSection,
+}
+
+impl ServerConfig {
+    /// Every listener this configuration asks for, in the order it named them.
+    ///
+    /// An empty `[[listeners]]` desugars to the single listener described by
+    /// `[server]` and `[auth]`, so the two configuration forms produce the same
+    /// shape and the rest of the server only ever handles a list.
+    pub fn resolved_listeners(&self) -> Vec<ResolvedListener> {
+        if self.listeners.is_empty() {
+            return vec![ResolvedListener {
+                listen_addr: self.server.listen_addr,
+                shards: self.server.shards,
+                auth: self.auth.clone(),
+            }];
+        }
+
+        self.listeners
+            .iter()
+            .map(|listener| ResolvedListener {
+                listen_addr: listener.listen_addr,
+                shards: listener.shards,
+                auth: listener.auth.clone().unwrap_or_else(|| self.auth.clone()),
+            })
+            .collect()
     }
 }
 
@@ -352,6 +426,7 @@ mod tests {
         assert!(cfg.auth.username.is_empty());
         assert!(cfg.auth.password_hash.is_empty());
         assert!(cfg.clients.is_empty());
+        assert!(cfg.listeners.is_empty());
         assert!(cfg.quic.enable_dgram);
         assert!(!cfg.quic.enable_udp_gso);
         assert!(cfg.quic.enable_udp_gro);
@@ -467,6 +542,137 @@ public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb3RoZXI="
         // A typo here would otherwise silently fall back to Basic and lock out
         // every client certificate.
         assert!(parse_toml("[auth]\nmode = \"mtls\"\n").is_err());
+    }
+
+    #[test]
+    fn a_configuration_without_listeners_desugars_to_one() {
+        let cfg = parse_toml(
+            r#"
+[server]
+listen_addr = "127.0.0.1:8443"
+shards = 3
+
+[auth]
+mode = "client_cert"
+"#,
+        )
+        .unwrap();
+
+        let listeners = cfg.resolved_listeners();
+        assert_eq!(listeners.len(), 1);
+        assert_eq!(listeners[0].listen_addr, "127.0.0.1:8443".parse().unwrap());
+        assert_eq!(listeners[0].shards, 3);
+        assert_eq!(listeners[0].auth, cfg.auth);
+    }
+
+    #[test]
+    fn listeners_replace_the_single_listener_form() {
+        let cfg = parse_toml(
+            r#"
+[server]
+listen_addr = "0.0.0.0:443"
+
+[auth]
+enabled = true
+mode = "basic"
+username = "alice"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
+
+[[listeners]]
+listen_addr = "0.0.0.0:8443"
+
+[[listeners]]
+listen_addr = "0.0.0.0:4443"
+shards = 2
+
+[listeners.auth]
+mode = "client_cert"
+"#,
+        )
+        .unwrap();
+
+        let listeners = cfg.resolved_listeners();
+        assert_eq!(listeners.len(), 2, "[server].listen_addr must not add one");
+
+        // No override: the top-level [auth] is inherited whole.
+        assert_eq!(listeners[0].listen_addr, "0.0.0.0:8443".parse().unwrap());
+        assert_eq!(listeners[0].shards, 1, "shards default to one per listener");
+        assert!(listeners[0].auth.basic_enabled());
+        assert_eq!(listeners[0].auth.username, "alice");
+
+        // An override replaces [auth] rather than merging into it, so the
+        // inherited username does not follow the mode across.
+        assert_eq!(listeners[1].listen_addr, "0.0.0.0:4443".parse().unwrap());
+        assert_eq!(listeners[1].shards, 2);
+        assert!(listeners[1].auth.client_cert_enabled());
+        assert!(listeners[1].auth.username.is_empty());
+    }
+
+    /// The whole point of the list: one process, two authentication modes.
+    #[test]
+    fn listeners_can_disagree_about_the_authentication_mode() {
+        let cfg = parse_toml(
+            r#"
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+
+[listeners.auth]
+mode = "basic"
+username = "alice"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
+
+[[listeners]]
+listen_addr = "0.0.0.0:4443"
+
+[listeners.auth]
+mode = "client_cert"
+"#,
+        )
+        .unwrap();
+
+        let listeners = cfg.resolved_listeners();
+        assert!(listeners[0].auth.basic_enabled());
+        assert!(!listeners[0].auth.client_cert_enabled());
+        assert!(listeners[1].auth.client_cert_enabled());
+        assert!(!listeners[1].auth.basic_enabled());
+    }
+
+    #[test]
+    fn a_listener_without_an_address_is_rejected() {
+        // Defaulting this would silently put the listener on 0.0.0.0:443,
+        // where it would fight whichever listener meant to take that port.
+        assert!(parse_toml("[[listeners]]\nshards = 2\n").is_err());
+    }
+
+    #[test]
+    fn parse_unknown_listener_auth_mode_is_rejected() {
+        let toml = r#"
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+
+[listeners.auth]
+mode = "mtls"
+"#;
+        assert!(parse_toml(toml).is_err());
+    }
+
+    #[test]
+    fn listener_password_hashes_are_redacted_in_debug_output() {
+        let cfg = parse_toml(
+            r#"
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+
+[listeners.auth]
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
+"#,
+        )
+        .unwrap();
+
+        // `info!(?cfg, ...)` logs the whole configuration at startup.
+        let debug = format!("{cfg:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("$argon2id$"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,53 +5,48 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 /// Top-level server configuration.
-#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct ServerConfig {
+    #[serde(default)]
     pub server: ServerSection,
+    #[serde(default)]
     pub tls: TlsSection,
-    pub auth: AuthSection,
+    #[serde(default)]
     pub quic: QuicSection,
+    #[serde(default)]
     pub tcp_proxy: TcpProxySection,
+    #[serde(default)]
     pub udp_proxy: UdpProxySection,
+    #[serde(default)]
     pub ip_proxy: IpProxySection,
     /// Pre-registered clients, identified by their TLS client certificate key.
     ///
-    /// Only consulted when `auth.mode = "client_cert"`. Written as repeated
-    /// `[[clients]]` tables.
+    /// Only consulted when a listener uses `auth.mode = "client_cert"`.
+    /// Written as repeated `[[clients]]` tables.
+    #[serde(default)]
     pub clients: Vec<ClientEntry>,
     /// Every socket this server listens on, written as repeated `[[listeners]]`
     /// tables.
     ///
-    /// This is the whole list, not an addition to `[server].listen_addr`: a
-    /// configuration that names any listener here stops deriving one from
-    /// `[server]`. Leaving it empty keeps the single-listener form, which is
-    /// what every configuration written before this existed uses.
-    ///
     /// Separate listeners are what allow one process to serve two
-    /// authentication modes at once — `auth.mode` fixes the TLS context, so a
-    /// Basic listener and a client-certificate listener cannot share a socket.
+    /// authentication modes at once — a listener's `auth.mode` fixes its TLS
+    /// context, so Basic and client-certificate modes cannot share a socket.
+    /// The field intentionally has no serde default: every configuration file
+    /// must name at least one listener explicitly.
     pub listeners: Vec<ListenerSection>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ServerSection {
-    pub listen_addr: SocketAddr,
     pub idle_timeout_secs: u64,
     pub max_connections: usize,
     pub max_tunnels_per_connection: usize,
-    /// Independent event loops to run, each with its own `SO_REUSEPORT` socket
-    /// and its own share of the connections.
-    ///
-    /// QUIC's per-packet crypto is what saturates a core, and a connection is
-    /// always handled by one loop, so this is what lets a busy server use more
-    /// than one core. `0` means one per available core. Linux only.
-    pub shards: usize,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TlsSection {
     pub cert_path: PathBuf,
     pub key_path: PathBuf,
@@ -73,7 +68,7 @@ pub enum AuthMode {
 }
 
 #[derive(Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AuthSection {
     /// Master switch. `false` disables authentication whatever `mode` says.
     pub enabled: bool,
@@ -118,60 +113,29 @@ impl AuthSection {
 /// silently become `0.0.0.0:443` and collide with whichever listener meant to
 /// take that port.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct ListenerSection {
     pub listen_addr: SocketAddr,
-    /// Independent event loops for this listener. See [`ServerSection::shards`].
+    /// Independent event loops for this listener. Each shard owns a
+    /// `SO_REUSEPORT` socket and a disjoint share of the connections. `0` means
+    /// one per available core and is accepted only for a single listener.
     #[serde(default = "default_listener_shards")]
     pub shards: usize,
-    /// Authentication for this listener. Omitted means the top-level `[auth]`.
-    ///
-    /// An override replaces `[auth]` outright rather than merging field by
-    /// field: half-inherited credentials would be an authentication decision
-    /// assembled from two places, which is not something to leave implicit.
-    #[serde(default)]
-    pub auth: Option<AuthSection>,
+    /// Authentication for this listener. Required so a socket's trust boundary
+    /// is never inherited from a distant part of the file.
+    pub auth: AuthSection,
 }
 
 fn default_listener_shards() -> usize {
     1
 }
 
-/// A listener whose authentication has been resolved against the top-level
-/// `[auth]` default.
-///
-/// Distinct from [`ListenerSection`] so the inheritance happens exactly once,
-/// where it can be tested, rather than at each place that reads a listener.
+/// A validated listener with `shards = 0` resolved to an explicit count.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedListener {
     pub listen_addr: SocketAddr,
     pub shards: usize,
     pub auth: AuthSection,
-}
-
-impl ServerConfig {
-    /// Every listener this configuration asks for, in the order it named them.
-    ///
-    /// An empty `[[listeners]]` desugars to the single listener described by
-    /// `[server]` and `[auth]`, so the two configuration forms produce the same
-    /// shape and the rest of the server only ever handles a list.
-    pub fn resolved_listeners(&self) -> Vec<ResolvedListener> {
-        if self.listeners.is_empty() {
-            return vec![ResolvedListener {
-                listen_addr: self.server.listen_addr,
-                shards: self.server.shards,
-                auth: self.auth.clone(),
-            }];
-        }
-
-        self.listeners
-            .iter()
-            .map(|listener| ResolvedListener {
-                listen_addr: listener.listen_addr,
-                shards: listener.shards,
-                auth: listener.auth.clone().unwrap_or_else(|| self.auth.clone()),
-            })
-            .collect()
-    }
 }
 
 /// One pre-registered client.
@@ -180,7 +144,7 @@ impl ServerConfig {
 /// operator generates a key pair, records its public key here, and hands the
 /// private key to the client out of band.
 #[derive(Debug, Clone, Default, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ClientEntry {
     /// Label used in logs. Optional, but makes the logs readable.
     pub name: String,
@@ -200,7 +164,7 @@ pub struct ClientEntry {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct QuicSection {
     pub max_datagram_size: usize,
     pub initial_max_streams_bidi: u64,
@@ -243,7 +207,7 @@ pub struct QuicSection {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct UdpProxySection {
     pub enabled: bool,
     pub uri_template: String,
@@ -252,7 +216,7 @@ pub struct UdpProxySection {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TcpProxySection {
     pub enabled: bool,
     pub connect_timeout_secs: u64,
@@ -261,7 +225,7 @@ pub struct TcpProxySection {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct IpProxySection {
     pub enabled: bool,
     pub uri_template: String,
@@ -285,20 +249,34 @@ pub struct IpProxySection {
 
 // ── Defaults ──────────────────────────────────────────────────────────
 
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            server: ServerSection::default(),
+            tls: TlsSection::default(),
+            quic: QuicSection::default(),
+            tcp_proxy: TcpProxySection::default(),
+            udp_proxy: UdpProxySection::default(),
+            ip_proxy: IpProxySection::default(),
+            clients: Vec::new(),
+            listeners: vec![ListenerSection {
+                listen_addr: "0.0.0.0:443".parse().unwrap(),
+                shards: default_listener_shards(),
+                auth: AuthSection::default(),
+            }],
+        }
+    }
+}
+
 impl Default for ServerSection {
     fn default() -> Self {
         Self {
-            listen_addr: "0.0.0.0:443".parse().unwrap(),
             // Comfortably above the 30s keepalive period MASQUE VPN clients
             // commonly default to, so a tunnel that is merely quiet does not
             // race its own keepalive to the timeout.
             idle_timeout_secs: 60,
             max_connections: 10_000,
             max_tunnels_per_connection: 100,
-            // Opt-in: sharding changes how connections are distributed, so an
-            // operator should turn it on deliberately after checking their
-            // own traffic rather than inheriting it from an upgrade.
-            shards: 1,
         }
     }
 }
@@ -414,19 +392,30 @@ pub fn parse_toml(toml_str: &str) -> Result<ServerConfig, toml::de::Error> {
 mod tests {
     use super::*;
 
+    const DISABLED_LISTENER: &str = r#"
+[[listeners]]
+listen_addr = "127.0.0.1:8443"
+
+[listeners.auth]
+enabled = false
+"#;
+
+    fn parse_with_listener(toml: &str) -> ServerConfig {
+        parse_toml(&format!("{toml}\n{DISABLED_LISTENER}")).unwrap()
+    }
+
     #[test]
     fn defaults_are_sensible() {
         let cfg = ServerConfig::default();
-        assert_eq!(cfg.server.listen_addr.port(), 443);
         assert_eq!(cfg.server.idle_timeout_secs, 60);
-        assert!(cfg.auth.enabled);
-        assert_eq!(cfg.auth.mode, AuthMode::Basic);
-        assert!(cfg.auth.basic_enabled());
-        assert!(!cfg.auth.client_cert_enabled());
-        assert!(cfg.auth.username.is_empty());
-        assert!(cfg.auth.password_hash.is_empty());
         assert!(cfg.clients.is_empty());
-        assert!(cfg.listeners.is_empty());
+        assert_eq!(cfg.listeners.len(), 1);
+        assert_eq!(cfg.listeners[0].listen_addr.port(), 443);
+        assert_eq!(cfg.listeners[0].shards, 1);
+        assert!(cfg.listeners[0].auth.basic_enabled());
+        assert!(!cfg.listeners[0].auth.client_cert_enabled());
+        assert!(cfg.listeners[0].auth.username.is_empty());
+        assert!(cfg.listeners[0].auth.password_hash.is_empty());
         assert!(cfg.quic.enable_dgram);
         assert!(!cfg.quic.enable_udp_gso);
         assert!(cfg.quic.enable_udp_gro);
@@ -448,49 +437,53 @@ mod tests {
     }
 
     #[test]
-    fn parse_empty_toml_gives_defaults() {
-        let cfg = parse_toml("").unwrap();
-        assert_eq!(cfg, ServerConfig::default());
+    fn configuration_file_requires_listeners() {
+        let error = parse_toml("").unwrap_err().to_string();
+        assert!(error.contains("listeners"), "unexpected error: {error}");
     }
 
     #[test]
     fn parse_partial_server_section() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [server]
-listen_addr = "127.0.0.1:8443"
-idle_timeout_secs = 60
-"#;
-        let cfg = parse_toml(toml).unwrap();
-        assert_eq!(cfg.server.listen_addr, "127.0.0.1:8443".parse().unwrap());
-        assert_eq!(cfg.server.idle_timeout_secs, 60);
+idle_timeout_secs = 75
+"#,
+        );
+        assert_eq!(cfg.server.idle_timeout_secs, 75);
         // Other fields keep defaults
         assert_eq!(cfg.server.max_connections, 10_000);
     }
 
     #[test]
     fn parse_tls_section() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [tls]
 cert_path = "/etc/masque/cert.pem"
 key_path = "/etc/masque/key.pem"
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert_eq!(cfg.tls.cert_path, PathBuf::from("/etc/masque/cert.pem"));
         assert_eq!(cfg.tls.key_path, PathBuf::from("/etc/masque/key.pem"));
     }
 
     #[test]
-    fn parse_auth_section_and_redact_hash_in_debug_output() {
+    fn parse_listener_auth_and_redact_hash_in_debug_output() {
         let toml = r#"
-[auth]
+[[listeners]]
+listen_addr = "127.0.0.1:8443"
+
+[listeners.auth]
 enabled = true
 username = "alice"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
 "#;
         let cfg = parse_toml(toml).unwrap();
-        assert!(cfg.auth.enabled);
-        assert_eq!(cfg.auth.username, "alice");
-        assert!(cfg.auth.password_hash.starts_with("$argon2id$"));
+        let auth = &cfg.listeners[0].auth;
+        assert!(auth.enabled);
+        assert_eq!(auth.username, "alice");
+        assert!(auth.password_hash.starts_with("$argon2id$"));
 
         let debug = format!("{cfg:?}");
         assert!(debug.contains("[REDACTED]"));
@@ -500,7 +493,10 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
     #[test]
     fn parse_client_cert_auth_mode_with_roster() {
         let toml = r#"
-[auth]
+[[listeners]]
+listen_addr = "127.0.0.1:8443"
+
+[listeners.auth]
 enabled = true
 mode = "client_cert"
 
@@ -515,11 +511,12 @@ name = "phone"
 public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb3RoZXI="
 "#;
         let cfg = parse_toml(toml).unwrap();
-        assert_eq!(cfg.auth.mode, AuthMode::ClientCert);
-        assert!(cfg.auth.client_cert_enabled());
+        let auth = &cfg.listeners[0].auth;
+        assert_eq!(auth.mode, AuthMode::ClientCert);
+        assert!(auth.client_cert_enabled());
         // The Basic pipeline must stand down, or a client certificate would not
         // be enough on its own.
-        assert!(!cfg.auth.basic_enabled());
+        assert!(!auth.basic_enabled());
 
         assert_eq!(cfg.clients.len(), 2);
         assert_eq!(cfg.clients[0].name, "laptop");
@@ -532,54 +529,40 @@ public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb3RoZXI="
 
     #[test]
     fn disabling_auth_overrides_the_mode() {
-        let cfg = parse_toml("[auth]\nenabled = false\nmode = \"client_cert\"\n").unwrap();
-        assert!(!cfg.auth.client_cert_enabled());
-        assert!(!cfg.auth.basic_enabled());
+        let cfg = parse_toml(
+            "[[listeners]]\nlisten_addr = \"127.0.0.1:8443\"\n\
+             [listeners.auth]\nenabled = false\nmode = \"client_cert\"\n",
+        )
+        .unwrap();
+        assert!(!cfg.listeners[0].auth.client_cert_enabled());
+        assert!(!cfg.listeners[0].auth.basic_enabled());
     }
 
     #[test]
     fn parse_unknown_auth_mode_is_rejected() {
         // A typo here would otherwise silently fall back to Basic and lock out
         // every client certificate.
-        assert!(parse_toml("[auth]\nmode = \"mtls\"\n").is_err());
+        assert!(
+            parse_toml(
+                "[[listeners]]\nlisten_addr = \"127.0.0.1:8443\"\n\
+                 [listeners.auth]\nmode = \"mtls\"\n"
+            )
+            .is_err()
+        );
     }
 
     #[test]
-    fn a_configuration_without_listeners_desugars_to_one() {
+    fn listeners_are_explicit_and_can_use_different_authentication_modes() {
         let cfg = parse_toml(
             r#"
-[server]
-listen_addr = "127.0.0.1:8443"
-shards = 3
+[[listeners]]
+listen_addr = "0.0.0.0:8443"
 
-[auth]
-mode = "client_cert"
-"#,
-        )
-        .unwrap();
-
-        let listeners = cfg.resolved_listeners();
-        assert_eq!(listeners.len(), 1);
-        assert_eq!(listeners[0].listen_addr, "127.0.0.1:8443".parse().unwrap());
-        assert_eq!(listeners[0].shards, 3);
-        assert_eq!(listeners[0].auth, cfg.auth);
-    }
-
-    #[test]
-    fn listeners_replace_the_single_listener_form() {
-        let cfg = parse_toml(
-            r#"
-[server]
-listen_addr = "0.0.0.0:443"
-
-[auth]
+[listeners.auth]
 enabled = true
 mode = "basic"
 username = "alice"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
-
-[[listeners]]
-listen_addr = "0.0.0.0:8443"
 
 [[listeners]]
 listen_addr = "0.0.0.0:4443"
@@ -591,111 +574,56 @@ mode = "client_cert"
         )
         .unwrap();
 
-        let listeners = cfg.resolved_listeners();
-        assert_eq!(listeners.len(), 2, "[server].listen_addr must not add one");
-
-        // No override: the top-level [auth] is inherited whole.
-        assert_eq!(listeners[0].listen_addr, "0.0.0.0:8443".parse().unwrap());
-        assert_eq!(listeners[0].shards, 1, "shards default to one per listener");
-        assert!(listeners[0].auth.basic_enabled());
-        assert_eq!(listeners[0].auth.username, "alice");
-
-        // An override replaces [auth] rather than merging into it, so the
-        // inherited username does not follow the mode across.
-        assert_eq!(listeners[1].listen_addr, "0.0.0.0:4443".parse().unwrap());
-        assert_eq!(listeners[1].shards, 2);
-        assert!(listeners[1].auth.client_cert_enabled());
-        assert!(listeners[1].auth.username.is_empty());
-    }
-
-    /// The whole point of the list: one process, two authentication modes.
-    #[test]
-    fn listeners_can_disagree_about_the_authentication_mode() {
-        let cfg = parse_toml(
-            r#"
-[[listeners]]
-listen_addr = "0.0.0.0:443"
-
-[listeners.auth]
-mode = "basic"
-username = "alice"
-password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
-
-[[listeners]]
-listen_addr = "0.0.0.0:4443"
-
-[listeners.auth]
-mode = "client_cert"
-"#,
-        )
-        .unwrap();
-
-        let listeners = cfg.resolved_listeners();
-        assert!(listeners[0].auth.basic_enabled());
-        assert!(!listeners[0].auth.client_cert_enabled());
-        assert!(listeners[1].auth.client_cert_enabled());
-        assert!(!listeners[1].auth.basic_enabled());
+        assert_eq!(cfg.listeners.len(), 2);
+        assert_eq!(cfg.listeners[0].shards, 1, "shards default to one");
+        assert!(cfg.listeners[0].auth.basic_enabled());
+        assert_eq!(cfg.listeners[0].auth.username, "alice");
+        assert_eq!(cfg.listeners[1].shards, 2);
+        assert!(cfg.listeners[1].auth.client_cert_enabled());
+        assert!(!cfg.listeners[1].auth.basic_enabled());
     }
 
     #[test]
-    fn a_listener_without_an_address_is_rejected() {
-        // Defaulting this would silently put the listener on 0.0.0.0:443,
-        // where it would fight whichever listener meant to take that port.
-        assert!(parse_toml("[[listeners]]\nshards = 2\n").is_err());
+    fn a_listener_requires_an_address_and_authentication() {
+        assert!(
+            parse_toml("[[listeners]]\nshards = 2\n[listeners.auth]\nenabled = false\n").is_err()
+        );
+        assert!(parse_toml("[[listeners]]\nlisten_addr = \"127.0.0.1:443\"\n").is_err());
     }
 
     #[test]
-    fn parse_unknown_listener_auth_mode_is_rejected() {
-        let toml = r#"
-[[listeners]]
-listen_addr = "0.0.0.0:443"
+    fn legacy_single_listener_fields_are_rejected() {
+        let top_level_auth = format!("[auth]\nenabled = false\n{DISABLED_LISTENER}");
+        assert!(parse_toml(&top_level_auth).is_err());
 
-[listeners.auth]
-mode = "mtls"
-"#;
-        assert!(parse_toml(toml).is_err());
-    }
-
-    #[test]
-    fn listener_password_hashes_are_redacted_in_debug_output() {
-        let cfg = parse_toml(
-            r#"
-[[listeners]]
-listen_addr = "0.0.0.0:443"
-
-[listeners.auth]
-password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA"
-"#,
-        )
-        .unwrap();
-
-        // `info!(?cfg, ...)` logs the whole configuration at startup.
-        let debug = format!("{cfg:?}");
-        assert!(debug.contains("[REDACTED]"));
-        assert!(!debug.contains("$argon2id$"));
+        let server_listener =
+            format!("[server]\nlisten_addr = \"127.0.0.1:443\"\nshards = 1\n{DISABLED_LISTENER}");
+        assert!(parse_toml(&server_listener).is_err());
     }
 
     #[test]
     fn parse_custom_connect_protocols() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [ip_proxy]
 connect_protocols = ["connect-ip"]
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert_eq!(cfg.ip_proxy.connect_protocols, vec!["connect-ip"]);
     }
 
     #[test]
     fn parse_quic_section() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [quic]
 max_datagram_size = 1200
 initial_max_streams_bidi = 64
 enable_dgram = false
 enable_udp_gso = true
 enable_udp_gro = false
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert_eq!(cfg.quic.max_datagram_size, 1200);
         assert_eq!(cfg.quic.initial_max_streams_bidi, 64);
         assert!(!cfg.quic.enable_dgram);
@@ -708,7 +636,8 @@ enable_udp_gro = false
 
     #[test]
     fn parse_quic_tuning_knobs() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [quic]
 cc_algorithm = "cubic"
 initial_congestion_window_packets = 10
@@ -719,8 +648,8 @@ max_stream_window = 1000000
 dgram_recv_queue_len = 512
 dgram_send_queue_len = 256
 discover_pmtu = true
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert_eq!(cfg.quic.cc_algorithm, "cubic");
         assert_eq!(cfg.quic.initial_congestion_window_packets, 10);
         assert_eq!(cfg.quic.initial_max_data, 1_000_000);
@@ -736,13 +665,14 @@ discover_pmtu = true
 
     #[test]
     fn parse_udp_proxy_section() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [udp_proxy]
 enabled = false
 allow_targets = ["192.168.0.0/16"]
 deny_targets = []
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert!(!cfg.udp_proxy.enabled);
         assert_eq!(cfg.udp_proxy.allow_targets, vec!["192.168.0.0/16"]);
         assert!(cfg.udp_proxy.deny_targets.is_empty());
@@ -750,14 +680,15 @@ deny_targets = []
 
     #[test]
     fn parse_tcp_proxy_section() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [tcp_proxy]
 enabled = false
 connect_timeout_secs = 3
 allow_targets = ["192.168.0.0/16"]
 deny_targets = []
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert!(!cfg.tcp_proxy.enabled);
         assert_eq!(cfg.tcp_proxy.connect_timeout_secs, 3);
         assert_eq!(cfg.tcp_proxy.allow_targets, vec!["192.168.0.0/16"]);
@@ -766,15 +697,16 @@ deny_targets = []
 
     #[test]
     fn parse_ip_proxy_section() {
-        let toml = r#"
+        let cfg = parse_with_listener(
+            r#"
 [ip_proxy]
 enabled = false
 tun_name = "tun7"
 tun_mtu = 1400
 ipv4_pool = "172.16.0.0/12"
 ipv6_pool = "fd01::/64"
-"#;
-        let cfg = parse_toml(toml).unwrap();
+"#,
+        );
         assert!(!cfg.ip_proxy.enabled);
         assert_eq!(cfg.ip_proxy.tun_name, "tun7");
         assert_eq!(cfg.ip_proxy.tun_mtu, 1400);
@@ -785,7 +717,6 @@ ipv6_pool = "fd01::/64"
     fn parse_full_config() {
         let toml = r#"
 [server]
-listen_addr = "0.0.0.0:443"
 idle_timeout_secs = 60
 max_connections = 10000
 max_tunnels_per_connection = 100
@@ -837,6 +768,16 @@ tun_name = "masque0"
 tun_mtu = 1280
 ipv4_pool = "10.89.0.0/16"
 ipv6_pool = "fd00:abcd::/64"
+
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "basic"
+username = ""
+password_hash = ""
 "#;
         let cfg = parse_toml(toml).unwrap();
         assert_eq!(cfg, ServerConfig::default());
@@ -845,29 +786,36 @@ ipv6_pool = "fd00:abcd::/64"
     #[test]
     fn parse_invalid_listen_addr() {
         let toml = r#"
-[server]
+[[listeners]]
 listen_addr = "not-an-address"
+
+[listeners.auth]
+enabled = false
 "#;
         assert!(parse_toml(toml).is_err());
     }
 
     #[test]
     fn parse_invalid_type() {
-        let toml = r#"
+        let toml = format!(
+            r#"
 [server]
 idle_timeout_secs = "not a number"
-"#;
-        assert!(parse_toml(toml).is_err());
+{DISABLED_LISTENER}
+"#
+        );
+        assert!(parse_toml(&toml).is_err());
     }
 
     #[test]
-    fn parse_unknown_field_is_ignored() {
-        // serde ignores unknown fields by default — good for forward compat.
-        let toml = r#"
+    fn parse_unknown_field_is_rejected() {
+        let toml = format!(
+            r#"
 [server]
 unknown_field = 42
-"#;
-        let cfg = parse_toml(toml).unwrap();
-        assert_eq!(cfg.server.listen_addr.port(), 443); // defaults preserved
+{DISABLED_LISTENER}
+"#
+        );
+        assert!(parse_toml(&toml).is_err());
     }
 }

--- a/src/enroll.rs
+++ b/src/enroll.rs
@@ -293,6 +293,14 @@ mod tests {
         boring::pkey::PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
     }
 
+    fn parse_with_listener(fragment: &str) -> config::ServerConfig {
+        config::parse_toml(&format!(
+            "{fragment}\n[[listeners]]\nlisten_addr = \"127.0.0.1:443\"\n\
+             [listeners.auth]\nenabled = false\n"
+        ))
+        .unwrap()
+    }
+
     #[test]
     fn generated_public_key_is_accepted_by_the_roster_parser() {
         let pair = generate_client_key().unwrap();
@@ -340,7 +348,7 @@ mod tests {
             Some("fd00:abcd::2".parse().unwrap()),
         );
 
-        let parsed = config::parse_toml(&block).unwrap();
+        let parsed = parse_with_listener(&block);
         assert_eq!(parsed.clients.len(), 1);
         assert_eq!(parsed.clients[0].name, "my laptop");
         assert_eq!(parsed.clients[0].public_key, pair.public_key_b64);
@@ -356,7 +364,7 @@ mod tests {
         assert!(!block.contains("ipv4"));
         assert!(!block.contains("ipv6"));
 
-        let parsed = config::parse_toml(&block).unwrap();
+        let parsed = parse_with_listener(&block);
         assert_eq!(parsed.clients[0].ipv4, None);
         assert_eq!(parsed.clients[0].ipv6, None);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,6 @@ struct Cli {
     #[arg(short, long, default_value = "masque.toml")]
     config: PathBuf,
 
-    /// Override listen address.
-    #[arg(short, long)]
-    listen: Option<String>,
-
     /// TLS certificate path.
     #[arg(long)]
     cert: Option<PathBuf>,
@@ -46,7 +42,7 @@ enum Command {
     HashPassword,
     /// Validate the configuration without binding sockets or creating a TUN.
     CheckConfig,
-    /// Generate a client key pair for `auth.mode = "client_cert"`.
+    /// Generate a client key pair for a listener using client-certificate auth.
     ///
     /// Prints the `[[clients]]` block to add to the server config, and the JSON
     /// configuration for the client. Nothing is written to the server config
@@ -221,23 +217,6 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // CLI overrides
-    if let Some(listen) = cli.listen {
-        // `[[listeners]]` is the whole list of sockets, so `[server].listen_addr`
-        // is not one of them and overriding it would change nothing. Silently
-        // accepting the flag would be the worst outcome: it is reached for to
-        // narrow a server's exposure, and appearing to work while the
-        // configured listeners stay bound is exactly the failure it was meant
-        // to prevent.
-        if !cfg.listeners.is_empty() {
-            anyhow::bail!(
-                "--listen cannot choose among the {} listeners configured in {}; \
-                 edit the [[listeners]] entry instead",
-                cfg.listeners.len(),
-                cli.config.display()
-            );
-        }
-        cfg.server.listen_addr = listen.parse()?;
-    }
     if let Some(cert) = cli.cert {
         cfg.tls.cert_path = cert;
     }
@@ -274,9 +253,8 @@ async fn main() -> anyhow::Result<()> {
             cli.config.display()
         );
         // Which sockets come up, and what each demands of a client. Worth
-        // printing for one listener and necessary for several: `[auth]` is only
-        // the default a listener may inherit, so reading it alone would
-        // describe one mode for a server that runs two.
+        // printing for one listener and necessary for several: authentication
+        // belongs to each listener, so there is no single server-wide mode.
         //
         // Reported from the validated plan rather than the parsed file, so the
         // shard count is the resolved one — `shards = 0` means one per core and

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,22 @@ enum Command {
     },
 }
 
+/// How a listener's authentication reads in `check-config` output.
+///
+/// Deliberately the effective answer rather than the configured `mode`:
+/// `enabled = false` turns any mode off, and reporting the mode it would have
+/// used would describe a listener that demands nothing as if it demanded
+/// something.
+fn auth_label(auth: &config::AuthSection) -> &'static str {
+    if auth.client_cert_enabled() {
+        "client_cert"
+    } else if auth.basic_enabled() {
+        "basic"
+    } else {
+        "disabled"
+    }
+}
+
 fn usque_port_instruction(port: u16) -> String {
     format!("# Start usque with --connect-port {port} (short form: -P {port}).")
 }
@@ -206,6 +222,20 @@ async fn main() -> anyhow::Result<()> {
 
     // CLI overrides
     if let Some(listen) = cli.listen {
+        // `[[listeners]]` is the whole list of sockets, so `[server].listen_addr`
+        // is not one of them and overriding it would change nothing. Silently
+        // accepting the flag would be the worst outcome: it is reached for to
+        // narrow a server's exposure, and appearing to work while the
+        // configured listeners stay bound is exactly the failure it was meant
+        // to prevent.
+        if !cfg.listeners.is_empty() {
+            anyhow::bail!(
+                "--listen cannot choose among the {} listeners configured in {}; \
+                 edit the [[listeners]] entry instead",
+                cfg.listeners.len(),
+                cli.config.display()
+            );
+        }
         cfg.server.listen_addr = listen.parse()?;
     }
     if let Some(cert) = cli.cert {
@@ -243,6 +273,18 @@ async fn main() -> anyhow::Result<()> {
             env!("CARGO_PKG_VERSION"),
             cli.config.display()
         );
+        // Which sockets come up, and what each demands of a client. Worth
+        // printing for one listener and necessary for several: `[auth]` is only
+        // the default a listener may inherit, so reading it alone would
+        // describe one mode for a server that runs two.
+        for listener in cfg.resolved_listeners() {
+            println!(
+                "listener {} auth={} shards={}",
+                listener.listen_addr,
+                auth_label(&listener.auth),
+                listener.shards
+            );
+        }
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if matches!(cli.command, Some(Command::CheckConfig)) {
-        validate_config(&cfg)?;
+        let listeners = validate_config(&cfg)?;
         println!(
             "configuration is compatible with masque-server {}: {}",
             env!("CARGO_PKG_VERSION"),
@@ -277,7 +277,11 @@ async fn main() -> anyhow::Result<()> {
         // printing for one listener and necessary for several: `[auth]` is only
         // the default a listener may inherit, so reading it alone would
         // describe one mode for a server that runs two.
-        for listener in cfg.resolved_listeners() {
+        //
+        // Reported from the validated plan rather than the parsed file, so the
+        // shard count is the resolved one — `shards = 0` means one per core and
+        // a large value is capped, neither of which the file shows.
+        for listener in listeners {
             println!(
                 "listener {} auth={} shards={}",
                 listener.listen_addr,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -65,7 +65,9 @@ const MAX_QUIC_RECV_BATCH: usize = MAX_BATCH_PACKETS;
 const MAX_TUN_RECV_BATCH: usize = tun::TUN_BATCH_SIZE;
 
 /// Upper bound on shards, so a machine with a very high core count does not
-/// fan out into more event loops than the listen socket can usefully feed.
+/// fan out into more event loops than the listen sockets can usefully feed.
+///
+/// Applied to the server's total, not to one listener's share of it.
 const MAX_SHARDS: usize = 32;
 
 /// Queue depth for packets handed between shards.
@@ -119,12 +121,19 @@ struct UdpResponse {
 
 /// Top-level MASQUE server.
 ///
-/// Runs one event loop per shard. Each shard binds the listen address with
-/// `SO_REUSEPORT` and owns a disjoint set of connections, so QUIC's per-packet
-/// crypto — which is what saturates a core — spreads across them. The kernel
-/// hashes each 4-tuple to a shard, and the rare packet that lands on the wrong
-/// one (a client that changed address) is handed to its owner rather than
-/// dropped.
+/// Runs one event loop per shard. A listener's shards each bind its address
+/// with `SO_REUSEPORT` and own a disjoint set of connections, so QUIC's
+/// per-packet crypto — which is what saturates a core — spreads across them.
+/// The kernel hashes each 4-tuple to a shard, and the rare packet that lands on
+/// the wrong one (a client that changed address) is handed to its owner rather
+/// than dropped.
+///
+/// A server may have several listeners, which is what lets one process serve
+/// more than one authentication mode: `auth.mode` decides which TLS context a
+/// shard builds, and that is fixed once its socket is bound. Shards are
+/// numbered across the whole server, so everything shared between them — the
+/// address pool, the routing table, the TUN device, the cross-shard queues —
+/// stays single and needs no knowledge of which listener a shard serves.
 pub struct Server {
     shards: Vec<Shard>,
 }
@@ -137,16 +146,119 @@ pub struct Server {
 /// address-pool mistakes.
 struct ValidatedServerConfig {
     clients: ClientRegistry,
-    shard_count: usize,
+    listeners: Vec<ListenerPlan>,
+    total_shards: usize,
     address_pool: AddressPool,
+}
+
+/// One listener's fully materialised configuration and shard count.
+struct ListenerPlan {
+    /// The whole configuration with this listener's address, shard count, and
+    /// authentication substituted in.
+    ///
+    /// A shard reads exactly one of these and never has to know it is one
+    /// listener among several, which is what keeps the multi-listener change
+    /// out of the request and packet paths entirely.
+    config: ServerConfig,
+    shards: usize,
+}
+
+/// Whether any listener authenticates with a client certificate.
+///
+/// The roster, and the reload that replaces it, belong to the server rather
+/// than to a listener, so both are governed by this rather than by one
+/// listener's mode.
+fn any_client_cert_listener(config: &ServerConfig) -> bool {
+    config
+        .resolved_listeners()
+        .iter()
+        .any(|listener| listener.auth.client_cert_enabled())
+}
+
+/// Expand the configured listeners into one plan each, rejecting the
+/// combinations that cannot be served.
+fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
+    let listeners = config.resolved_listeners();
+    let mut plans: Vec<ListenerPlan> = Vec::with_capacity(listeners.len());
+    let mut total_shards = 0usize;
+
+    for listener in &listeners {
+        // Two listeners on one address is not merely a bind failure to let the
+        // kernel report. A listener with more than one shard opens its socket
+        // with SO_REUSEPORT, so a second listener on the same address would
+        // join that load-balancing group and the kernel would hand it
+        // connections meant for a different authentication mode.
+        if plans
+            .iter()
+            .any(|plan| plan.config.server.listen_addr == listener.listen_addr)
+        {
+            anyhow::bail!(
+                "two listeners are configured for {}; each listener needs its own address",
+                listener.listen_addr
+            );
+        }
+
+        // "One per core" has no single answer once the cores are shared between
+        // listeners, and quietly giving every listener a full set would
+        // oversubscribe the machine by the number of listeners.
+        if listener.shards == 0 && listeners.len() > 1 {
+            anyhow::bail!(
+                "listener {} uses shards = 0 (one per core), which has no meaning \
+                 alongside other listeners; give each listener an explicit count",
+                listener.listen_addr
+            );
+        }
+
+        let shards = resolve_shard_count(listener.shards);
+        // Sharing one address needs SO_REUSEPORT, which only Linux provides in
+        // the load-balancing form this depends on.
+        if shards > 1 && !cfg!(target_os = "linux") {
+            anyhow::bail!(
+                "listener {} asks for {shards} shards, which needs SO_REUSEPORT; \
+                 that is Linux only, so set shards = 1",
+                listener.listen_addr
+            );
+        }
+
+        total_shards += shards;
+
+        let mut listener_config = config.clone();
+        listener_config.server.listen_addr = listener.listen_addr;
+        listener_config.server.shards = shards;
+        listener_config.auth = listener.auth.clone();
+        // A shard's configuration describes only its own listener, so the list
+        // cannot be misread as something it should act on.
+        listener_config.listeners.clear();
+
+        plans.push(ListenerPlan {
+            config: listener_config,
+            shards,
+        });
+    }
+
+    // Every shard costs two cross-shard queues in each direction and a slice of
+    // the shared verification budget, so the cap is on the total rather than on
+    // any one listener's share of it.
+    if total_shards > MAX_SHARDS {
+        anyhow::bail!(
+            "{} listeners ask for {total_shards} shards in total, more than the \
+             {MAX_SHARDS} this server runs",
+            plans.len()
+        );
+    }
+
+    Ok(plans)
 }
 
 /// Build only the roster selected by the active authentication mode.
 ///
 /// Keeping this decision separate from binding makes the "ignored outside
 /// client_cert" contract testable without opening sockets or loading TLS keys.
-fn active_client_registry(config: &ServerConfig) -> anyhow::Result<ClientRegistry> {
-    if !config.auth.client_cert_enabled() {
+fn active_client_registry(
+    config: &ServerConfig,
+    any_client_cert: bool,
+) -> anyhow::Result<ClientRegistry> {
+    if !any_client_cert {
         return Ok(ClientRegistry::default());
     }
 
@@ -172,11 +284,24 @@ pub fn validate_config(config: &ServerConfig) -> anyhow::Result<()> {
 }
 
 fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServerConfig> {
+    let listeners = plan_listeners(config)?;
+    let any_client_cert = any_client_cert_listener(config);
+
+    if !config.listeners.is_empty() {
+        // [[listeners]] is the whole list, so these are dead settings. Only
+        // worth a warning: which sockets actually came up is spelled out by the
+        // "listening" line each listener logs, and by `check-config`.
+        warn!(
+            "[[listeners]] replaces [server].listen_addr and [server].shards, \
+             which are ignored"
+        );
+    }
+
     // Surface a bad credential or active roster configuration first. A roster
     // outside client-cert mode is deliberately not parsed or allowed to
     // reserve pool addresses: the configuration contract says it is ignored.
-    let clients = active_client_registry(config)?;
-    if config.auth.client_cert_enabled() {
+    let clients = active_client_registry(config, any_client_cert)?;
+    if any_client_cert {
         info!(
             clients = clients.len(),
             "client certificate authentication enabled"
@@ -188,10 +313,16 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
         );
     }
 
-    if config.auth.basic_enabled() {
-        BasicAuthenticator::new(&config.auth.username, &config.auth.password_hash)?;
-    } else if !config.auth.client_cert_enabled() {
-        warn!("proxy authentication is disabled");
+    // Credentials are per listener, so a mistake in the second one has to name
+    // the listener it came from or it cannot be found in a multi-listener file.
+    for plan in &listeners {
+        let addr = plan.config.server.listen_addr;
+        if plan.config.auth.basic_enabled() {
+            BasicAuthenticator::new(&plan.config.auth.username, &plan.config.auth.password_hash)
+                .with_context(|| format!("listener {addr}"))?;
+        } else if !plan.config.auth.client_cert_enabled() {
+            warn!(%addr, "proxy authentication is disabled on this listener");
+        }
     }
 
     // Flow-control autotuning only ever grows a window toward its ceiling, so
@@ -231,16 +362,6 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
         );
     }
 
-    let shard_count = resolve_shard_count(config.server.shards);
-    // Sharing one address needs SO_REUSEPORT, which only Linux provides in the
-    // load-balancing form this depends on.
-    if shard_count > 1 && !cfg!(target_os = "linux") {
-        anyhow::bail!(
-            "server.shards = {shard_count} needs SO_REUSEPORT, which is only \
-             supported on Linux; set server.shards = 1"
-        );
-    }
-
     let mut address_pool = AddressPool::new(&config.ip_proxy.ipv4_pool, &config.ip_proxy.ipv6_pool)
         .map_err(|e| anyhow::anyhow!("address pool: {e}"))?;
 
@@ -261,16 +382,26 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
     // Build and discard the protocol configurations. This loads and matches
     // the certificate/key pair and exercises the same quiche setters a shard
     // will use, but has no network or device side effects.
-    let client_certs = config
-        .auth
-        .client_cert_enabled()
-        .then(|| Arc::new(SharedRoster::new(clients.clone())));
-    build_quic_config(config, client_certs)?;
+    //
+    // Once per listener rather than once per server: the authentication mode
+    // decides which of two TLS contexts is built, so validating one listener's
+    // would say nothing about another's.
+    for plan in &listeners {
+        let client_certs = plan
+            .config
+            .auth
+            .client_cert_enabled()
+            .then(|| Arc::new(SharedRoster::new(clients.clone())));
+        build_quic_config(&plan.config, client_certs)
+            .with_context(|| format!("listener {}", plan.config.server.listen_addr))?;
+    }
     build_h3_config()?;
 
+    let total_shards = listeners.iter().map(|plan| plan.shards).sum();
     Ok(ValidatedServerConfig {
         clients,
-        shard_count,
+        listeners,
+        total_shards,
         address_pool,
     })
 }
@@ -282,7 +413,7 @@ fn roster_reload_settings(
 ) -> Option<RosterReload> {
     config_path.map(|path| RosterReload {
         path,
-        client_cert_enabled: config.auth.client_cert_enabled(),
+        client_cert_enabled: any_client_cert_listener(config),
         ip_proxy_enabled: config.ip_proxy.enabled,
     })
 }
@@ -304,10 +435,10 @@ impl Server {
     ) -> anyhow::Result<Self> {
         let ValidatedServerConfig {
             clients,
-            shard_count,
+            listeners,
+            total_shards,
             address_pool,
         } = validate_server_config(&config)?;
-        let reuseport = shard_count > 1;
 
         let tun = build_tun(&config)?;
 
@@ -316,12 +447,15 @@ impl Server {
             .map_err(|_| anyhow::anyhow!("failed to seed connection ID key"))?;
 
         // Every shard needs a handle to every other shard's inboxes, so the
-        // channels are made before the shards that read them.
-        let mut forward_tx = Vec::with_capacity(shard_count);
-        let mut forward_rx = Vec::with_capacity(shard_count);
-        let mut tun_tx = Vec::with_capacity(shard_count);
-        let mut tun_rx = Vec::with_capacity(shard_count);
-        for _ in 0..shard_count {
+        // channels are made before the shards that read them. Shards are
+        // numbered across the whole server rather than within a listener, so a
+        // packet or a TUN packet reaches its owner without anyone having to
+        // know which listener that owner belongs to.
+        let mut forward_tx = Vec::with_capacity(total_shards);
+        let mut forward_rx = Vec::with_capacity(total_shards);
+        let mut tun_tx = Vec::with_capacity(total_shards);
+        let mut tun_rx = Vec::with_capacity(total_shards);
+        for _ in 0..total_shards {
             let (tx, rx) = mpsc::channel(SHARD_FORWARD_QUEUE_CAPACITY);
             forward_tx.push(tx);
             forward_rx.push(rx);
@@ -332,7 +466,9 @@ impl Server {
 
         // A live switch from Basic to client-certificate authentication is not
         // possible: the TLS context is fixed when each shard binds. Capture the
-        // startup mode so SIGHUP can be consumed safely but cannot fake a switch.
+        // startup mode so SIGHUP can be consumed safely but cannot fake a
+        // switch — including the switch from no client-certificate listener to
+        // one, which no reload can conjure a TLS context for.
         let roster_reload = roster_reload_settings(&config, config_path);
 
         let shared = Arc::new(Shared {
@@ -345,28 +481,38 @@ impl Server {
             tun,
             forward_tx,
             tun_tx,
-            auth_permits: Arc::new(Semaphore::new(auth_concurrency(shard_count))),
+            auth_permits: Arc::new(Semaphore::new(auth_concurrency(total_shards))),
             auth_queue_slots: Arc::new(Semaphore::new(MAX_PENDING_AUTH_GLOBAL)),
             clients: Arc::new(SharedRoster::new(clients)),
             roster_reload,
         });
 
-        let mut shards = Vec::with_capacity(shard_count);
-        for (index, (forward_rx, tun_rx)) in forward_rx.into_iter().zip(tun_rx).enumerate() {
-            shards.push(
-                Shard::bind(
-                    index,
-                    Arc::clone(&shared),
-                    config.clone(),
-                    reuseport,
-                    forward_rx,
-                    tun_rx,
-                )
-                .await?,
-            );
+        let mut shards = Vec::with_capacity(total_shards);
+        let mut inboxes = forward_rx.into_iter().zip(tun_rx);
+        for plan in listeners {
+            // SO_REUSEPORT is what lets one listener's shards share an address.
+            // A single-shard listener must not set it, or a later listener that
+            // was misconfigured onto the same address could join its group.
+            let reuseport = plan.shards > 1;
+            for _ in 0..plan.shards {
+                let (forward_rx, tun_rx) = inboxes
+                    .next()
+                    .expect("one inbox pair was created per planned shard");
+                shards.push(
+                    Shard::bind(
+                        shards.len(),
+                        Arc::clone(&shared),
+                        plan.config.clone(),
+                        reuseport,
+                        forward_rx,
+                        tun_rx,
+                    )
+                    .await?,
+                );
+            }
         }
 
-        info!(shards = shard_count, "server ready");
+        info!(shards = total_shards, "server ready");
         Ok(Self { shards })
     }
 
@@ -489,14 +635,15 @@ fn reload_roster(shared: &Shared) -> anyhow::Result<(u64, usize)> {
     let config = crate::config::parse_toml(&text)
         .with_context(|| format!("failed to parse {}", reload.path.display()))?;
 
-    if !config.auth.client_cert_enabled() {
+    let any_client_cert = any_client_cert_listener(&config);
+    if !any_client_cert {
         anyhow::bail!(
-            "refusing to reload: auth.mode is no longer \"client_cert\", which cannot be \
-             changed without a restart"
+            "refusing to reload: no listener uses auth.mode = \"client_cert\" any more, \
+             which cannot be changed without a restart"
         );
     }
 
-    let registry = active_client_registry(&config)?;
+    let registry = active_client_registry(&config, any_client_cert)?;
 
     // Reservations are recomputed before the swap: if a pinned address became
     // invalid, the roster is rejected rather than half-applied.
@@ -1059,6 +1206,9 @@ impl Shard {
         let mut tun_send = TunSendBatch::new();
         let mut recv_batch = RecvPacketBatch::new(MAX_QUIC_RECV_BATCH);
         let mut send_batch = SendPacketBatch::new();
+        // One shard reads the shared TUN device and hands each packet to the
+        // connection that owns its address. Shard 0 is an arbitrary but stable
+        // choice; nothing here depends on which listener that shard serves.
         let tun_device = if self.index == 0 {
             self.shared.tun.as_ref().map(TunManager::device)
         } else {
@@ -2899,7 +3049,7 @@ impl Shard {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{AuthMode, ClientEntry, ServerConfig};
+    use crate::config::{AuthMode, AuthSection, ClientEntry, ListenerSection, ServerConfig};
 
     fn invalid_roster_entry() -> ClientEntry {
         ClientEntry {
@@ -2910,26 +3060,77 @@ mod tests {
         }
     }
 
+    /// A default configuration that listens on the given listeners.
+    fn config_with(listeners: Vec<ListenerSection>) -> ServerConfig {
+        ServerConfig {
+            listeners,
+            ..Default::default()
+        }
+    }
+
+    /// A listener with the given address and authentication mode.
+    fn listener(addr: &str, mode: AuthMode) -> ListenerSection {
+        ListenerSection {
+            listen_addr: addr.parse().unwrap(),
+            shards: 1,
+            auth: Some(AuthSection {
+                enabled: true,
+                mode,
+                // Enough to satisfy `BasicAuthenticator`; the hash is only
+                // parsed when a request actually arrives.
+                username: "alice".into(),
+                password_hash: "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA".into(),
+            }),
+        }
+    }
+
     #[test]
     fn roster_is_not_parsed_outside_client_certificate_mode() {
         let mut config = ServerConfig::default();
         config.auth.mode = AuthMode::Basic;
         config.clients.push(invalid_roster_entry());
-        assert!(super::active_client_registry(&config).unwrap().is_empty());
+        assert!(
+            super::active_client_registry(&config, false)
+                .unwrap()
+                .is_empty()
+        );
 
         config.auth.enabled = false;
         config.auth.mode = AuthMode::ClientCert;
-        assert!(super::active_client_registry(&config).unwrap().is_empty());
+        assert!(!super::any_client_cert_listener(&config));
+        assert!(
+            super::active_client_registry(&config, false)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
     fn active_client_certificate_roster_is_fail_closed() {
         let mut config = ServerConfig::default();
         config.auth.mode = AuthMode::ClientCert;
-        assert!(super::active_client_registry(&config).is_err());
+        assert!(super::active_client_registry(&config, true).is_err());
 
         config.clients.push(invalid_roster_entry());
-        assert!(super::active_client_registry(&config).is_err());
+        assert!(super::active_client_registry(&config, true).is_err());
+    }
+
+    /// The roster belongs to the server, so one certificate listener among
+    /// several is enough to make it load — and to keep reload available.
+    #[test]
+    fn one_certificate_listener_is_enough_to_activate_the_roster() {
+        let mut config = config_with(vec![
+            listener("0.0.0.0:443", AuthMode::Basic),
+            listener("0.0.0.0:4443", AuthMode::ClientCert),
+        ]);
+        assert!(super::any_client_cert_listener(&config));
+
+        // Fail closed for the whole server: the certificate listener has no
+        // roster to admit anyone from.
+        assert!(super::active_client_registry(&config, true).is_err());
+
+        config.listeners = vec![listener("0.0.0.0:443", AuthMode::Basic)];
+        assert!(!super::any_client_cert_listener(&config));
     }
 
     #[test]
@@ -2950,8 +3151,98 @@ mod tests {
         assert!(reload.client_cert_enabled);
         assert!(!reload.ip_proxy_enabled);
 
+        // A certificate listener reached only through [[listeners]] must enable
+        // reload too, or revoking a client would cost a restart.
+        let config = config_with(vec![
+            listener("0.0.0.0:443", AuthMode::Basic),
+            listener("0.0.0.0:4443", AuthMode::ClientCert),
+        ]);
+        let reload = super::roster_reload_settings(&config, Some(path.clone())).unwrap();
+        assert!(reload.client_cert_enabled);
+
         // Programmatic servers have no source file to re-read.
         assert!(super::roster_reload_settings(&config, None).is_none());
+    }
+
+    // ── Listener planning ────────────────────────────────────────────
+
+    #[test]
+    fn a_configuration_without_listeners_plans_exactly_one() {
+        let mut config = ServerConfig::default();
+        config.server.listen_addr = "127.0.0.1:8443".parse().unwrap();
+        config.server.shards = 1;
+
+        let plans = super::plan_listeners(&config).unwrap();
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].shards, 1);
+        assert_eq!(
+            plans[0].config.server.listen_addr,
+            "127.0.0.1:8443".parse::<std::net::SocketAddr>().unwrap()
+        );
+    }
+
+    /// Each shard reads one listener's configuration, so the substitution has
+    /// to be complete: a shard that could still see the list might act on it.
+    #[test]
+    fn a_plan_describes_only_its_own_listener() {
+        let config = config_with(vec![
+            listener("127.0.0.1:8443", AuthMode::Basic),
+            listener("127.0.0.1:8444", AuthMode::ClientCert),
+        ]);
+
+        let plans = super::plan_listeners(&config).unwrap();
+        assert_eq!(plans.len(), 2);
+        for plan in &plans {
+            assert!(plan.config.listeners.is_empty());
+            assert_eq!(plan.config.server.shards, plan.shards);
+        }
+        assert!(plans[0].config.auth.basic_enabled());
+        assert!(plans[1].config.auth.client_cert_enabled());
+        assert_eq!(
+            plans[1].config.server.listen_addr,
+            "127.0.0.1:8444".parse::<std::net::SocketAddr>().unwrap()
+        );
+    }
+
+    /// Not just a bind failure: a multi-shard listener uses SO_REUSEPORT, so a
+    /// second listener on its address would join that load-balancing group and
+    /// be handed connections meant for a different authentication mode.
+    #[test]
+    fn two_listeners_cannot_share_an_address() {
+        let config = config_with(vec![
+            listener("0.0.0.0:443", AuthMode::Basic),
+            listener("0.0.0.0:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&config).is_err());
+    }
+
+    #[test]
+    fn automatic_sharding_is_rejected_for_multiple_listeners() {
+        let mut config = ServerConfig::default();
+        let mut listeners = vec![
+            listener("0.0.0.0:443", AuthMode::Basic),
+            listener("0.0.0.0:4443", AuthMode::ClientCert),
+        ];
+        listeners[0].shards = 0;
+        config.listeners = listeners;
+        assert!(super::plan_listeners(&config).is_err());
+
+        // A lone listener still gets to ask for one per core.
+        config.listeners.truncate(1);
+        assert!(super::plan_listeners(&config).is_ok());
+    }
+
+    #[test]
+    fn the_shard_cap_applies_to_the_server_total() {
+        let mut config = ServerConfig::default();
+        let mut first = listener("0.0.0.0:443", AuthMode::Basic);
+        let mut second = listener("0.0.0.0:4443", AuthMode::Basic);
+        first.shards = super::MAX_SHARDS;
+        second.shards = 1;
+        config.listeners = vec![first, second];
+
+        // Each listener is under the cap on its own; together they are not.
+        assert!(super::plan_listeners(&config).is_err());
     }
 
     /// The default algorithm name is only validated when a server starts, and

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -97,11 +97,20 @@ const MAX_PENDING_AUTH_PER_CONNECTION: usize = 16;
 /// shard keeps every shard able to make progress, but never more than one per
 /// core: hashing moved off the event loop still competes with it for CPU, and
 /// oversubscribing just trades a stall for scheduler thrash.
-fn auth_concurrency(shards: usize) -> usize {
+///
+/// `shards` counts only the shards that verify passwords. A client-certificate
+/// listener never reaches this path — its shards hold no `BasicAuthenticator` —
+/// so counting them would let a large certificate deployment raise the budget
+/// that exists to ration what unauthenticated callers can demand of a small
+/// Basic one.
+fn auth_concurrency(basic_shards: usize) -> usize {
     let cores = std::thread::available_parallelism()
         .map(|count| count.get())
         .unwrap_or(1);
-    (shards * 2).min(cores.max(2))
+    // Never zero: with no Basic listener nothing acquires a permit, but a
+    // semaphore that cannot be acquired would turn any future caller into a
+    // hang rather than a rejection.
+    (basic_shards * 2).clamp(1, cores.max(2))
 }
 
 /// How often idle tunnels are swept. Tunnels close after `idle_timeout_secs`,
@@ -175,6 +184,41 @@ fn any_client_cert_listener(config: &ServerConfig) -> bool {
         .any(|listener| listener.auth.client_cert_enabled())
 }
 
+/// Shards that verify passwords, which is what the verification budget rations.
+///
+/// A client-certificate listener's shards hold no `BasicAuthenticator` and
+/// never reach that path, so counting them would let a large certificate
+/// deployment widen what unauthenticated callers can demand of a small Basic
+/// one.
+fn basic_shard_count(listeners: &[ListenerPlan]) -> usize {
+    listeners
+        .iter()
+        .filter(|plan| plan.config.auth.basic_enabled())
+        .map(|plan| plan.shards)
+        .sum()
+}
+
+/// Whether binding `wildcard` also claims `other`.
+///
+/// `::` is treated as covering IPv4 too. Whether it really does is the kernel's
+/// `IPV6_V6ONLY` default — `0` on Linux unless `net.ipv6.bindv6only` says
+/// otherwise, and the two wildcards were observed to collide on macOS. Nothing
+/// here sets that option, so assuming the wider meaning is what keeps the
+/// answer from depending on the host: the pair is refused everywhere instead of
+/// failing to bind on some hosts and quietly splitting traffic on others.
+fn address_covers(wildcard: IpAddr, other: IpAddr) -> bool {
+    match wildcard {
+        IpAddr::V4(v4) => v4.is_unspecified() && other.is_ipv4(),
+        IpAddr::V6(v6) => v6.is_unspecified(),
+    }
+}
+
+/// Whether two listeners would contend for the same packets.
+fn listen_addresses_overlap(a: SocketAddr, b: SocketAddr) -> bool {
+    a.port() == b.port()
+        && (a.ip() == b.ip() || address_covers(a.ip(), b.ip()) || address_covers(b.ip(), a.ip()))
+}
+
 /// Expand the configured listeners into one plan each, rejecting the
 /// combinations that cannot be served.
 fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
@@ -183,17 +227,29 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
     let mut total_shards = 0usize;
 
     for listener in &listeners {
-        // Two listeners on one address is not merely a bind failure to let the
-        // kernel report. A listener with more than one shard opens its socket
-        // with SO_REUSEPORT, so a second listener on the same address would
-        // join that load-balancing group and the kernel would hand it
+        // Two listeners over one address is not merely a bind failure to let
+        // the kernel report. A listener with more than one shard opens its
+        // socket with SO_REUSEPORT, so a second listener on the same address
+        // would join that load-balancing group and the kernel would hand it
         // connections meant for a different authentication mode.
-        if plans
-            .iter()
-            .any(|plan| plan.config.server.listen_addr == listener.listen_addr)
-        {
+        //
+        // Wildcards count: `0.0.0.0` claims every IPv4 address on its port, and
+        // `::` claims everything on its port. An overlapping pair is refused
+        // rather than left to fail at bind time with an EADDRINUSE that says
+        // nothing about which two listeners disagreed.
+        if let Some(existing) = plans.iter().find(|plan| {
+            listen_addresses_overlap(plan.config.server.listen_addr, listener.listen_addr)
+        }) {
+            let existing = existing.config.server.listen_addr;
+            if existing == listener.listen_addr {
+                anyhow::bail!(
+                    "two listeners are configured for {existing}; \
+                     each listener needs its own address"
+                );
+            }
             anyhow::bail!(
-                "two listeners are configured for {}; each listener needs its own address",
+                "listeners {existing} and {} overlap; a wildcard address claims every \
+                 address of its family on that port, and :: may claim IPv4 as well",
                 listener.listen_addr
             );
         }
@@ -287,14 +343,25 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
     let listeners = plan_listeners(config)?;
     let any_client_cert = any_client_cert_listener(config);
 
+    // [[listeners]] is the whole list, so `[server]`'s own socket settings are
+    // dead. Warned about only when they were set to something other than the
+    // default, which is what "I left the old listen address behind and expect
+    // it to still serve" looks like; a file that simply never mentions them has
+    // nothing to correct. Only a warning either way: which sockets actually
+    // came up is spelled out by the "listening" line each listener logs, and by
+    // `check-config`.
     if !config.listeners.is_empty() {
-        // [[listeners]] is the whole list, so these are dead settings. Only
-        // worth a warning: which sockets actually came up is spelled out by the
-        // "listening" line each listener logs, and by `check-config`.
-        warn!(
-            "[[listeners]] replaces [server].listen_addr and [server].shards, \
-             which are ignored"
-        );
+        let defaults = crate::config::ServerSection::default();
+        if config.server.listen_addr != defaults.listen_addr
+            || config.server.shards != defaults.shards
+        {
+            warn!(
+                listen_addr = %config.server.listen_addr,
+                shards = config.server.shards,
+                "[server].listen_addr and [server].shards are ignored because \
+                 [[listeners]] names the sockets"
+            );
+        }
     }
 
     // Surface a bad credential or active roster configuration first. A roster
@@ -440,6 +507,8 @@ impl Server {
             address_pool,
         } = validate_server_config(&config)?;
 
+        let basic_shards = basic_shard_count(&listeners);
+
         let tun = build_tun(&config)?;
 
         let mut key_bytes = [0u8; 32];
@@ -481,7 +550,7 @@ impl Server {
             tun,
             forward_tx,
             tun_tx,
-            auth_permits: Arc::new(Semaphore::new(auth_concurrency(total_shards))),
+            auth_permits: Arc::new(Semaphore::new(auth_concurrency(basic_shards))),
             auth_queue_slots: Arc::new(Semaphore::new(MAX_PENDING_AUTH_GLOBAL)),
             clients: Arc::new(SharedRoster::new(clients)),
             roster_reload,
@@ -1066,6 +1135,9 @@ struct Shared {
     /// unauthenticated requests turn into hundreds of megabytes and cores of
     /// work. The old inline check bounded this at one per shard by blocking
     /// the event loop; this keeps a bound without the stall.
+    ///
+    /// Sized from the shards that verify passwords, so adding a
+    /// client-certificate listener does not widen what a Basic one will accept.
     auth_permits: Arc<Semaphore>,
     /// Bounds both queued and running password verifications across all shards.
     auth_queue_slots: Arc<Semaphore>,
@@ -3216,6 +3288,46 @@ mod tests {
         assert!(super::plan_listeners(&config).is_err());
     }
 
+    /// A wildcard claims every address of its family on its port, so an
+    /// overlapping pair must be refused rather than left to fail at bind time.
+    #[test]
+    fn wildcard_listeners_cannot_overlap_a_specific_address() {
+        let config = config_with(vec![
+            listener("0.0.0.0:443", AuthMode::Basic),
+            listener("127.0.0.1:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&config).is_err());
+    }
+
+    /// `::` may claim IPv4 too, depending on `IPV6_V6ONLY`, which nothing here
+    /// sets. Refusing the pair everywhere beats binding on some hosts and
+    /// failing on others.
+    #[test]
+    fn the_ipv6_wildcard_is_assumed_to_claim_ipv4() {
+        let config = config_with(vec![
+            listener("[::]:443", AuthMode::Basic),
+            listener("0.0.0.0:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&config).is_err());
+
+        // Nothing wider than it needs to be: distinct ports, distinct specific
+        // addresses, and a v6 loopback beside the v4 wildcard all still stand.
+        for pair in [
+            ["0.0.0.0:443", "0.0.0.0:4443"],
+            ["127.0.0.1:443", "127.0.0.2:443"],
+            ["[::1]:443", "0.0.0.0:443"],
+        ] {
+            let config = config_with(vec![
+                listener(pair[0], AuthMode::Basic),
+                listener(pair[1], AuthMode::ClientCert),
+            ]);
+            assert!(
+                super::plan_listeners(&config).is_ok(),
+                "{pair:?} do not contend for the same packets"
+            );
+        }
+    }
+
     #[test]
     fn automatic_sharding_is_rejected_for_multiple_listeners() {
         let mut config = ServerConfig::default();
@@ -3301,6 +3413,40 @@ mod tests {
             );
             assert!(permits <= shards * 2);
         }
+
+        // No Basic listener means nothing acquires a permit, but a semaphore
+        // that can never be acquired would hang a future caller.
+        assert_eq!(super::auth_concurrency(0), 1);
+    }
+
+    /// The verification budget rations what unauthenticated callers can demand
+    /// of the Basic listeners. A certificate listener never reaches that path,
+    /// so its shards must not widen the budget.
+    #[test]
+    fn certificate_shards_do_not_enlarge_the_verification_budget() {
+        // One shard each: multi-shard listeners need SO_REUSEPORT, so a larger
+        // certificate listener cannot be planned off Linux. One is enough — the
+        // point is that certificate shards are not counted at all.
+        let config = config_with(vec![
+            listener("0.0.0.0:443", AuthMode::Basic),
+            listener("0.0.0.0:4443", AuthMode::ClientCert),
+        ]);
+        let plans = super::plan_listeners(&config).unwrap();
+
+        let total_shards: usize = plans.iter().map(|plan| plan.shards).sum();
+        assert_eq!(total_shards, 2);
+        assert_eq!(super::basic_shard_count(&plans), 1);
+
+        // The Basic listener gets the budget one Basic shard gets, whatever the
+        // certificate listener contributes to the server's size.
+        assert_eq!(super::auth_concurrency(super::basic_shard_count(&plans)), 2);
+
+        // And a server with no Basic listener rations nothing away, but still
+        // hands out a permit rather than a semaphore that cannot be acquired.
+        let certs_only = config_with(vec![listener("0.0.0.0:4443", AuthMode::ClientCert)]);
+        let plans = super::plan_listeners(&certs_only).unwrap();
+        assert_eq!(super::basic_shard_count(&plans), 0);
+        assert_eq!(super::auth_concurrency(0), 1);
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -24,7 +24,7 @@ use crate::auth::BasicAuthenticator;
 use crate::capsule;
 use crate::capsule::{AssignedAddress, CapsuleFrame, IpAddress, IpAddressRange};
 use crate::client_identity::{ClientIdentity, ClientRegistry, IdentityError, SharedRoster};
-use crate::config::ServerConfig;
+use crate::config::{ResolvedListener, ServerConfig};
 use crate::connection::{AwaitingAuth, ClientConnection};
 use crate::datagram::{self, DatagramHeader};
 use crate::fxhash::FxHashMap;
@@ -213,10 +213,28 @@ fn address_covers(wildcard: IpAddr, other: IpAddr) -> bool {
     }
 }
 
+/// Reduce an address to the one form two listeners can be compared in.
+///
+/// `::ffff:127.0.0.1` and `127.0.0.1` name the same interface, so comparing
+/// them as written lets a pair through that the kernel then refuses with
+/// `EADDRINUSE` — or worse, accepts under `SO_REUSEPORT`, leaving one listener
+/// shadowing traffic meant for the other's authentication mode.
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(ip, IpAddr::V4),
+        IpAddr::V4(_) => ip,
+    }
+}
+
 /// Whether two listeners would contend for the same packets.
 fn listen_addresses_overlap(a: SocketAddr, b: SocketAddr) -> bool {
-    a.port() == b.port()
-        && (a.ip() == b.ip() || address_covers(a.ip(), b.ip()) || address_covers(b.ip(), a.ip()))
+    if a.port() != b.port() {
+        return false;
+    }
+    // Canonical form first, so an IPv4-mapped spelling cannot present itself as
+    // a different address from the IPv4 one it resolves to.
+    let (a, b) = (canonical_ip(a.ip()), canonical_ip(b.ip()));
+    a == b || address_covers(a, b) || address_covers(b, a)
 }
 
 /// Expand the configured listeners into one plan each, rejecting the
@@ -335,8 +353,20 @@ fn active_client_registry(
 /// existing configuration with a candidate binary before replacing the
 /// running version. Runtime-only failures such as an occupied UDP port or a
 /// missing kernel TUN device are still reported when the server starts.
-pub fn validate_config(config: &ServerConfig) -> anyhow::Result<()> {
-    validate_server_config(config).map(|_| ())
+/// Returns the listeners the server would actually run, with their shard counts
+/// resolved — `shards = 0` expanded to one per core and the cap applied — so a
+/// caller reports what will run rather than what was asked for.
+pub fn validate_config(config: &ServerConfig) -> anyhow::Result<Vec<ResolvedListener>> {
+    let validated = validate_server_config(config)?;
+    Ok(validated
+        .listeners
+        .iter()
+        .map(|plan| ResolvedListener {
+            listen_addr: plan.config.server.listen_addr,
+            shards: plan.shards,
+            auth: plan.config.auth.clone(),
+        })
+        .collect())
 }
 
 fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServerConfig> {
@@ -3326,6 +3356,36 @@ mod tests {
                 "{pair:?} do not contend for the same packets"
             );
         }
+    }
+
+    /// `::ffff:127.0.0.1` is `127.0.0.1`. Comparing the two spellings as
+    /// written let the pair through, and the kernel then either refused to bind
+    /// or — with SO_REUSEPORT — accepted both and let one listener shadow the
+    /// other's traffic.
+    #[test]
+    fn ipv4_mapped_addresses_are_compared_as_ipv4() {
+        for pair in [
+            ["127.0.0.1:443", "[::ffff:127.0.0.1]:443"],
+            // The mapped wildcard is still the IPv4 wildcard.
+            ["[::ffff:0.0.0.0]:443", "127.0.0.1:443"],
+            ["[::ffff:127.0.0.1]:443", "0.0.0.0:443"],
+        ] {
+            let config = config_with(vec![
+                listener(pair[0], AuthMode::Basic),
+                listener(pair[1], AuthMode::ClientCert),
+            ]);
+            assert!(
+                super::plan_listeners(&config).is_err(),
+                "{pair:?} name the same interface"
+            );
+        }
+
+        // A genuine IPv6 address that merely looks similar is still distinct.
+        let config = config_with(vec![
+            listener("127.0.0.1:443", AuthMode::Basic),
+            listener("[::1]:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&config).is_ok());
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -226,15 +226,45 @@ fn canonical_ip(ip: IpAddr) -> IpAddr {
     }
 }
 
-/// Whether two listeners would contend for the same packets.
-fn listen_addresses_overlap(a: SocketAddr, b: SocketAddr) -> bool {
+/// How two listeners contend for the same packets, if they do.
+///
+/// Distinguished so the diagnostic can say which of them it is: told that a
+/// loopback pair "overlaps because a wildcard claims its family", an operator
+/// would go looking for a wildcard that is not there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AddressConflict {
+    /// The same address, written the same way.
+    Identical,
+    /// The same address, written two ways — `127.0.0.1` and `::ffff:127.0.0.1`.
+    SameAddress,
+    /// One is a wildcard that claims the other.
+    WildcardCovers,
+}
+
+/// How two listeners would contend, or `None` if they would not.
+fn listen_address_conflict(a: SocketAddr, b: SocketAddr) -> Option<AddressConflict> {
     if a.port() != b.port() {
-        return false;
+        return None;
     }
-    // Canonical form first, so an IPv4-mapped spelling cannot present itself as
-    // a different address from the IPv4 one it resolves to.
-    let (a, b) = (canonical_ip(a.ip()), canonical_ip(b.ip()));
-    a == b || address_covers(a, b) || address_covers(b, a)
+    // Port 0 asks the kernel for whichever port is free, so two listeners that
+    // both do cannot land on the same one.
+    if a.port() == 0 {
+        return None;
+    }
+    if a == b {
+        return Some(AddressConflict::Identical);
+    }
+
+    // Canonical form, so an IPv4-mapped spelling cannot present itself as a
+    // different address from the IPv4 one it resolves to.
+    let (canonical_a, canonical_b) = (canonical_ip(a.ip()), canonical_ip(b.ip()));
+    if canonical_a == canonical_b {
+        return Some(AddressConflict::SameAddress);
+    }
+    if address_covers(canonical_a, canonical_b) || address_covers(canonical_b, canonical_a) {
+        return Some(AddressConflict::WildcardCovers);
+    }
+    None
 }
 
 /// Expand the configured listeners into one plan each, rejecting the
@@ -255,21 +285,27 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
         // `::` claims everything on its port. An overlapping pair is refused
         // rather than left to fail at bind time with an EADDRINUSE that says
         // nothing about which two listeners disagreed.
-        if let Some(existing) = plans.iter().find(|plan| {
-            listen_addresses_overlap(plan.config.server.listen_addr, listener.listen_addr)
-        }) {
-            let existing = existing.config.server.listen_addr;
-            if existing == listener.listen_addr {
-                anyhow::bail!(
+        let conflict = plans.iter().find_map(|plan| {
+            let existing = plan.config.server.listen_addr;
+            listen_address_conflict(existing, listener.listen_addr)
+                .map(|conflict| (existing, conflict))
+        });
+        if let Some((existing, conflict)) = conflict {
+            let new = listener.listen_addr;
+            match conflict {
+                AddressConflict::Identical => anyhow::bail!(
                     "two listeners are configured for {existing}; \
                      each listener needs its own address"
-                );
+                ),
+                AddressConflict::SameAddress => anyhow::bail!(
+                    "listeners {existing} and {new} are the same address written two ways; \
+                     each listener needs its own address"
+                ),
+                AddressConflict::WildcardCovers => anyhow::bail!(
+                    "listeners {existing} and {new} overlap; a wildcard address claims every \
+                     address of its family on that port, and :: may claim IPv4 as well"
+                ),
             }
-            anyhow::bail!(
-                "listeners {existing} and {} overlap; a wildcard address claims every \
-                 address of its family on that port, and :: may claim IPv4 as well",
-                listener.listen_addr
-            );
         }
 
         // "One per core" has no single answer once the cores are shared between
@@ -613,6 +649,23 @@ impl Server {
 
         info!(shards = total_shards, "server ready");
         Ok(Self { shards })
+    }
+
+    /// The address every shard actually bound, in shard order.
+    ///
+    /// A listener configured on port `0` takes whichever port the kernel had
+    /// free, so this is the only way to learn where it ended up. Shards of one
+    /// listener share an address and so repeat here.
+    pub fn listen_addrs(&self) -> Vec<SocketAddr> {
+        self.shards
+            .iter()
+            .map(|shard| {
+                shard
+                    .socket
+                    .local_addr()
+                    .unwrap_or(shard.config.server.listen_addr)
+            })
+            .collect()
     }
 
     /// Reload the roster whenever `SIGHUP` arrives.
@@ -3386,6 +3439,57 @@ mod tests {
             listener("[::1]:443", AuthMode::ClientCert),
         ]);
         assert!(super::plan_listeners(&config).is_ok());
+    }
+
+    /// Port 0 asks the kernel for whichever port is free, so two listeners that
+    /// both do cannot land on the same one — and refusing the pair would make
+    /// the ephemeral form unusable.
+    #[test]
+    fn listeners_may_both_ask_for_an_ephemeral_port() {
+        let config = config_with(vec![
+            listener("127.0.0.1:0", AuthMode::Basic),
+            listener("127.0.0.1:0", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&config).is_ok());
+    }
+
+    /// The diagnostic has to name the conflict it found. Told that a loopback
+    /// pair overlaps "because a wildcard claims its family", an operator would
+    /// go looking for a wildcard that is not there.
+    #[test]
+    fn an_address_conflict_is_described_by_its_kind() {
+        let cases = [
+            (
+                "0.0.0.0:443",
+                "0.0.0.0:443",
+                "two listeners are configured for",
+            ),
+            (
+                "127.0.0.1:443",
+                "[::ffff:127.0.0.1]:443",
+                "are the same address written two ways",
+            ),
+            (
+                "0.0.0.0:443",
+                "127.0.0.1:443",
+                "overlap; a wildcard address",
+            ),
+        ];
+
+        for (first, second, expected) in cases {
+            let config = config_with(vec![
+                listener(first, AuthMode::Basic),
+                listener(second, AuthMode::ClientCert),
+            ]);
+            let error = match super::plan_listeners(&config) {
+                Ok(_) => panic!("{first} and {second} contend and must be refused"),
+                Err(error) => error.to_string(),
+            };
+            assert!(
+                error.contains(expected),
+                "{first} vs {second}: expected {expected:?}, got {error:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -90,6 +90,15 @@ const MAX_PENDING_AUTH_GLOBAL: usize = 256;
 /// that is what `Shared::auth_permits` does.
 const MAX_PENDING_AUTH_PER_CONNECTION: usize = 16;
 
+/// How many fresh kernel-selected ports to try when an ephemeral listener
+/// happens to overlap another listener.
+///
+/// `SO_REUSEPORT` makes such an overlap legal at the kernel boundary, so the
+/// server has to detect it itself or two authentication modes can accidentally
+/// join one load-balancing group. A collision is rare; a bounded retry keeps a
+/// pathological host configuration from turning startup into an infinite loop.
+const MAX_EPHEMERAL_BIND_ATTEMPTS: usize = 32;
+
 /// Concurrent password verifications allowed across all shards.
 ///
 /// Each one costs roughly 19 MiB and tens of milliseconds of CPU, so this caps
@@ -138,10 +147,10 @@ struct UdpResponse {
 /// than dropped.
 ///
 /// A server may have several listeners, which is what lets one process serve
-/// more than one authentication mode: `auth.mode` decides which TLS context a
-/// shard builds, and that is fixed once its socket is bound. Shards are
-/// numbered across the whole server, so everything shared between them — the
-/// address pool, the routing table, the TUN device, the cross-shard queues —
+/// more than one authentication mode: each listener's `auth.mode` decides which
+/// TLS context a shard builds, and that is fixed once its socket is bound.
+/// Shards are numbered across the whole server, so everything shared between
+/// them — the address pool, routing table, TUN device, and cross-shard queues —
 /// stays single and needs no knowledge of which listener a shard serves.
 pub struct Server {
     shards: Vec<Shard>,
@@ -160,16 +169,9 @@ struct ValidatedServerConfig {
     address_pool: AddressPool,
 }
 
-/// One listener's fully materialised configuration and shard count.
+/// One listener after its shard count has been resolved.
 struct ListenerPlan {
-    /// The whole configuration with this listener's address, shard count, and
-    /// authentication substituted in.
-    ///
-    /// A shard reads exactly one of these and never has to know it is one
-    /// listener among several, which is what keeps the multi-listener change
-    /// out of the request and packet paths entirely.
-    config: ServerConfig,
-    shards: usize,
+    listener: ResolvedListener,
 }
 
 /// Whether any listener authenticates with a client certificate.
@@ -179,7 +181,7 @@ struct ListenerPlan {
 /// listener's mode.
 fn any_client_cert_listener(config: &ServerConfig) -> bool {
     config
-        .resolved_listeners()
+        .listeners
         .iter()
         .any(|listener| listener.auth.client_cert_enabled())
 }
@@ -193,8 +195,8 @@ fn any_client_cert_listener(config: &ServerConfig) -> bool {
 fn basic_shard_count(listeners: &[ListenerPlan]) -> usize {
     listeners
         .iter()
-        .filter(|plan| plan.config.auth.basic_enabled())
-        .map(|plan| plan.shards)
+        .filter(|plan| plan.listener.auth.basic_enabled())
+        .map(|plan| plan.listener.shards)
         .sum()
 }
 
@@ -226,6 +228,29 @@ fn canonical_ip(ip: IpAddr) -> IpAddr {
     }
 }
 
+/// Whether two socket addresses name the same interface after normalising an
+/// IPv4-mapped IPv6 spelling.
+///
+/// A non-zero scope ID is part of a link-local IPv6 interface identity. In
+/// particular, `fe80::1%2` and `fe80::1%3` may coexist on two links even though
+/// `ip()` alone returns the same address for both. Scope IDs on global addresses
+/// and flow information are ignored because they do not distinguish bind
+/// targets. A zero link-local scope remains conservative because the kernel may
+/// resolve it to the same interface as an explicit one.
+fn same_canonical_address(a: SocketAddr, b: SocketAddr) -> bool {
+    let (canonical_a, canonical_b) = (canonical_ip(a.ip()), canonical_ip(b.ip()));
+    if canonical_a != canonical_b {
+        return false;
+    }
+
+    match (canonical_a, a, b) {
+        (IpAddr::V6(ip), SocketAddr::V6(a), SocketAddr::V6(b)) if ip.is_unicast_link_local() => {
+            a.scope_id() == 0 || b.scope_id() == 0 || a.scope_id() == b.scope_id()
+        }
+        _ => true,
+    }
+}
+
 /// How two listeners contend for the same packets, if they do.
 ///
 /// Distinguished so the diagnostic can say which of them it is: told that a
@@ -246,8 +271,9 @@ fn listen_address_conflict(a: SocketAddr, b: SocketAddr) -> Option<AddressConfli
     if a.port() != b.port() {
         return None;
     }
-    // Port 0 asks the kernel for whichever port is free, so two listeners that
-    // both do cannot land on the same one.
+    // Port 0 has no fixed address to compare yet. Binding resolves it and checks
+    // the result against both already-bound and still-planned listeners; this is
+    // necessary because SO_REUSEPORT can make the kernel reuse a selected port.
     if a.port() == 0 {
         return None;
     }
@@ -258,7 +284,7 @@ fn listen_address_conflict(a: SocketAddr, b: SocketAddr) -> Option<AddressConfli
     // Canonical form, so an IPv4-mapped spelling cannot present itself as a
     // different address from the IPv4 one it resolves to.
     let (canonical_a, canonical_b) = (canonical_ip(a.ip()), canonical_ip(b.ip()));
-    if canonical_a == canonical_b {
+    if same_canonical_address(a, b) {
         return Some(AddressConflict::SameAddress);
     }
     if address_covers(canonical_a, canonical_b) || address_covers(canonical_b, canonical_a) {
@@ -270,11 +296,14 @@ fn listen_address_conflict(a: SocketAddr, b: SocketAddr) -> Option<AddressConfli
 /// Expand the configured listeners into one plan each, rejecting the
 /// combinations that cannot be served.
 fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
-    let listeners = config.resolved_listeners();
-    let mut plans: Vec<ListenerPlan> = Vec::with_capacity(listeners.len());
+    if config.listeners.is_empty() {
+        anyhow::bail!("at least one [[listeners]] entry is required");
+    }
+
+    let mut plans: Vec<ListenerPlan> = Vec::with_capacity(config.listeners.len());
     let mut total_shards = 0usize;
 
-    for listener in &listeners {
+    for listener in &config.listeners {
         // Two listeners over one address is not merely a bind failure to let
         // the kernel report. A listener with more than one shard opens its
         // socket with SO_REUSEPORT, so a second listener on the same address
@@ -286,7 +315,7 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
         // rather than left to fail at bind time with an EADDRINUSE that says
         // nothing about which two listeners disagreed.
         let conflict = plans.iter().find_map(|plan| {
-            let existing = plan.config.server.listen_addr;
+            let existing = plan.listener.listen_addr;
             listen_address_conflict(existing, listener.listen_addr)
                 .map(|conflict| (existing, conflict))
         });
@@ -311,7 +340,7 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
         // "One per core" has no single answer once the cores are shared between
         // listeners, and quietly giving every listener a full set would
         // oversubscribe the machine by the number of listeners.
-        if listener.shards == 0 && listeners.len() > 1 {
+        if listener.shards == 0 && config.listeners.len() > 1 {
             anyhow::bail!(
                 "listener {} uses shards = 0 (one per core), which has no meaning \
                  alongside other listeners; give each listener an explicit count",
@@ -331,18 +360,12 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
         }
 
         total_shards += shards;
-
-        let mut listener_config = config.clone();
-        listener_config.server.listen_addr = listener.listen_addr;
-        listener_config.server.shards = shards;
-        listener_config.auth = listener.auth.clone();
-        // A shard's configuration describes only its own listener, so the list
-        // cannot be misread as something it should act on.
-        listener_config.listeners.clear();
-
         plans.push(ListenerPlan {
-            config: listener_config,
-            shards,
+            listener: ResolvedListener {
+                listen_addr: listener.listen_addr,
+                shards,
+                auth: listener.auth.clone(),
+            },
         });
     }
 
@@ -375,7 +398,7 @@ fn active_client_registry(
     let clients = ClientRegistry::from_config(&config.clients)?;
     if clients.is_empty() {
         anyhow::bail!(
-            "auth.mode = \"client_cert\" needs at least one [[clients]] entry; \
+            "listener auth.mode = \"client_cert\" needs at least one [[clients]] entry; \
              run `masque-server enroll-client` to create one"
         );
     }
@@ -397,38 +420,13 @@ pub fn validate_config(config: &ServerConfig) -> anyhow::Result<Vec<ResolvedList
     Ok(validated
         .listeners
         .iter()
-        .map(|plan| ResolvedListener {
-            listen_addr: plan.config.server.listen_addr,
-            shards: plan.shards,
-            auth: plan.config.auth.clone(),
-        })
+        .map(|plan| plan.listener.clone())
         .collect())
 }
 
 fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServerConfig> {
     let listeners = plan_listeners(config)?;
     let any_client_cert = any_client_cert_listener(config);
-
-    // [[listeners]] is the whole list, so `[server]`'s own socket settings are
-    // dead. Warned about only when they were set to something other than the
-    // default, which is what "I left the old listen address behind and expect
-    // it to still serve" looks like; a file that simply never mentions them has
-    // nothing to correct. Only a warning either way: which sockets actually
-    // came up is spelled out by the "listening" line each listener logs, and by
-    // `check-config`.
-    if !config.listeners.is_empty() {
-        let defaults = crate::config::ServerSection::default();
-        if config.server.listen_addr != defaults.listen_addr
-            || config.server.shards != defaults.shards
-        {
-            warn!(
-                listen_addr = %config.server.listen_addr,
-                shards = config.server.shards,
-                "[server].listen_addr and [server].shards are ignored because \
-                 [[listeners]] names the sockets"
-            );
-        }
-    }
 
     // Surface a bad credential or active roster configuration first. A roster
     // outside client-cert mode is deliberately not parsed or allowed to
@@ -441,19 +439,22 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
         );
     } else if !config.clients.is_empty() {
         warn!(
-            "[[clients]] entries are ignored unless auth.mode = \"client_cert\" \
-             and auth.enabled = true"
+            "[[clients]] entries are ignored unless a listener has auth.mode = \
+             \"client_cert\" and auth.enabled = true"
         );
     }
 
     // Credentials are per listener, so a mistake in the second one has to name
     // the listener it came from or it cannot be found in a multi-listener file.
     for plan in &listeners {
-        let addr = plan.config.server.listen_addr;
-        if plan.config.auth.basic_enabled() {
-            BasicAuthenticator::new(&plan.config.auth.username, &plan.config.auth.password_hash)
-                .with_context(|| format!("listener {addr}"))?;
-        } else if !plan.config.auth.client_cert_enabled() {
+        let addr = plan.listener.listen_addr;
+        if plan.listener.auth.basic_enabled() {
+            BasicAuthenticator::new(
+                &plan.listener.auth.username,
+                &plan.listener.auth.password_hash,
+            )
+            .with_context(|| format!("listener {addr}"))?;
+        } else if !plan.listener.auth.client_cert_enabled() {
             warn!(%addr, "proxy authentication is disabled on this listener");
         }
     }
@@ -521,16 +522,16 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
     // would say nothing about another's.
     for plan in &listeners {
         let client_certs = plan
-            .config
+            .listener
             .auth
             .client_cert_enabled()
             .then(|| Arc::new(SharedRoster::new(clients.clone())));
-        build_quic_config(&plan.config, client_certs)
-            .with_context(|| format!("listener {}", plan.config.server.listen_addr))?;
+        build_quic_config(config, client_certs)
+            .with_context(|| format!("listener {}", plan.listener.listen_addr))?;
     }
     build_h3_config()?;
 
-    let total_shards = listeners.iter().map(|plan| plan.shards).sum();
+    let total_shards = listeners.iter().map(|plan| plan.listener.shards).sum();
     Ok(ValidatedServerConfig {
         clients,
         listeners,
@@ -549,6 +550,70 @@ fn roster_reload_settings(
         client_cert_enabled: any_client_cert_listener(config),
         ip_proxy_enabled: config.ip_proxy.enabled,
     })
+}
+
+/// Open the UDP socket for one shard with the listener's transport settings.
+async fn open_quic_socket(
+    config: &ServerConfig,
+    listen_addr: SocketAddr,
+    reuseport: bool,
+) -> anyhow::Result<QuicUdpSocket> {
+    QuicUdpSocket::bind_shared(
+        listen_addr,
+        config.quic.max_datagram_size,
+        config.quic.enable_udp_gso,
+        config.quic.enable_udp_gro,
+        reuseport,
+    )
+    .await
+    .with_context(|| format!("failed to bind listener {listen_addr}"))
+}
+
+/// Bind the first shard of a listener and resolve an ephemeral port, if any.
+///
+/// A multi-shard socket sets `SO_REUSEPORT` before binding. Linux may therefore
+/// choose an ephemeral port that is already held by another reuseport group,
+/// including a later fixed listener from this configuration. Detect that before
+/// the remaining shards join the group and ask the kernel for another port.
+async fn bind_first_listener_socket(
+    config: &ServerConfig,
+    requested: SocketAddr,
+    reuseport: bool,
+    unavailable: &[SocketAddr],
+) -> anyhow::Result<(QuicUdpSocket, SocketAddr)> {
+    for attempt in 1..=MAX_EPHEMERAL_BIND_ATTEMPTS {
+        let socket = open_quic_socket(config, requested, reuseport).await?;
+        let bound = socket.local_addr()?;
+
+        if requested.port() != 0 {
+            return Ok((socket, bound));
+        }
+
+        if let Some(existing) = unavailable
+            .iter()
+            .copied()
+            .find(|existing| listen_address_conflict(bound, *existing).is_some())
+        {
+            if attempt == MAX_EPHEMERAL_BIND_ATTEMPTS {
+                anyhow::bail!(
+                    "listener {requested} was repeatedly assigned an ephemeral address that \
+                     overlaps listener {existing}; tried {MAX_EPHEMERAL_BIND_ATTEMPTS} ports"
+                );
+            }
+            debug!(
+                %requested,
+                assigned = %bound,
+                conflicts_with = %existing,
+                attempt,
+                "ephemeral listener address overlaps another listener; retrying"
+            );
+            continue;
+        }
+
+        return Ok((socket, bound));
+    }
+
+    unreachable!("the bounded ephemeral-port loop either returns or reports its last conflict")
 }
 
 impl Server {
@@ -574,6 +639,7 @@ impl Server {
         } = validate_server_config(&config)?;
 
         let basic_shards = basic_shard_count(&listeners);
+        let config = Arc::new(config);
 
         let tun = build_tun(&config)?;
 
@@ -624,12 +690,49 @@ impl Server {
 
         let mut shards = Vec::with_capacity(total_shards);
         let mut inboxes = forward_rx.into_iter().zip(tun_rx);
-        for plan in listeners {
+        // Ephemeral listeners must avoid not only sockets that are already up,
+        // but fixed listeners that have not been reached yet. Otherwise an
+        // early `:0` listener can take a later port and, under SO_REUSEPORT,
+        // silently join the other authentication mode's group.
+        let mut unavailable_listener_addrs: Vec<SocketAddr> = listeners
+            .iter()
+            .map(|plan| plan.listener.listen_addr)
+            .filter(|addr| addr.port() != 0)
+            .collect();
+
+        for mut plan in listeners {
             // SO_REUSEPORT is what lets one listener's shards share an address.
             // A single-shard listener must not set it, or a later listener that
             // was misconfigured onto the same address could join its group.
-            let reuseport = plan.shards > 1;
-            for _ in 0..plan.shards {
+            let reuseport = plan.listener.shards > 1;
+
+            // Bind `:0` only once, then use the assigned address for every
+            // remaining shard. Asking the kernel for `:0` independently would
+            // split one logical listener across unrelated ports.
+            let (first_socket, bound_addr) = bind_first_listener_socket(
+                &config,
+                plan.listener.listen_addr,
+                reuseport,
+                &unavailable_listener_addrs,
+            )
+            .await?;
+            plan.listener.listen_addr = bound_addr;
+            unavailable_listener_addrs.push(bound_addr);
+
+            let (forward_rx, tun_rx) = inboxes
+                .next()
+                .expect("one inbox pair was created per planned shard");
+            shards.push(Shard::from_socket(
+                shards.len(),
+                Arc::clone(&shared),
+                Arc::clone(&config),
+                plan.listener.clone(),
+                first_socket,
+                forward_rx,
+                tun_rx,
+            )?);
+
+            for _ in 1..plan.listener.shards {
                 let (forward_rx, tun_rx) = inboxes
                     .next()
                     .expect("one inbox pair was created per planned shard");
@@ -637,7 +740,8 @@ impl Server {
                     Shard::bind(
                         shards.len(),
                         Arc::clone(&shared),
-                        plan.config.clone(),
+                        Arc::clone(&config),
+                        plan.listener.clone(),
                         reuseport,
                         forward_rx,
                         tun_rx,
@@ -654,17 +758,12 @@ impl Server {
     /// The address every shard actually bound, in shard order.
     ///
     /// A listener configured on port `0` takes whichever port the kernel had
-    /// free, so this is the only way to learn where it ended up. Shards of one
-    /// listener share an address and so repeat here.
+    /// free. This is the programmatic way to learn it; the live `listening` log
+    /// reports it too. Shards of one listener share an address and repeat here.
     pub fn listen_addrs(&self) -> Vec<SocketAddr> {
         self.shards
             .iter()
-            .map(|shard| {
-                shard
-                    .socket
-                    .local_addr()
-                    .unwrap_or(shard.config.server.listen_addr)
-            })
+            .map(|shard| shard.socket.local_addr().unwrap_or(shard.listen_addr))
             .collect()
     }
 
@@ -1251,7 +1350,9 @@ struct Shard {
     client_certs: Option<Arc<SharedRoster>>,
     tcp_policy: TargetPolicy,
     udp_policy: TargetPolicy,
-    config: ServerConfig,
+    config: Arc<ServerConfig>,
+    /// Configured address after an ephemeral port, if any, has been resolved.
+    listen_addr: SocketAddr,
     /// Reverse index for routing TUN packets without scanning every connection.
     conn_by_index: FxHashMap<u64, quiche::ConnectionId<'static>>,
     udp_response_tx: mpsc::Sender<UdpResponse>,
@@ -1274,37 +1375,50 @@ impl Shard {
     async fn bind(
         index: usize,
         shared: Arc<Shared>,
-        config: ServerConfig,
+        config: Arc<ServerConfig>,
+        listener: ResolvedListener,
         reuseport: bool,
         forward_rx: mpsc::Receiver<ForwardedPacket>,
         tun_rx: mpsc::Receiver<Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        let auth = if config.auth.basic_enabled() {
+        let socket = open_quic_socket(&config, listener.listen_addr, reuseport).await?;
+        Self::from_socket(index, shared, config, listener, socket, forward_rx, tun_rx)
+    }
+
+    /// Build one shard around a socket that has already been bound.
+    ///
+    /// The first shard takes this path because an ephemeral listener has to
+    /// inspect the kernel-selected port before the rest of its reuseport group
+    /// is opened.
+    #[allow(clippy::too_many_arguments)]
+    fn from_socket(
+        index: usize,
+        shared: Arc<Shared>,
+        config: Arc<ServerConfig>,
+        listener: ResolvedListener,
+        socket: QuicUdpSocket,
+        forward_rx: mpsc::Receiver<ForwardedPacket>,
+        tun_rx: mpsc::Receiver<Vec<u8>>,
+    ) -> anyhow::Result<Self> {
+        let auth = if listener.auth.basic_enabled() {
             Some(BasicAuthenticator::new(
-                &config.auth.username,
-                &config.auth.password_hash,
+                &listener.auth.username,
+                &listener.auth.password_hash,
             )?)
         } else {
             None
         };
 
-        let socket = QuicUdpSocket::bind_shared(
-            config.server.listen_addr,
-            config.quic.max_datagram_size,
-            config.quic.enable_udp_gso,
-            config.quic.enable_udp_gro,
-            reuseport,
-        )
-        .await?;
+        let bound_addr = socket.local_addr()?;
         info!(
             shard = index,
-            addr = %config.server.listen_addr,
+            addr = %bound_addr,
             udp_gso = socket.udp_gso_enabled(),
             udp_gro = socket.udp_gro_enabled(),
             "listening"
         );
 
-        let client_certs = if config.auth.client_cert_enabled() {
+        let client_certs = if listener.auth.client_cert_enabled() {
             Some(Arc::clone(&shared.clients))
         } else {
             None
@@ -1339,6 +1453,7 @@ impl Shard {
             tcp_policy,
             udp_policy,
             config,
+            listen_addr: listener.listen_addr,
             conn_by_index: FxHashMap::default(),
             udp_response_tx,
             udp_response_rx,
@@ -3228,21 +3343,20 @@ mod tests {
         ListenerSection {
             listen_addr: addr.parse().unwrap(),
             shards: 1,
-            auth: Some(AuthSection {
+            auth: AuthSection {
                 enabled: true,
                 mode,
                 // Enough to satisfy `BasicAuthenticator`; the hash is only
                 // parsed when a request actually arrives.
                 username: "alice".into(),
                 password_hash: "$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA".into(),
-            }),
+            },
         }
     }
 
     #[test]
     fn roster_is_not_parsed_outside_client_certificate_mode() {
         let mut config = ServerConfig::default();
-        config.auth.mode = AuthMode::Basic;
         config.clients.push(invalid_roster_entry());
         assert!(
             super::active_client_registry(&config, false)
@@ -3250,8 +3364,8 @@ mod tests {
                 .is_empty()
         );
 
-        config.auth.enabled = false;
-        config.auth.mode = AuthMode::ClientCert;
+        config.listeners[0].auth.enabled = false;
+        config.listeners[0].auth.mode = AuthMode::ClientCert;
         assert!(!super::any_client_cert_listener(&config));
         assert!(
             super::active_client_registry(&config, false)
@@ -3263,7 +3377,7 @@ mod tests {
     #[test]
     fn active_client_certificate_roster_is_fail_closed() {
         let mut config = ServerConfig::default();
-        config.auth.mode = AuthMode::ClientCert;
+        config.listeners[0].auth.mode = AuthMode::ClientCert;
         assert!(super::active_client_registry(&config, true).is_err());
 
         config.clients.push(invalid_roster_entry());
@@ -3299,7 +3413,7 @@ mod tests {
         let reload = super::roster_reload_settings(&config, Some(path.clone())).unwrap();
         assert!(!reload.client_cert_enabled);
 
-        config.auth.mode = AuthMode::ClientCert;
+        config.listeners[0].auth.mode = AuthMode::ClientCert;
         config.ip_proxy.enabled = false;
         let reload = super::roster_reload_settings(&config, Some(path.clone())).unwrap();
         assert_eq!(reload.path, path);
@@ -3322,24 +3436,16 @@ mod tests {
     // ── Listener planning ────────────────────────────────────────────
 
     #[test]
-    fn a_configuration_without_listeners_plans_exactly_one() {
+    fn a_configuration_without_listeners_is_rejected() {
         let mut config = ServerConfig::default();
-        config.server.listen_addr = "127.0.0.1:8443".parse().unwrap();
-        config.server.shards = 1;
-
-        let plans = super::plan_listeners(&config).unwrap();
-        assert_eq!(plans.len(), 1);
-        assert_eq!(plans[0].shards, 1);
-        assert_eq!(
-            plans[0].config.server.listen_addr,
-            "127.0.0.1:8443".parse::<std::net::SocketAddr>().unwrap()
-        );
+        config.listeners.clear();
+        assert!(super::plan_listeners(&config).is_err());
     }
 
-    /// Each shard reads one listener's configuration, so the substitution has
-    /// to be complete: a shard that could still see the list might act on it.
+    /// Planning keeps the listener-specific trust boundary separate from the
+    /// process-wide proxy, QUIC, TLS, and connection settings.
     #[test]
-    fn a_plan_describes_only_its_own_listener() {
+    fn a_plan_resolves_each_listener_independently() {
         let config = config_with(vec![
             listener("127.0.0.1:8443", AuthMode::Basic),
             listener("127.0.0.1:8444", AuthMode::ClientCert),
@@ -3348,13 +3454,12 @@ mod tests {
         let plans = super::plan_listeners(&config).unwrap();
         assert_eq!(plans.len(), 2);
         for plan in &plans {
-            assert!(plan.config.listeners.is_empty());
-            assert_eq!(plan.config.server.shards, plan.shards);
+            assert_eq!(plan.listener.shards, 1);
         }
-        assert!(plans[0].config.auth.basic_enabled());
-        assert!(plans[1].config.auth.client_cert_enabled());
+        assert!(plans[0].listener.auth.basic_enabled());
+        assert!(plans[1].listener.auth.client_cert_enabled());
         assert_eq!(
-            plans[1].config.server.listen_addr,
+            plans[1].listener.listen_addr,
             "127.0.0.1:8444".parse::<std::net::SocketAddr>().unwrap()
         );
     }
@@ -3441,9 +3546,33 @@ mod tests {
         assert!(super::plan_listeners(&config).is_ok());
     }
 
-    /// Port 0 asks the kernel for whichever port is free, so two listeners that
-    /// both do cannot land on the same one — and refusing the pair would make
-    /// the ephemeral form unusable.
+    /// A link-local IPv6 scope selects the interface. Dropping it during
+    /// canonicalisation would reject two valid listeners as one address.
+    #[test]
+    fn native_ipv6_scope_ids_remain_distinct() {
+        let config = config_with(vec![
+            listener("[fe80::1%2]:443", AuthMode::Basic),
+            listener("[fe80::1%3]:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&config).is_ok());
+
+        let same_scope = config_with(vec![
+            listener("[fe80::1%2]:443", AuthMode::Basic),
+            listener("[fe80::1%2]:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&same_scope).is_err());
+
+        // The kernel ignores a zone on a non-link-local address, so spelling a
+        // loopback address with two scopes must not bypass the conflict check.
+        let scoped_loopback = config_with(vec![
+            listener("[::1%2]:443", AuthMode::Basic),
+            listener("[::1%3]:443", AuthMode::ClientCert),
+        ]);
+        assert!(super::plan_listeners(&scoped_loopback).is_err());
+    }
+
+    /// Port 0 has no fixed value until bind. Planning permits several such
+    /// listeners; startup resolves each one and prevents reuseport collisions.
     #[test]
     fn listeners_may_both_ask_for_an_ephemeral_port() {
         let config = config_with(vec![
@@ -3545,7 +3674,7 @@ mod tests {
     /// an upgrade must not silently switch a server over to it.
     #[test]
     fn sharding_is_off_by_default() {
-        assert_eq!(ServerConfig::default().server.shards, 1);
+        assert_eq!(ServerConfig::default().listeners[0].shards, 1);
         assert_eq!(super::resolve_shard_count(1), 1);
     }
 
@@ -3597,7 +3726,7 @@ mod tests {
         ]);
         let plans = super::plan_listeners(&config).unwrap();
 
-        let total_shards: usize = plans.iter().map(|plan| plan.shards).sum();
+        let total_shards: usize = plans.iter().map(|plan| plan.listener.shards).sum();
         assert_eq!(total_shards, 2);
         assert_eq!(super::basic_shard_count(&plans), 1);
 

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -4,6 +4,7 @@
 use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine as _;
@@ -20,13 +21,18 @@ struct TempDir(PathBuf);
 
 impl TempDir {
     fn new() -> Self {
+        // The tests share a process and run in parallel, so the clock alone
+        // does not separate them: two that start within the same nanosecond
+        // would build the same path and the second `create_dir` would fail.
+        static SEQUENCE: AtomicU32 = AtomicU32::new(0);
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
         let path = std::env::temp_dir().join(format!(
-            "masque-check-config-{}-{nonce}",
-            std::process::id()
+            "masque-check-config-{}-{nonce}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir(&path).unwrap();
         Self(path)
@@ -242,6 +248,75 @@ fn check_config_rejects_two_listeners_on_the_same_address() {
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("two listeners are configured for"),
         "unexpected diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// `--listen` overrides `[server].listen_addr`, which a multi-listener
+/// configuration does not use. Silently accepting it would be the worst
+/// outcome: the flag is reached for to narrow a server's exposure, so appearing
+/// to work while the configured listeners stay bound is the failure it was
+/// meant to prevent.
+#[test]
+fn listen_override_is_refused_against_a_multi_listener_configuration() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        dual_listener_config_text("0.0.0.0:8449", "0.0.0.0:8450", &cert_path, &key_path),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--listen")
+        .arg("127.0.0.1:8451")
+        .arg("check-config")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "--listen must not silently leave 0.0.0.0 bound"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--listen cannot choose among"),
+        "unexpected diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The override still works for the single-listener form it describes.
+#[test]
+fn listen_override_still_applies_without_listeners() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        config_text(
+            "127.0.0.1:8449".parse().unwrap(),
+            &cert_path,
+            &key_path,
+            "cubic",
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--listen")
+        .arg("127.0.0.1:8452")
+        .arg("check-config")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "check-config failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -321,6 +321,62 @@ fn listen_override_still_applies_without_listeners() {
     );
 }
 
+/// The reported shard count is the one that will run, not the one written down.
+/// `shards = 0` means "one per core", so echoing the file back would tell an
+/// operator the server runs no event loops at all.
+#[test]
+fn check_config_reports_the_resolved_shard_count() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"[server]
+listen_addr = "127.0.0.1:8449"
+shards = 0
+
+[tls]
+cert_path = "{}"
+key_path = "{}"
+
+[auth]
+enabled = false
+
+[ip_proxy]
+enabled = false
+"#,
+            cert_path.display(),
+            key_path.display()
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check-config")
+        .output()
+        .unwrap();
+
+    // Sharding needs SO_REUSEPORT, so the resolved count is one per core on
+    // Linux and exactly one elsewhere. Either way it is never the configured 0.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "check-config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("listener 127.0.0.1:8449 auth=disabled shards="),
+        "unexpected listener line: {stdout}"
+    );
+    assert!(
+        !stdout.contains("shards=0"),
+        "the configured 0 must not be reported as the shard count: {stdout}"
+    );
+}
+
 #[test]
 fn check_config_rejects_an_unknown_congestion_controller() {
     let dir = TempDir::new();

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
 use boring::asn1::Asn1Time;
 use boring::bn::BigNum;
 use boring::ec::{EcGroup, EcKey};
@@ -135,6 +137,113 @@ fn check_config_validates_without_binding_the_listen_port() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(String::from_utf8_lossy(&output.stdout).contains("configuration is compatible"));
+}
+
+/// A roster-ready public key, in the base64 SubjectPublicKeyInfo DER form
+/// `enroll-client` prints.
+fn public_key_b64(key: &PKey<Private>) -> String {
+    STANDARD.encode(key.public_key_to_der().unwrap())
+}
+
+/// A two-listener file, with the credentials each mode needs.
+fn dual_listener_config_text(
+    basic_addr: &str,
+    cert_addr: &str,
+    cert_path: &Path,
+    key_path: &Path,
+) -> String {
+    let client_public_key = public_key_b64(&p256_key());
+    // `check-config` parses the PHC string, so a placeholder will not do.
+    let password_hash = masque::auth::hash_password(b"correct horse battery staple").unwrap();
+    format!(
+        r#"[tls]
+cert_path = "{}"
+key_path = "{}"
+
+[ip_proxy]
+enabled = false
+
+[[listeners]]
+listen_addr = "{basic_addr}"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "basic"
+username = "alice"
+password_hash = "{password_hash}"
+
+[[listeners]]
+listen_addr = "{cert_addr}"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "client_cert"
+
+[[clients]]
+name = "laptop"
+public_key = "{client_public_key}"
+"#,
+        cert_path.display(),
+        key_path.display()
+    )
+}
+
+/// The installer's preflight has to understand the multi-listener form, or an
+/// operator who splits their authentication modes cannot qualify an upgrade.
+#[test]
+fn check_config_accepts_two_listeners_with_different_authentication_modes() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        dual_listener_config_text("127.0.0.1:8449", "127.0.0.1:8450", &cert_path, &key_path),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check-config")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "check-config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Two listeners on one address is not a bind failure to discover at startup:
+/// a multi-shard listener uses SO_REUSEPORT, so the kernel would hand the
+/// second one connections meant for a different authentication mode.
+#[test]
+fn check_config_rejects_two_listeners_on_the_same_address() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        dual_listener_config_text("127.0.0.1:8449", "127.0.0.1:8449", &cert_path, &key_path),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check-config")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("two listeners are configured for"),
+        "unexpected diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -91,26 +91,39 @@ fn config_text(
     cc_algorithm: &str,
 ) -> String {
     format!(
-        r#"[server]
-listen_addr = "{listen_addr}"
-shards = 1
-
-[tls]
+        r#"[tls]
 cert_path = "{}"
 key_path = "{}"
-
-[auth]
-enabled = false
 
 [quic]
 cc_algorithm = "{cc_algorithm}"
 
 [ip_proxy]
 enabled = false
+
+[[listeners]]
+listen_addr = "{listen_addr}"
+shards = 1
+
+[listeners.auth]
+enabled = false
 "#,
         cert_path.display(),
         key_path.display()
     )
+}
+
+/// The packaged template is the source for fresh installs, so schema changes
+/// must fail locally instead of first appearing in a release archive.
+#[test]
+fn packaged_config_uses_the_current_listener_schema() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("deploy/config/masque.toml");
+    let text = std::fs::read_to_string(path).unwrap();
+    let config = masque::config::parse_toml(&text).unwrap();
+
+    assert_eq!(config.listeners.len(), 1);
+    assert_eq!(config.listeners[0].listen_addr.to_string(), "0.0.0.0:443");
+    assert!(config.listeners[0].auth.basic_enabled());
 }
 
 #[test]
@@ -143,6 +156,44 @@ fn check_config_validates_without_binding_the_listen_port() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(String::from_utf8_lossy(&output.stdout).contains("configuration is compatible"));
+}
+
+/// A preflight deliberately has no network side effects, so an ephemeral port
+/// does not exist yet. Report the configured `:0`; the live `listening` log is
+/// what reports the address selected by the kernel.
+#[test]
+fn check_config_keeps_an_ephemeral_port_unresolved() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let config_path = dir.path().join("masque.toml");
+    std::fs::write(
+        &config_path,
+        config_text(
+            "127.0.0.1:0".parse().unwrap(),
+            &cert_path,
+            &key_path,
+            "cubic",
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("check-config")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "check-config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("listener 127.0.0.1:0 auth=disabled shards=1"),
+        "check-config must not invent a runtime port: {stdout}"
+    );
 }
 
 /// A roster-ready public key, in the base64 SubjectPublicKeyInfo DER form
@@ -252,55 +303,30 @@ fn check_config_rejects_two_listeners_on_the_same_address() {
     );
 }
 
-/// `--listen` overrides `[server].listen_addr`, which a multi-listener
-/// configuration does not use. Silently accepting it would be the worst
-/// outcome: the flag is reached for to narrow a server's exposure, so appearing
-/// to work while the configured listeners stay bound is the failure it was
-/// meant to prevent.
+/// The 0.2 single-listener keys are deliberately not accepted by the 0.3
+/// configuration model. A stale deployment must fail preflight instead of
+/// appearing to run while silently selecting different defaults.
 #[test]
-fn listen_override_is_refused_against_a_multi_listener_configuration() {
+fn check_config_rejects_legacy_single_listener_configuration() {
     let dir = TempDir::new();
     let (cert_path, key_path) = write_server_identity(dir.path());
     let config_path = dir.path().join("masque.toml");
     std::fs::write(
         &config_path,
-        dual_listener_config_text("0.0.0.0:8449", "0.0.0.0:8450", &cert_path, &key_path),
-    )
-    .unwrap();
+        format!(
+            r#"[server]
+listen_addr = "127.0.0.1:8449"
+shards = 1
 
-    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
-        .arg("--config")
-        .arg(&config_path)
-        .arg("--listen")
-        .arg("127.0.0.1:8451")
-        .arg("check-config")
-        .output()
-        .unwrap();
+[tls]
+cert_path = "{}"
+key_path = "{}"
 
-    assert!(
-        !output.status.success(),
-        "--listen must not silently leave 0.0.0.0 bound"
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("--listen cannot choose among"),
-        "unexpected diagnostic: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
-
-/// The override still works for the single-listener form it describes.
-#[test]
-fn listen_override_still_applies_without_listeners() {
-    let dir = TempDir::new();
-    let (cert_path, key_path) = write_server_identity(dir.path());
-    let config_path = dir.path().join("masque.toml");
-    std::fs::write(
-        &config_path,
-        config_text(
-            "127.0.0.1:8449".parse().unwrap(),
-            &cert_path,
-            &key_path,
-            "cubic",
+[auth]
+enabled = false
+"#,
+            cert_path.display(),
+            key_path.display()
         ),
     )
     .unwrap();
@@ -308,15 +334,14 @@ fn listen_override_still_applies_without_listeners() {
     let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
         .arg("--config")
         .arg(&config_path)
-        .arg("--listen")
-        .arg("127.0.0.1:8452")
         .arg("check-config")
         .output()
         .unwrap();
 
+    assert!(!output.status.success());
     assert!(
-        output.status.success(),
-        "check-config failed: {}",
+        String::from_utf8_lossy(&output.stderr).contains("unknown field"),
+        "unexpected diagnostic: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }
@@ -332,18 +357,18 @@ fn check_config_reports_the_resolved_shard_count() {
     std::fs::write(
         &config_path,
         format!(
-            r#"[server]
-listen_addr = "127.0.0.1:8449"
-shards = 0
-
-[tls]
+            r#"[tls]
 cert_path = "{}"
 key_path = "{}"
 
-[auth]
+[ip_proxy]
 enabled = false
 
-[ip_proxy]
+[[listeners]]
+listen_addr = "127.0.0.1:8449"
+shards = 0
+
+[listeners.auth]
 enabled = false
 "#,
             cert_path.display(),

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -28,7 +28,7 @@ use quiche::h3::NameValue as _;
 
 use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
 use masque::capsule::{CapsuleFrame, IpAddress};
-use masque::config::{AuthMode, ClientEntry, ServerConfig};
+use masque::config::{AuthMode, AuthSection, ClientEntry, ListenerSection, ServerConfig};
 use masque::datagram::DatagramHeader;
 use masque::server::Server;
 
@@ -198,6 +198,16 @@ impl Client {
     /// the endpoint, so they skip chain validation and pin the server's public
     /// key instead.
     fn connect(peer: SocketAddr, cert: &Path, key: &Path) -> anyhow::Result<Self> {
+        Self::connect_with(peer, Some((cert, key)))
+    }
+
+    /// Connect without a client certificate, the way a standards-compliant
+    /// MASQUE client that authenticates with `Proxy-Authorization` does.
+    fn connect_anonymous(peer: SocketAddr) -> anyhow::Result<Self> {
+        Self::connect_with(peer, None)
+    }
+
+    fn connect_with(peer: SocketAddr, identity: Option<(&Path, &Path)>) -> anyhow::Result<Self> {
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.connect(peer)?;
         socket.set_read_timeout(Some(Duration::from_millis(50)))?;
@@ -205,8 +215,10 @@ impl Client {
 
         let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION)?;
         config.verify_peer(false);
-        config.load_cert_chain_from_pem_file(cert.to_str().unwrap())?;
-        config.load_priv_key_from_pem_file(key.to_str().unwrap())?;
+        if let Some((cert, key)) = identity {
+            config.load_cert_chain_from_pem_file(cert.to_str().unwrap())?;
+            config.load_priv_key_from_pem_file(key.to_str().unwrap())?;
+        }
         config.set_application_protos(quiche::h3::APPLICATION_PROTOCOL)?;
         config.set_max_idle_timeout(10_000);
         config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
@@ -329,7 +341,16 @@ impl Client {
 
     /// Send the CONNECT-IP request exactly as Cloudflare's clients send it.
     fn send_connect_ip(&mut self, protocol: &str) -> anyhow::Result<u64> {
-        let headers = [
+        self.send_connect_ip_with_credentials(protocol, None)
+    }
+
+    /// The same request, optionally carrying `Proxy-Authorization`.
+    fn send_connect_ip_with_credentials(
+        &mut self,
+        protocol: &str,
+        credentials: Option<&str>,
+    ) -> anyhow::Result<u64> {
+        let mut headers = vec![
             quiche::h3::Header::new(b":method", b"CONNECT"),
             quiche::h3::Header::new(b":protocol", protocol.as_bytes()),
             quiche::h3::Header::new(b":scheme", b"https"),
@@ -340,6 +361,12 @@ impl Client {
             // QPACK and the server's header scan.
             quiche::h3::Header::new(b"user-agent", b""),
         ];
+        if let Some(credentials) = credentials {
+            headers.push(quiche::h3::Header::new(
+                b"proxy-authorization",
+                credentials.as_bytes(),
+            ));
+        }
 
         let h3 = self.h3.as_mut().unwrap();
         let stream_id = h3.send_request(&mut self.quic, &headers, false)?;
@@ -472,6 +499,101 @@ fn fixture(tag: &str) -> Fixture {
         client_key: client_key_path,
         stranger_cert,
         stranger_key: stranger_key_path,
+    }
+}
+
+// ── Multi-listener fixture ───────────────────────────────────────────
+
+const BASIC_USERNAME: &str = "alice";
+const BASIC_PASSWORD: &str = "correct horse battery staple";
+
+/// A server running both authentication modes at once, on two ports.
+struct DualFixture {
+    _dir: TempDir,
+    basic_peer: SocketAddr,
+    cert_peer: SocketAddr,
+    client_cert: PathBuf,
+    client_key: PathBuf,
+    /// A ready-made `Proxy-Authorization` value for the Basic listener.
+    credentials: String,
+}
+
+/// Start one process listening on two ports: Basic on the first,
+/// client-certificate on the second.
+///
+/// `auth.mode` fixes the TLS context when a socket is bound, so this is the
+/// only shape in which one process can serve both.
+fn dual_fixture(tag: &str) -> DualFixture {
+    let dir = TempDir::new(tag);
+
+    let server_key = p256_key();
+    let (cert_path, key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+
+    let client_key = p256_key();
+    let (client_cert, client_key_path) = write_pem(
+        dir.path(),
+        "client",
+        &client_key,
+        &self_signed(&client_key, None),
+    );
+
+    let basic_port = free_port();
+    let cert_port = free_port();
+
+    let mut config = ServerConfig::default();
+    config.tls.cert_path = cert_path;
+    config.tls.key_path = key_path;
+    // Only CONNECT-IP is under test here; the other forms would dial real
+    // targets.
+    config.tcp_proxy.enabled = false;
+    config.udp_proxy.enabled = false;
+    config.listeners = vec![
+        ListenerSection {
+            listen_addr: SocketAddr::from(([127, 0, 0, 1], basic_port)),
+            shards: 1,
+            auth: Some(AuthSection {
+                enabled: true,
+                mode: AuthMode::Basic,
+                username: BASIC_USERNAME.into(),
+                password_hash: masque::auth::hash_password(BASIC_PASSWORD.as_bytes()).unwrap(),
+            }),
+        },
+        ListenerSection {
+            listen_addr: SocketAddr::from(([127, 0, 0, 1], cert_port)),
+            shards: 1,
+            auth: Some(AuthSection {
+                enabled: true,
+                mode: AuthMode::ClientCert,
+                username: String::new(),
+                password_hash: String::new(),
+            }),
+        },
+    ];
+    config.clients = vec![ClientEntry {
+        name: "laptop".into(),
+        public_key: public_key_b64(&client_key),
+        ipv4: Some(CLIENT_IPV4.into()),
+        ipv6: Some(CLIENT_IPV6.into()),
+    }];
+
+    spawn_server(config);
+    std::thread::sleep(Duration::from_millis(300));
+
+    DualFixture {
+        _dir: dir,
+        basic_peer: SocketAddr::from(([127, 0, 0, 1], basic_port)),
+        cert_peer: SocketAddr::from(([127, 0, 0, 1], cert_port)),
+        client_cert,
+        client_key: client_key_path,
+        credentials: format!(
+            "Basic {}",
+            STANDARD.encode(format!("{BASIC_USERNAME}:{BASIC_PASSWORD}"))
+        ),
     }
 }
 
@@ -756,6 +878,123 @@ fn registered_client_gets_its_pinned_addresses_over_cf_connect_ip() {
             .any(|frame| matches!(frame, CapsuleFrame::RouteAdvertisement(_))),
         "expected ROUTE_ADVERTISEMENT, got {capsules:?}"
     );
+}
+
+/// One process, two listeners, two authentication modes.
+///
+/// `auth.mode` decides which TLS context a shard builds, and that is settled
+/// when its socket is bound — so a Cloudflare-style client and a
+/// standards-compliant one cannot share a listener. They can share a process,
+/// and this is the test that says so.
+///
+/// It also pins the reason for sharing one: the address pool is per server, not
+/// per listener, so the two clients cannot be handed the same tunnel address.
+#[test]
+fn two_listeners_serve_both_authentication_modes_from_one_process() {
+    let fixture = dual_fixture("dual");
+
+    // The certificate listener: authenticated during the handshake, pinned
+    // addresses from the roster.
+    let mut cert_client =
+        Client::connect(fixture.cert_peer, &fixture.client_cert, &fixture.client_key).unwrap();
+    cert_client.handshake(Duration::from_secs(5)).unwrap();
+    cert_client.init_h3().unwrap();
+
+    let stream_id = cert_client.send_connect_ip("cf-connect-ip").unwrap();
+    assert_eq!(
+        cert_client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200,
+        "the certificate listener must accept the enrolled client"
+    );
+    let cert_addresses = assigned_addresses(&mut cert_client, stream_id);
+    assert!(
+        cert_addresses.contains(&IpAddress::V4(CLIENT_IPV4.parse::<Ipv4Addr>().unwrap())),
+        "expected the pinned IPv4, got {cert_addresses:?}"
+    );
+
+    // The Basic listener, at the same time, in the same process: no client
+    // certificate at all, credentials on the request instead.
+    let mut basic_client = Client::connect_anonymous(fixture.basic_peer).unwrap();
+    basic_client.handshake(Duration::from_secs(5)).unwrap();
+    basic_client.init_h3().unwrap();
+
+    let stream_id = basic_client
+        .send_connect_ip_with_credentials("connect-ip", Some(&fixture.credentials))
+        .unwrap();
+    assert_eq!(
+        basic_client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200,
+        "the Basic listener must accept correct credentials"
+    );
+    let basic_addresses = assigned_addresses(&mut basic_client, stream_id);
+    assert!(
+        !basic_addresses.is_empty(),
+        "the Basic listener must assign an address from the pool"
+    );
+
+    // One pool behind both listeners. Two processes could not do this: each
+    // would allocate from its own copy and hand out the same addresses.
+    for address in &basic_addresses {
+        assert!(
+            !cert_addresses.contains(address),
+            "listeners handed out the same address {address:?}; the pool is not shared"
+        );
+    }
+}
+
+/// Each listener enforces its own mode and only its own.
+#[test]
+fn a_listener_enforces_only_its_own_authentication_mode() {
+    let fixture = dual_fixture("dual-refuse");
+
+    // Basic listener, no credentials: refused at the request, not the
+    // handshake, because this listener never asks for a certificate.
+    let mut client = Client::connect_anonymous(fixture.basic_peer).unwrap();
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+    let stream_id = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        407,
+        "the Basic listener must still demand credentials"
+    );
+
+    // Certificate listener, same anonymous client: refused during the
+    // handshake, before it can open a stream.
+    let mut client = Client::connect_anonymous(fixture.cert_peer).unwrap();
+    let _ = client.handshake(Duration::from_secs(5));
+    assert!(
+        client.wait_for_close(Duration::from_secs(5)),
+        "the certificate listener must not serve a client without a certificate"
+    );
+
+    // And credentials are no substitute for a certificate on that listener.
+    let mut client = Client::connect_anonymous(fixture.cert_peer).unwrap();
+    let _ = client.handshake(Duration::from_secs(5));
+    assert!(
+        client.wait_for_close(Duration::from_secs(5)),
+        "Basic credentials must not open the certificate listener"
+    );
+}
+
+/// Collect the addresses the server assigned on `stream_id`.
+fn assigned_addresses(client: &mut Client, stream_id: u64) -> Vec<IpAddress> {
+    client
+        .capsules(stream_id, 2, Duration::from_secs(5))
+        .iter()
+        .find_map(|frame| match frame {
+            CapsuleFrame::AddressAssign(addrs) => {
+                Some(addrs.iter().map(|a| a.ip.clone()).collect())
+            }
+            _ => None,
+        })
+        .expect("server must send ADDRESS_ASSIGN")
 }
 
 /// The registered `connect-ip` spelling has to keep working: accepting

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -134,11 +134,18 @@ impl Drop for TempDir {
 /// `Server::bind` does not report the port it landed on, so the port has to be
 /// chosen before it starts.
 fn free_port() -> u16 {
-    UdpSocket::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
+    free_ports::<1>()[0]
+}
+
+/// Reserve several distinct loopback UDP ports at once.
+///
+/// Every socket is held until all of them are bound, because calling
+/// [`free_port`] twice in a row can return the same port: the first is released
+/// before the second is asked for, so nothing stops the kernel handing it out
+/// again.
+fn free_ports<const N: usize>() -> [u16; N] {
+    let sockets: [UdpSocket; N] = std::array::from_fn(|_| UdpSocket::bind("127.0.0.1:0").unwrap());
+    std::array::from_fn(|index| sockets[index].local_addr().unwrap().port())
 }
 
 fn server_config(
@@ -542,8 +549,9 @@ fn dual_fixture(tag: &str) -> DualFixture {
         &self_signed(&client_key, None),
     );
 
-    let basic_port = free_port();
-    let cert_port = free_port();
+    // Both at once: two separate calls could hand back the same port, and the
+    // server would then refuse to start with an overlapping-listener error.
+    let [basic_port, cert_port] = free_ports::<2>();
 
     let mut config = ServerConfig::default();
     config.tls.cert_path = cert_path;

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -146,12 +146,12 @@ fn server_config(
     clients: Vec<ClientEntry>,
 ) -> ServerConfig {
     let mut config = ServerConfig::default();
-    config.server.listen_addr = listen_addr;
-    config.server.shards = 1;
     config.tls.cert_path = cert;
     config.tls.key_path = key;
-    config.auth.enabled = true;
-    config.auth.mode = AuthMode::ClientCert;
+    config.listeners[0].listen_addr = listen_addr;
+    config.listeners[0].shards = 1;
+    config.listeners[0].auth.enabled = true;
+    config.listeners[0].auth.mode = AuthMode::ClientCert;
     config.clients = clients;
     // The tunnels under test are CONNECT-IP only, and the TCP and UDP paths
     // would otherwise resolve and dial real targets.
@@ -555,29 +555,29 @@ fn dual_fixture(tag: &str) -> DualFixture {
     // targets.
     config.tcp_proxy.enabled = false;
     config.udp_proxy.enabled = false;
-    // Both on port 0: the kernel picks two free ports, and the server reports
-    // which. Two listeners asking for port 0 do not count as contending,
-    // because neither has a port yet.
+    // Both on port 0: the server asks the kernel for distinct free ports and
+    // reports which. They do not count as contending before bind, because
+    // neither has a port yet; startup detects and retries a reuseport collision.
     config.listeners = vec![
         ListenerSection {
             listen_addr: ephemeral_addr(),
             shards: 1,
-            auth: Some(AuthSection {
+            auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::Basic,
                 username: BASIC_USERNAME.into(),
                 password_hash: masque::auth::hash_password(BASIC_PASSWORD.as_bytes()).unwrap(),
-            }),
+            },
         },
         ListenerSection {
             listen_addr: ephemeral_addr(),
             shards: 1,
-            auth: Some(AuthSection {
+            auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::ClientCert,
                 username: String::new(),
                 password_hash: String::new(),
-            }),
+            },
         },
     ];
     config.clients = vec![ClientEntry {
@@ -613,12 +613,12 @@ fn dual_fixture(tag: &str) -> DualFixture {
 /// alone and the port stays valid across a reload.
 fn server_config_file(cert: &Path, key: &Path, clients: &[(&str, &str)]) -> String {
     let mut text = format!(
-        "[server]\nlisten_addr = \"127.0.0.1:0\"\nshards = 1\n\n\
-         [tls]\ncert_path = \"{}\"\nkey_path = \"{}\"\n\n\
-         [auth]\nenabled = true\nmode = \"client_cert\"\n\n\
+        "[tls]\ncert_path = \"{}\"\nkey_path = \"{}\"\n\n\
          [tcp_proxy]\nenabled = false\n\n[udp_proxy]\nenabled = false\n\n\
          [ip_proxy]\nenabled = true\nipv4_pool = \"10.89.0.0/24\"\n\
-         ipv6_pool = \"fd00:abcd::/64\"\n",
+         ipv6_pool = \"fd00:abcd::/64\"\n\n\
+         [[listeners]]\nlisten_addr = \"127.0.0.1:0\"\nshards = 1\n\n\
+         [listeners.auth]\nenabled = true\nmode = \"client_cert\"\n",
         cert.display(),
         key.display()
     );
@@ -670,6 +670,64 @@ fn raise_sighup() {
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
+
+/// Resolving `:0` once per shard would turn each shard into a different
+/// listener. The first socket must select the port and every later socket in
+/// that listener must join the exact same reuseport group. Separate listeners
+/// must still receive separate ports.
+#[cfg(target_os = "linux")]
+#[test]
+fn ephemeral_multi_shard_listeners_share_only_their_own_port() {
+    let dir = TempDir::new("ephemeral-shards");
+    let server_key = p256_key();
+    let (cert_path, key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+
+    let mut config = ServerConfig::default();
+    config.tls.cert_path = cert_path;
+    config.tls.key_path = key_path;
+    config.tcp_proxy.enabled = false;
+    config.udp_proxy.enabled = false;
+    config.ip_proxy.enabled = false;
+    config.listeners = vec![
+        ListenerSection {
+            listen_addr: ephemeral_addr(),
+            shards: 2,
+            auth: AuthSection {
+                enabled: false,
+                ..Default::default()
+            },
+        },
+        ListenerSection {
+            listen_addr: ephemeral_addr(),
+            shards: 2,
+            auth: AuthSection {
+                enabled: false,
+                ..Default::default()
+            },
+        },
+    ];
+
+    let bound = spawn_server(config);
+    assert_eq!(bound.len(), 4);
+    assert_ne!(bound[0].port(), 0);
+    assert_eq!(
+        bound[0], bound[1],
+        "one listener's shards must share a port"
+    );
+    assert_eq!(
+        bound[2], bound[3],
+        "one listener's shards must share a port"
+    );
+    assert_ne!(
+        bound[0], bound[2],
+        "separate listeners must not join one reuseport group"
+    );
+}
 
 /// Revoking a client must drop the tunnel it already holds, without restarting
 /// the server and without disturbing anyone else.

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -129,33 +129,24 @@ impl Drop for TempDir {
 
 // ── Server under test ────────────────────────────────────────────────
 
-/// Reserve a loopback UDP port and release it for the server to take.
+/// The loopback address that asks the kernel for whichever port is free.
 ///
-/// `Server::bind` does not report the port it landed on, so the port has to be
-/// chosen before it starts.
-fn free_port() -> u16 {
-    free_ports::<1>()[0]
-}
-
-/// Reserve several distinct loopback UDP ports at once.
-///
-/// Every socket is held until all of them are bound, because calling
-/// [`free_port`] twice in a row can return the same port: the first is released
-/// before the second is asked for, so nothing stops the kernel handing it out
-/// again.
-fn free_ports<const N: usize>() -> [u16; N] {
-    let sockets: [UdpSocket; N] = std::array::from_fn(|_| UdpSocket::bind("127.0.0.1:0").unwrap());
-    std::array::from_fn(|index| sockets[index].local_addr().unwrap().port())
+/// Servers under test bind this and report back what they got, rather than
+/// picking a port in advance. Reserving one and releasing it leaves a window in
+/// which a parallel test can take it, and the whole point of a probe socket is
+/// that it must be closed before the server can have the port.
+fn ephemeral_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], 0))
 }
 
 fn server_config(
     cert: PathBuf,
     key: PathBuf,
-    port: u16,
+    listen_addr: SocketAddr,
     clients: Vec<ClientEntry>,
 ) -> ServerConfig {
     let mut config = ServerConfig::default();
-    config.server.listen_addr = SocketAddr::from(([127, 0, 0, 1], port));
+    config.server.listen_addr = listen_addr;
     config.server.shards = 1;
     config.tls.cert_path = cert;
     config.tls.key_path = key;
@@ -169,11 +160,17 @@ fn server_config(
     config
 }
 
-/// Run a server on its own runtime thread for the duration of the test.
+/// Run a server on its own runtime thread and return the addresses it bound.
 ///
 /// The thread is detached: the runtime is dropped when the process exits, and
-/// the OS reclaims the port.
-fn spawn_server(config: ServerConfig) {
+/// the OS reclaims the ports.
+///
+/// Waiting for the real addresses rather than sleeping is what makes a
+/// `127.0.0.1:0` listener usable: the port is never held by anything but the
+/// server, so no parallel test can take it in between, and a caller cannot
+/// start talking to a socket that is not up yet.
+fn spawn_server(config: ServerConfig) -> Vec<SocketAddr> {
+    let (bound_tx, bound_rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -182,12 +179,19 @@ fn spawn_server(config: ServerConfig) {
         runtime.block_on(async move {
             match Server::bind(config).await {
                 Ok(mut server) => {
+                    // A failed send means the test gave up; run anyway and let
+                    // the detached thread die with the process.
+                    let _ = bound_tx.send(server.listen_addrs());
                     let _ = server.run().await;
                 }
                 Err(e) => panic!("server failed to bind: {e:#}"),
             }
         });
     });
+
+    bound_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("server did not report its listen addresses")
 }
 
 // ── Client ───────────────────────────────────────────────────────────
@@ -482,22 +486,17 @@ fn fixture(tag: &str) -> Fixture {
         &self_signed(&stranger_key, None),
     );
 
-    let port = free_port();
-    spawn_server(server_config(
+    let peer = spawn_server(server_config(
         cert_path,
         key_path,
-        port,
+        ephemeral_addr(),
         vec![ClientEntry {
             name: "laptop".into(),
             public_key: public_key_b64(&client_key),
             ipv4: Some(CLIENT_IPV4.into()),
             ipv6: Some(CLIENT_IPV6.into()),
         }],
-    ));
-
-    let peer = SocketAddr::from(([127, 0, 0, 1], port));
-    // The server binds on another thread; give it a moment to take the port.
-    std::thread::sleep(Duration::from_millis(300));
+    ))[0];
 
     Fixture {
         _dir: dir,
@@ -549,10 +548,6 @@ fn dual_fixture(tag: &str) -> DualFixture {
         &self_signed(&client_key, None),
     );
 
-    // Both at once: two separate calls could hand back the same port, and the
-    // server would then refuse to start with an overlapping-listener error.
-    let [basic_port, cert_port] = free_ports::<2>();
-
     let mut config = ServerConfig::default();
     config.tls.cert_path = cert_path;
     config.tls.key_path = key_path;
@@ -560,9 +555,12 @@ fn dual_fixture(tag: &str) -> DualFixture {
     // targets.
     config.tcp_proxy.enabled = false;
     config.udp_proxy.enabled = false;
+    // Both on port 0: the kernel picks two free ports, and the server reports
+    // which. Two listeners asking for port 0 do not count as contending,
+    // because neither has a port yet.
     config.listeners = vec![
         ListenerSection {
-            listen_addr: SocketAddr::from(([127, 0, 0, 1], basic_port)),
+            listen_addr: ephemeral_addr(),
             shards: 1,
             auth: Some(AuthSection {
                 enabled: true,
@@ -572,7 +570,7 @@ fn dual_fixture(tag: &str) -> DualFixture {
             }),
         },
         ListenerSection {
-            listen_addr: SocketAddr::from(([127, 0, 0, 1], cert_port)),
+            listen_addr: ephemeral_addr(),
             shards: 1,
             auth: Some(AuthSection {
                 enabled: true,
@@ -589,13 +587,14 @@ fn dual_fixture(tag: &str) -> DualFixture {
         ipv6: Some(CLIENT_IPV6.into()),
     }];
 
-    spawn_server(config);
-    std::thread::sleep(Duration::from_millis(300));
+    // One shard each, in configuration order.
+    let bound = spawn_server(config);
+    assert_eq!(bound.len(), 2, "one shard per listener");
 
     DualFixture {
         _dir: dir,
-        basic_peer: SocketAddr::from(([127, 0, 0, 1], basic_port)),
-        cert_peer: SocketAddr::from(([127, 0, 0, 1], cert_port)),
+        basic_peer: bound[0],
+        cert_peer: bound[1],
         client_cert,
         client_key: client_key_path,
         credentials: format!(
@@ -608,9 +607,13 @@ fn dual_fixture(tag: &str) -> DualFixture {
 // ── Roster reload fixture ────────────────────────────────────────────
 
 /// Render a server configuration file with the given roster entries.
-fn server_config_file(cert: &Path, key: &Path, port: u16, clients: &[(&str, &str)]) -> String {
+///
+/// The listen address is `127.0.0.1:0`; the server reports the port it took.
+/// Only the roster is reloaded, so rewriting this file leaves the bound socket
+/// alone and the port stays valid across a reload.
+fn server_config_file(cert: &Path, key: &Path, clients: &[(&str, &str)]) -> String {
     let mut text = format!(
-        "[server]\nlisten_addr = \"127.0.0.1:{port}\"\nshards = 1\n\n\
+        "[server]\nlisten_addr = \"127.0.0.1:0\"\nshards = 1\n\n\
          [tls]\ncert_path = \"{}\"\nkey_path = \"{}\"\n\n\
          [auth]\nenabled = true\nmode = \"client_cert\"\n\n\
          [tcp_proxy]\nenabled = false\n\n[udp_proxy]\nenabled = false\n\n\
@@ -625,6 +628,36 @@ fn server_config_file(cert: &Path, key: &Path, port: u16, clients: &[(&str, &str
         ));
     }
     text
+}
+
+/// Start a reloadable server and return the addresses it bound.
+///
+/// Separate from [`spawn_server`] because these tests need the `SIGHUP` handler,
+/// which `run` installs after `bind` returns — so the caller still has to give
+/// it a moment before raising one.
+fn spawn_reloadable_server(config: ServerConfig, reload_path: PathBuf) -> Vec<SocketAddr> {
+    let (bound_tx, bound_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let mut server = Server::bind_with_reload(config, Some(reload_path))
+                .await
+                .expect("server failed to bind");
+            let _ = bound_tx.send(server.listen_addrs());
+            let _ = server.run().await;
+        });
+    });
+
+    let bound = bound_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("server did not report its listen addresses");
+    // Bound is not the same as ready to reload: `run` installs the SIGHUP
+    // handler, and a signal raised before that would be the default action.
+    std::thread::sleep(Duration::from_millis(600));
+    bound
 }
 
 /// Ask this process to reload, the way an operator would.
@@ -670,14 +703,12 @@ fn revoked_client_is_disconnected_on_reload_while_others_keep_running() {
         &self_signed(&keeper_key, None),
     );
 
-    let port = free_port();
     let config_path = dir.path().join("masque.toml");
     std::fs::write(
         &config_path,
         server_config_file(
             &cert_path,
             &key_path,
-            port,
             &[
                 ("doomed", &public_key_b64(&doomed_key)),
                 ("keeper", &public_key_b64(&keeper_key)),
@@ -688,23 +719,8 @@ fn revoked_client_is_disconnected_on_reload_while_others_keep_running() {
 
     let config =
         masque::config::parse_toml(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
-    let reload_path = config_path.clone();
-    std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.block_on(async move {
-            let mut server = Server::bind_with_reload(config, Some(reload_path))
-                .await
-                .expect("server failed to bind");
-            let _ = server.run().await;
-        });
-    });
-    // Let the server bind and install its signal handler before raising one.
-    std::thread::sleep(Duration::from_millis(600));
+    let peer = spawn_reloadable_server(config, config_path.clone())[0];
 
-    let peer = SocketAddr::from(([127, 0, 0, 1], port));
     let mut doomed = Client::connect(peer, &doomed_cert, &doomed_key_path).unwrap();
     doomed.handshake(Duration::from_secs(5)).unwrap();
     doomed.init_h3().unwrap();
@@ -733,7 +749,6 @@ fn revoked_client_is_disconnected_on_reload_while_others_keep_running() {
         server_config_file(
             &cert_path,
             &key_path,
-            port,
             &[("keeper", &public_key_b64(&keeper_key))],
         ),
     )
@@ -775,33 +790,17 @@ fn a_broken_reload_keeps_the_previous_roster() {
         &self_signed(&client_key, None),
     );
 
-    let port = free_port();
     let config_path = dir.path().join("masque.toml");
     let good = server_config_file(
         &cert_path,
         &key_path,
-        port,
         &[("laptop", &public_key_b64(&client_key))],
     );
     std::fs::write(&config_path, &good).unwrap();
 
     let config = masque::config::parse_toml(&good).unwrap();
-    let reload_path = config_path.clone();
-    std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.block_on(async move {
-            let mut server = Server::bind_with_reload(config, Some(reload_path))
-                .await
-                .expect("server failed to bind");
-            let _ = server.run().await;
-        });
-    });
-    std::thread::sleep(Duration::from_millis(600));
+    let peer = spawn_reloadable_server(config, config_path.clone())[0];
 
-    let peer = SocketAddr::from(([127, 0, 0, 1], port));
     let mut client = Client::connect(peer, &client_cert, &client_key_path).unwrap();
     client.handshake(Duration::from_secs(5)).unwrap();
     client.init_h3().unwrap();
@@ -816,7 +815,7 @@ fn a_broken_reload_keeps_the_previous_roster() {
     // An unparseable public key: the roster must be rejected as a whole.
     std::fs::write(
         &config_path,
-        server_config_file(&cert_path, &key_path, port, &[("laptop", "!!not base64!!")]),
+        server_config_file(&cert_path, &key_path, &[("laptop", "!!not base64!!")]),
     )
     .unwrap();
     raise_sighup();
@@ -1166,11 +1165,10 @@ fn exhausted_address_pool_returns_503_instead_of_an_early_200() {
         &self_signed(&second_key, None),
     );
 
-    let port = free_port();
     let mut config = server_config(
         server_cert,
         server_key_path,
-        port,
+        ephemeral_addr(),
         vec![
             ClientEntry {
                 name: "first".into(),
@@ -1189,9 +1187,7 @@ fn exhausted_address_pool_returns_503_instead_of_an_early_200() {
     // network=.0, TUN gateway=.1, and the sole client address=.2.
     config.ip_proxy.ipv4_pool = "10.89.0.0/30".into();
     config.ip_proxy.ipv6_pool.clear();
-    spawn_server(config);
-    let peer = SocketAddr::from(([127, 0, 0, 1], port));
-    std::thread::sleep(Duration::from_millis(300));
+    let peer = spawn_server(config)[0];
 
     let mut first = Client::connect(peer, &first_cert, &first_key_path).unwrap();
     first.handshake(Duration::from_secs(5)).unwrap();

--- a/tests/e2e/masque-e2e.toml
+++ b/tests/e2e/masque-e2e.toml
@@ -1,11 +1,11 @@
-[server]
-listen_addr = "0.0.0.0:4433"
-
 [tls]
 cert_path = "/certs/server.crt"
 key_path = "/certs/server.key"
 
-[auth]
+[[listeners]]
+listen_addr = "0.0.0.0:4433"
+
+[listeners.auth]
 enabled = true
 username = "test"
 password_hash = "$argon2id$v=19$m=19456,t=2,p=1$1xNVXhqKU7jJ6cqTBJKphQ$GXXAINVTW1qhloFtN1IR8lSr7pI7QEY79fq4K6d8scQ"

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -93,21 +93,21 @@ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
 write_config() {
     cc_algorithm=$1
     cat >"$CONFIG_PATH" <<EOF
-[server]
-listen_addr = "127.0.0.1:8449"
-shards = 1
-
 [tls]
 cert_path = "/etc/masque/certs/server.crt"
 key_path = "/etc/masque/certs/server.key"
-
-[auth]
-enabled = false
 
 [quic]
 cc_algorithm = "$cc_algorithm"
 
 [ip_proxy]
+enabled = false
+
+[[listeners]]
+listen_addr = "127.0.0.1:8449"
+shards = 1
+
+[listeners.auth]
 enabled = false
 EOF
     chmod 0640 "$CONFIG_PATH"
@@ -152,11 +152,11 @@ grep -q '^listen_addr = "0.0.0.0:8449"$' "$CONFIG_PATH" ||
     die "the Basic listener did not take MASQUE_LISTEN_PORT"
 grep -q '^listen_addr = "0.0.0.0:8450"$' "$CONFIG_PATH" ||
     die "the certificate listener did not take MASQUE_CERT_LISTEN_PORT"
-# [[listeners]] names the sockets, so [server] must not still name one.
+# [server] contains only process-wide limits; listeners name every socket.
 grep -q '^\[server\]$' "$CONFIG_PATH" ||
     die "the [server] section disappeared from the dual configuration"
 ! grep -q '^listen_addr = "0.0.0.0:443"$' "$CONFIG_PATH" ||
-    die "the ignored [server].listen_addr was left in the dual configuration"
+    die "the template listener port was not replaced"
 grep -q '^\[\[clients\]\]$' "$CONFIG_PATH" ||
     die "dual mode did not enroll the first certificate client"
 [ -s "$DUAL_CLIENT_JSON" ] || die "dual mode did not write the client JSON"
@@ -168,10 +168,6 @@ grep -q '^listener 0.0.0.0:8449 auth=basic shards=1$' "$TEST_TMP/dual-check.log"
     die "the Basic listener was not reported by check-config"
 grep -q '^listener 0.0.0.0:8450 auth=client_cert shards=1$' "$TEST_TMP/dual-check.log" ||
     die "the certificate listener was not reported by check-config"
-# Nothing should warn about settings the rendered file no longer contains.
-! grep -q 'are ignored because' "$TEST_TMP/dual-check.log" ||
-    die "the dual configuration left ignored [server] settings behind"
-
 # A reinstall over it is an upgrade, and must report both modes rather than one.
 MASQUE_START_SERVICE=0 "$PACKAGE_DIR/install.sh" \
     >"$TEST_TMP/dual-upgrade.log" 2>&1 ||

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -130,6 +130,57 @@ assert_sha_unchanged() {
     [ "$actual" = "$expected" ] || die "$path changed unexpectedly"
 }
 
+# A fresh dual installation writes a two-listener configuration and provisions
+# both authentication modes. This runs first, while the runner still has no
+# configuration; the upgrade cases below overwrite everything it leaves behind.
+DUAL_CLIENT_JSON=$TEST_TMP/dual-client.json
+MASQUE_AUTH_MODE=dual \
+    MASQUE_AUTH_USERNAME=proxy-user \
+    MASQUE_AUTH_PASSWORD=a-strong-password \
+    MASQUE_LISTEN_PORT=8449 \
+    MASQUE_CERT_LISTEN_PORT=8450 \
+    MASQUE_CLIENT_NAME=laptop \
+    MASQUE_CLIENT_ENDPOINT=203.0.113.9:8450 \
+    MASQUE_CLIENT_CONFIG_OUT="$DUAL_CLIENT_JSON" \
+    MASQUE_START_SERVICE=0 \
+    "$PACKAGE_DIR/install.sh" >"$TEST_TMP/dual.log" 2>&1 ||
+    die "fresh dual installation failed; see $TEST_TMP/dual.log"
+
+[ "$(grep -c '^\[\[listeners\]\]$' "$CONFIG_PATH")" -eq 2 ] ||
+    die "dual mode did not write two listeners"
+grep -q '^listen_addr = "0.0.0.0:8449"$' "$CONFIG_PATH" ||
+    die "the Basic listener did not take MASQUE_LISTEN_PORT"
+grep -q '^listen_addr = "0.0.0.0:8450"$' "$CONFIG_PATH" ||
+    die "the certificate listener did not take MASQUE_CERT_LISTEN_PORT"
+# [[listeners]] names the sockets, so [server] must not still name one.
+grep -q '^\[server\]$' "$CONFIG_PATH" ||
+    die "the [server] section disappeared from the dual configuration"
+! grep -q '^listen_addr = "0.0.0.0:443"$' "$CONFIG_PATH" ||
+    die "the ignored [server].listen_addr was left in the dual configuration"
+grep -q '^\[\[clients\]\]$' "$CONFIG_PATH" ||
+    die "dual mode did not enroll the first certificate client"
+[ -s "$DUAL_CLIENT_JSON" ] || die "dual mode did not write the client JSON"
+
+# The server itself must agree about what those listeners are.
+"$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/dual-check.log" 2>&1 ||
+    die "the dual configuration failed check-config"
+grep -q '^listener 0.0.0.0:8449 auth=basic shards=1$' "$TEST_TMP/dual-check.log" ||
+    die "the Basic listener was not reported by check-config"
+grep -q '^listener 0.0.0.0:8450 auth=client_cert shards=1$' "$TEST_TMP/dual-check.log" ||
+    die "the certificate listener was not reported by check-config"
+# Nothing should warn about settings the rendered file no longer contains.
+! grep -q 'are ignored because' "$TEST_TMP/dual-check.log" ||
+    die "the dual configuration left ignored [server] settings behind"
+
+# A reinstall over it is an upgrade, and must report both modes rather than one.
+MASQUE_START_SERVICE=0 "$PACKAGE_DIR/install.sh" \
+    >"$TEST_TMP/dual-upgrade.log" 2>&1 ||
+    die "upgrading over the dual configuration failed"
+grep -q 'Authentication: basic + client_cert' "$TEST_TMP/dual-upgrade.log" ||
+    die "the upgrade summary did not report both authentication modes"
+
+rm -f -- "$CONFIG_PATH"
+
 # An incompatible existing configuration must fail before replacement.
 write_old_installation
 write_config not-a-controller


### PR DESCRIPTION
## Summary

- serve multiple explicit `[[listeners]]` entries from one process
- let each listener select HTTP Basic or TLS client-certificate authentication while sharing TLS files, proxy policies, the client roster, TUN state, and address pools
- make the 0.3 configuration intentionally reject the legacy top-level `[auth]`, `[server].listen_addr`, and `[server].shards` format; installers validate but do not migrate old configurations
- harden listener address conflict detection, ephemeral-port binding, sharding limits, reload behavior, and authentication isolation
- document multi-listener and dual-auth installation in the README and operator documentation

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.88.0 test --workspace --all-targets --locked --no-run`
- `shellcheck install-latest.sh deploy/install.sh tests/install-upgrade.sh scripts/network-bench.sh`
- Linux multi-listener/multi-shard integration test in Rust 1.88 Docker

## Breaking change

Existing 0.2 configurations must be rewritten manually to use explicit `[[listeners]]` and `[listeners.auth]` tables before upgrading. The installer deliberately does not migrate them.