### PR TITLE
feat: add listener management command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.3.1 - 2026-08-19
+
+### Added
+
+- `masque-server add-listener` safely appends another Basic,
+  client-certificate, or trusted-network listener to a deployed configuration.
+  It supports interactive and unattended use, validates the complete result,
+  probes the new UDP address, preserves comments and file ownership, and
+  refuses conflicting authentication arguments.
+- The Linux installer now points existing installations to `add-listener`, and
+  its integration test verifies that a listener added after installation
+  survives a later upgrade unchanged.
+
+### Fixed
+
+- Configuration edits use a stable advisory lock and a final content check so
+  concurrent edits are refused instead of silently overwritten.
+- Generated Basic credentials are delivered and flushed before their hash is
+  committed, while `--dry-run` refuses to create an unrecoverable password.
+- Interactive password entry fails closed if terminal echo cannot be disabled,
+  and the post-edit instruction names the installed `masque.service` unit.
+
 ## 0.3.0 - 2026-08-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tun-rs = { version = "2", features = ["async_tokio"] }
 zeroize = "1"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+# Linux uses this for the packet path (recvmmsg, GSO/GRO, TUN offload); every
+# Unix uses it to turn terminal echo off while `add-listener` reads a password
+# and to keep an edited configuration file's owner.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ its own `[[listeners]]` entry in the same process; see
 [Authentication](docs/configuration.md#authentication) and
 [Listeners](docs/configuration.md#listeners).
 
+A second listener can be added to a deployed configuration without editing TOML
+by hand. This prompts for the address, the authentication mode, and any
+credentials, validates the merged file the way `check-config` does, test-binds
+the new address, and leaves the file untouched if anything is wrong:
+
+```sh
+masque-server --config /etc/masque/masque.toml add-listener
+```
+
+Every value is also available as a flag for provisioning scripts. See
+[Adding a listener](docs/configuration.md#adding-a-listener). A new socket is
+bound at startup, so open its UDP port, restart the service, and confirm it came
+up.
+
 ## One-command Linux install
 
 On Linux x86_64, download, verify, and install the latest stable release with:

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -135,6 +135,11 @@ ipv6_pool = "fd00:abcd::/64"
 
 # ── Additional listener ─────────────────────────────────────────────
 #
+# `masque-server --config /etc/masque/masque.toml add-listener` appends one of
+# these for you: it asks for the address, the authentication mode, and any
+# credentials, validates the result the way check-config does, and leaves this
+# file untouched if the new listener would not start.
+#
 # One socket can serve only one authentication mode: auth.mode decides which
 # TLS context is built before clients connect. Add another [[listeners]] entry
 # to serve another mode in the same process. Everything behind the sockets stays

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -660,3 +660,11 @@ elif [ "$START_REQUESTED" -eq 0 ]; then
     echo "Start the service with: systemctl start masque"
 fi
 echo "Review $CONFIG_PATH, especially the proxy allow/deny policy."
+
+# Listeners are written only for a fresh installation; an upgrade keeps the
+# existing file. Adding one later is a separate, deliberate command, so name it
+# here rather than leaving hand-edited TOML as the discoverable option.
+echo
+echo "To serve another authentication mode, or another port, add a listener:"
+echo "  masque-server --config $CONFIG_PATH add-listener"
+echo "Then open its UDP port in the firewall and run: systemctl restart masque"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ file is the canonical deployable example and is tested by the release flow.
 masque-server [OPTIONS]
 masque-server hash-password
 masque-server --config <PATH> check-config
+masque-server --config <PATH> add-listener [OPTIONS]
 masque-server enroll-client [OPTIONS] --name <NAME> --endpoint <ADDR:PORT>
 
   -c, --config <PATH>       Config file [default: masque.toml]
@@ -28,6 +29,9 @@ masque-server enroll-client [OPTIONS] --name <NAME> --endpoint <ADDR:PORT>
 settings, client roster, and address pools without binding the UDP listener or
 creating a TUN device. It is suitable for upgrade preflight, but cannot detect
 runtime conditions such as an occupied port or unavailable kernel device.
+
+`add-listener` appends a `[[listeners]]` block to the configuration file, and is
+described under [Adding a listener](#adding-a-listener).
 
 `hash-password` reads a password on stdin and prints an Argon2id hash for
 `listeners.auth.password_hash`. `enroll-client` generates a client key pair for
@@ -363,6 +367,95 @@ and produce a startup warning.
 logs a warning. This is only
 appropriate in an isolated test environment or behind another trusted
 authentication boundary.
+
+### Adding a listener
+
+`add-listener` appends one `[[listeners]]` block to an existing configuration
+file. Run without flags it prompts for everything, defaulting to a free port and
+to whichever authentication mode the file does not serve yet:
+
+```sh
+masque-server --config /etc/masque/masque.toml add-listener
+```
+
+```
+Listen address (ip:port) [0.0.0.0:4443]:
+Authentication mode (basic | client_cert) [client_cert]:
+Event loops for this listener (shards) [1]:
+```
+
+A Basic listener also asks for a username and a password. The password is read
+without echo and confirmed; leaving it empty generates a strong one and prints
+it once. Only the Argon2id hash is written to the file.
+
+Every value can be given as a flag instead, which is also what a provisioning
+script must do — prompting requires a terminal, and without one a missing value
+is an error rather than a hang:
+
+```sh
+masque-server --config /etc/masque/masque.toml add-listener \
+    --listen-addr 0.0.0.0:4443 --mode client-cert --yes
+```
+
+```text
+add-listener options:
+      --listen-addr <ADDR:PORT>  Address for the new socket
+      --mode <MODE>         basic | client-cert
+      --shards <N>          Event loops for this listener [default: 1]
+      --username <NAME>     Basic username
+      --password-hash <PHC>  Argon2id hash, as printed by hash-password
+      --password-stdin      Read the password from stdin and hash it here
+      --disable-auth        Write enabled = false (trusted networks only)
+      --no-bind-check       Do not test-bind the new address
+      --dry-run             Print the block; leave the file unchanged
+  -y, --yes                 Skip the confirmation prompt
+```
+
+Combinations that would be ignored are refused rather than dropped:
+`--username`, `--password-hash`, and `--password-stdin` apply to `--mode basic`
+only, and `--disable-auth` cannot be combined with `--mode`, since a listener
+that demands nothing has no mode to record.
+
+#### What is checked, and what is not
+
+Before writing, the merged file is parsed and put through the same validation
+`check-config` runs — address overlap with an existing listener, credentials,
+shard counts, the client roster behind a certificate listener — and the new
+address is then bound once to see that nothing else holds it. If any of it
+fails, the error says so and the file is left byte for byte as it was.
+
+The bind test exists because `check-config` is side-effect-free and therefore
+says nothing about an occupied port, while the server binds every listener at
+startup and exits if one fails: a bad address would take down the listeners that
+work today at the next restart. It is a probe of the moment it runs, not a
+reservation, so **restart the server and confirm it came up**; nothing here can
+promise a start that happens minutes later. Use `--no-bind-check` when the
+address becomes available only later — a floating address, or a service running
+in another network namespace.
+
+The file is replaced atomically, keeping its mode and owner, so a password hash
+is never exposed and the service does not lose read access. Comments survive:
+the block is appended as text rather than the file being regenerated.
+
+Concurrent edits are refused, never merged silently. One run holds an advisory
+lock (`.masque.toml.lock` beside the configuration) so a second one stops
+immediately, and the file is compared against what was read before the
+replacement, so a change made by anything else — an editor, a script appending
+`[[clients]]` — aborts the edit and asks for a retry instead of being discarded.
+
+Two ordering rules follow from the validation being real:
+
+- A `client_cert` listener needs at least one `[[clients]]` entry, because the
+  server refuses to start without one. Run
+  [`enroll-client`](#enrolling-a-client) and append its `[[clients]]` block
+  first.
+- A file whose only listener uses `shards = 0` (one per core) has to be given an
+  explicit count first; that setting has no meaning once a second listener
+  exists.
+
+A new socket is bound at startup, so restart the server afterwards, and open the
+new UDP port in the firewall. `SIGHUP` reloads the `[[clients]]` roster only —
+it never adds, removes, or rebinds a listener.
 
 ## QUIC and UDP
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,7 +274,7 @@ the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
-configuration is compatible with masque-server 0.3.0: /etc/masque/masque.toml
+configuration is compatible with masque-server 0.3.1: /etc/masque/masque.toml
 listener 0.0.0.0:443 auth=basic shards=1
 listener 0.0.0.0:4443 auth=client_cert shards=1
 ```
@@ -416,6 +416,10 @@ Combinations that would be ignored are refused rather than dropped:
 only, and `--disable-auth` cannot be combined with `--mode`, since a listener
 that demands nothing has no mode to record.
 
+A Basic `--dry-run` must be given a password through `--password-stdin` or an
+existing hash through `--password-hash`. It never generates a password whose
+only recoverable copy would be omitted from the dry-run output.
+
 #### What is checked, and what is not
 
 Before writing, the merged file is parsed and put through the same validation
@@ -437,11 +441,13 @@ The file is replaced atomically, keeping its mode and owner, so a password hash
 is never exposed and the service does not lose read access. Comments survive:
 the block is appended as text rather than the file being regenerated.
 
-Concurrent edits are refused, never merged silently. One run holds an advisory
-lock (`.masque.toml.lock` beside the configuration) so a second one stops
-immediately, and the file is compared against what was read before the
-replacement, so a change made by anything else — an editor, a script appending
-`[[clients]]` — aborts the edit and asks for a retry instead of being discarded.
+Concurrent `add-listener` edits are refused. One run holds an advisory lock
+(`.masque.toml.lock` beside the configuration) so a second one stops
+immediately. A final content comparison immediately before replacement also
+catches normal editor and script changes that do not honour the lock. No
+portable file API can exclude an uncooperative writer racing the final rename,
+so configuration-management tools should take the same lock or avoid writing
+the file while this command runs.
 
 Two ordering rules follow from the validation being real:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,7 +90,7 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
     sh
 ```
 
-`MASQUE_VERSION=0.3.0` selects `v0.3.0`. This is also how to install a
+`MASQUE_VERSION=0.3.1` selects `v0.3.1`. This is also how to install a
 prerelease explicitly; automatic resolution deliberately chooses only GitHub's
 latest stable release. Authentication, listen, TLS-source, and client
 provisioning variables apply only when `/etc/masque/masque.toml` does not yet

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -195,6 +195,42 @@ Check the effective sandbox:
 systemd-analyze security masque.service
 ```
 
+## Add a listener after installation
+
+The installer writes listeners only for a fresh installation; an upgrade keeps
+the existing file untouched. To add one to a deployed server — a second socket
+for the authentication mode the first does not serve, for example — use:
+
+```sh
+sudo masque-server --config /etc/masque/masque.toml add-listener
+sudo systemctl restart masque
+```
+
+It prompts for the address, the authentication mode, and any credentials,
+validates the merged file the way the upgrade preflight does, and test-binds the
+new address; anything wrong leaves the file byte for byte unchanged. The file is
+replaced atomically with its mode and owner preserved, so the service account
+keeps its access. Flags cover every value for unattended use; see
+[Adding a listener](configuration.md#adding-a-listener).
+
+Open the new UDP port in the firewall as well — see
+[Network and firewall](#network-and-firewall). A new socket is bound at startup,
+so the restart is required; `systemctl reload` only re-reads the `[[clients]]`
+roster.
+
+The bind test describes the moment it ran, so confirm the service after the
+restart rather than assuming it:
+
+```sh
+sudo systemctl restart masque
+systemctl status masque --no-pager
+```
+
+If it failed to bind, the journal names the address, and the previous
+configuration is one `[[listeners]]` block away — remove the appended block and
+restart. Keep the usual configuration backups; this command edits in place and
+does not keep a copy.
+
 ## Upgrade
 
 For the latest stable release, rerun the bootstrap command:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,7 @@
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
 | Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth, CONNECT-IP setup, and both authentication modes served from one process |
 | Config preflight | `cargo test --test check_config` | `check-config` accepts what a server accepts, including multi-listener files |
+| Config editing | `cargo test --test add_listener` | `add-listener` writes a listener that starts, or leaves the file untouched |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
 
 ## Local tests

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -17,14 +17,25 @@ pub(crate) struct BasicAuthenticator {
     password_hash: String,
 }
 
+/// Reject a username the Basic scheme cannot carry.
+///
+/// RFC 7617 joins the username and password with a colon before base64, so a
+/// colon inside the username makes the pair ambiguous. Shared with
+/// `add-listener`, which asks for a username interactively and has to reject a
+/// bad one while the operator is still there to retype it.
+pub(crate) fn check_username(username: &str) -> anyhow::Result<()> {
+    if username.is_empty() {
+        bail!("auth.username must not be empty when authentication is enabled");
+    }
+    if username.contains(':') || username.chars().any(char::is_control) {
+        bail!("auth.username must not contain ':' or control characters");
+    }
+    Ok(())
+}
+
 impl BasicAuthenticator {
     pub(crate) fn new(username: &str, password_hash: &str) -> anyhow::Result<Self> {
-        if username.is_empty() {
-            bail!("auth.username must not be empty when authentication is enabled");
-        }
-        if username.contains(':') || username.chars().any(char::is_control) {
-            bail!("auth.username must not contain ':' or control characters");
-        }
+        check_username(username)?;
 
         let parsed = PasswordHash::new(password_hash)
             .context("auth.password_hash is not a valid PHC password hash")?;

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -23,9 +23,10 @@
 //!
 //! Concurrency is handled twice over, because losing another operator's edit is
 //! silent and unrecoverable: an advisory lock keeps two of these commands off
-//! one file, and the file is compared against what was read before it is
-//! replaced, so an edit made by anything else — an editor, a script appending
-//! `[[clients]]` — is detected rather than overwritten.
+//! one file, and the file is compared against what was read immediately before
+//! it is replaced. The comparison catches ordinary editors and scripts that do
+//! not honour the lock; like every portable compare-then-rename sequence, it
+//! cannot control an uncooperative writer racing the final system call.
 
 use std::fs::OpenOptions;
 use std::io::{IsTerminal, Write as _};
@@ -223,6 +224,13 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         }
     }
 
+    // Deliver the only copy before committing the hash. In particular, a
+    // broken pipe or full redirected output must leave the configuration
+    // untouched instead of installing a credential the operator never saw.
+    if let Some(password) = generated_password.as_ref() {
+        print_generated_password(&listener.auth.username, password)?;
+    }
+
     write_in_place(config_path, &text, &merged)?;
 
     println!(
@@ -230,14 +238,6 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         auth_label(&listener.auth),
         config_path.display()
     );
-    if let Some(password) = generated_password {
-        println!(
-            "generated password for {}: {}",
-            listener.auth.username,
-            password.as_str()
-        );
-        println!("this password is not stored anywhere; copy it now");
-    }
     // A new socket is bound at startup, so unlike a roster change this cannot
     // be picked up by the running process. The unit the installer writes is
     // `masque`, not the program name.
@@ -252,6 +252,24 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         );
     }
 
+    Ok(())
+}
+
+/// Deliver a generated credential and make output failure observable before
+/// its hash is committed to the configuration.
+fn print_generated_password(username: &str, password: &str) -> anyhow::Result<()> {
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    writeln!(output, "generated password for {username}: {password}")
+        .context("failed to print the generated password; configuration is unchanged")?;
+    writeln!(
+        output,
+        "copy this password now; the configuration has not been written yet"
+    )
+    .context("failed to print the generated password notice; configuration is unchanged")?;
+    output
+        .flush()
+        .context("failed to flush the generated password; configuration is unchanged")?;
     Ok(())
 }
 
@@ -400,10 +418,20 @@ fn resolve_password(
     }
 
     if interactive {
-        let password = prompt_password()?;
+        let password = prompt_password(!request.dry_run)?;
         if let Some(password) = password {
             return Ok((auth::hash_password(password.as_bytes())?, None));
         }
+    }
+
+    // A dry run returns before generated credentials are delivered, so
+    // inventing one here would emit a hash without the only password copy.
+    if request.dry_run {
+        bail!(
+            "--dry-run cannot generate a Basic password because its output would contain a \
+             hash without the only copy of the password; provide --password-hash or \
+             --password-stdin"
+        );
     }
 
     // Nothing was supplied. A generated password is the safe default — the
@@ -532,10 +560,23 @@ fn prompt_username() -> anyhow::Result<String> {
     })
 }
 
-/// Read a password twice without echoing it, or `None` to generate one.
-fn prompt_password() -> anyhow::Result<Option<Zeroizing<String>>> {
-    let password = read_hidden_line("Password (empty to generate a strong one): ")?;
+/// Read a password twice without echoing it, or `None` when generation is
+/// allowed and the operator leaves it empty.
+fn prompt_password(allow_generate: bool) -> anyhow::Result<Option<Zeroizing<String>>> {
+    let prompt = if allow_generate {
+        "Password (empty to generate a strong one): "
+    } else {
+        "Password (--dry-run requires an explicit password): "
+    };
+    let password = read_hidden_line(prompt)?;
     if password.is_empty() {
+        if !allow_generate {
+            bail!(
+                "--dry-run cannot generate a Basic password because its output would contain a \
+                 hash without the only copy of the password; provide --password-hash or \
+                 --password-stdin"
+            );
+        }
         return Ok(None);
     }
     check_password(&password)?;
@@ -595,12 +636,26 @@ fn read_hidden_line(prompt: &str) -> anyhow::Result<Zeroizing<String>> {
     struct EchoOff {
         fd: i32,
         saved: libc::termios,
+        active: bool,
+    }
+
+    impl EchoOff {
+        fn restore(&mut self) -> std::io::Result<()> {
+            if !self.active {
+                return Ok(());
+            }
+            // SAFETY: `saved` was filled by tcgetattr on this descriptor.
+            if unsafe { libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.saved) } != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            self.active = false;
+            Ok(())
+        }
     }
 
     impl Drop for EchoOff {
         fn drop(&mut self) {
-            // SAFETY: `saved` was filled by tcgetattr on this same descriptor.
-            unsafe { libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.saved) };
+            let _ = self.restore();
         }
     }
 
@@ -610,22 +665,33 @@ fn read_hidden_line(prompt: &str) -> anyhow::Result<Zeroizing<String>> {
     let fd = std::io::stdin().as_raw_fd();
     let mut saved = std::mem::MaybeUninit::<libc::termios>::uninit();
     // SAFETY: writes a termios into our own uninitialised storage.
-    let _guard = if unsafe { libc::tcgetattr(fd, saved.as_mut_ptr()) } == 0 {
-        // SAFETY: tcgetattr returned success, so the value is initialised.
-        let saved = unsafe { saved.assume_init() };
-        let mut quiet = saved;
-        quiet.c_lflag &= !libc::ECHO;
-        // SAFETY: `quiet` is a complete termios for this descriptor.
-        unsafe { libc::tcsetattr(fd, libc::TCSAFLUSH, &quiet) };
-        Some(EchoOff { fd, saved })
-    } else {
-        None
+    if unsafe { libc::tcgetattr(fd, saved.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error()).context(
+            "failed to inspect terminal settings; refusing to read a password that might echo",
+        );
+    }
+    // SAFETY: tcgetattr returned success, so the value is initialised.
+    let saved = unsafe { saved.assume_init() };
+    let mut quiet = saved;
+    quiet.c_lflag &= !libc::ECHO;
+    // SAFETY: `quiet` is a complete termios for this descriptor.
+    if unsafe { libc::tcsetattr(fd, libc::TCSAFLUSH, &quiet) } != 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to disable terminal echo; no password was read");
+    }
+    let mut guard = EchoOff {
+        fd,
+        saved,
+        active: true,
     };
 
     let mut line = Zeroizing::new(String::new());
     if std::io::stdin().read_line(&mut line)? == 0 {
         bail!("standard input ended before the password was entered; nothing was written");
     }
+    guard
+        .restore()
+        .context("failed to restore terminal echo; configuration is unchanged")?;
     // The newline the operator typed was not echoed, so the next output would
     // otherwise continue on the prompt's line.
     eprintln!();
@@ -633,14 +699,11 @@ fn read_hidden_line(prompt: &str) -> anyhow::Result<Zeroizing<String>> {
 }
 
 #[cfg(not(unix))]
-fn read_hidden_line(prompt: &str) -> anyhow::Result<Zeroizing<String>> {
-    eprint!("{prompt}");
-    std::io::stderr().flush()?;
-    let mut line = Zeroizing::new(String::new());
-    if std::io::stdin().read_line(&mut line)? == 0 {
-        bail!("standard input ended before the password was entered; nothing was written");
-    }
-    Ok(Zeroizing::new(trim_newline(&line).to_owned()))
+fn read_hidden_line(_prompt: &str) -> anyhow::Result<Zeroizing<String>> {
+    bail!(
+        "hidden password input is unavailable on this platform; use --password-stdin or \
+         --password-hash so the password is not echoed"
+    )
 }
 
 // ── Writing ───────────────────────────────────────────────────────────
@@ -672,16 +735,6 @@ fn write_in_place(path: &Path, expected: &str, contents: &str) -> anyhow::Result
     let metadata = std::fs::metadata(&path)
         .with_context(|| format!("failed to inspect {}", path.display()))?;
 
-    let current = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to re-read {}", path.display()))?;
-    if current != expected {
-        bail!(
-            "{} changed while this edit was being prepared, and applying it would discard \
-             that change; nothing was written, so run the command again",
-            path.display()
-        );
-    }
-
     let temp = TempPath(dir.join(format!(".{name}.new.{}", std::process::id())));
 
     let mut options = OpenOptions::new();
@@ -706,6 +759,20 @@ fn write_in_place(path: &Path, expected: &str, contents: &str) -> anyhow::Result
     file.sync_all()
         .with_context(|| format!("failed to sync {}", temp.0.display()))?;
     drop(file);
+
+    // Keep this comparison after the new file is completely prepared and as
+    // close to rename as portable APIs allow. Checking before the potentially
+    // slow write and fsync would leave a much wider window in which an editor
+    // could make a change that the rename then silently discards.
+    let current = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to re-read {}", path.display()))?;
+    if current != expected {
+        bail!(
+            "{} changed while this edit was being prepared, and applying it would discard \
+             that change; nothing was written, so run the command again",
+            path.display()
+        );
+    }
 
     std::fs::rename(&temp.0, &path)
         .with_context(|| format!("failed to replace {}", path.display()))?;

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -1,0 +1,1092 @@
+//! Edits to an existing configuration file.
+//!
+//! Adding a listener is the one routine change to a deployed configuration
+//! that has to be right the first time. A second socket is normally added to
+//! serve a second authentication mode, and every way of getting it wrong — an
+//! address that overlaps the running listener, a Basic listener without
+//! credentials, a certificate listener with an empty roster — shows up as a
+//! server that refuses to start. By then the listener that used to work is down
+//! too, because both live in one process.
+//!
+//! So the edit is validated before anything is written: the merged text is
+//! parsed, run through the same [`validate_config`] the server and
+//! `check-config` use, and the new address is probed by binding it. What that
+//! rules out is everything a configuration can be wrong about, plus the one
+//! runtime condition that is worth catching here — an address already in use.
+//! It is not a promise that the next start succeeds: the probe describes this
+//! moment, and the port can be taken, or an interface removed, between the edit
+//! and the restart. Verify the service after restarting it.
+//!
+//! The edit is a text append rather than a re-serialisation of the parsed
+//! model. A deployed `masque.toml` is mostly comments explaining the tuning
+//! knobs, and a round trip through `toml::to_string` would delete all of them.
+//!
+//! Concurrency is handled twice over, because losing another operator's edit is
+//! silent and unrecoverable: an advisory lock keeps two of these commands off
+//! one file, and the file is compared against what was read before it is
+//! replaced, so an edit made by anything else — an editor, a script appending
+//! `[[clients]]` — is detected rather than overwritten.
+
+use std::fs::OpenOptions;
+use std::io::{IsTerminal, Write as _};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail, ensure};
+use zeroize::Zeroizing;
+
+use crate::auth;
+use crate::config::{self, AuthMode, AuthSection, ListenerSection, ServerConfig};
+use crate::enroll::toml_string;
+use crate::server::validate_config;
+
+/// Bytes of entropy in a generated password, matching the installer's.
+const GENERATED_PASSWORD_BYTES: usize = 24;
+
+/// The first port offered for a second listener, when the operator has not
+/// named one. Only a starting point: the suggestion walks upward past every
+/// port the file already uses.
+const SUGGESTED_PORT: u16 = 4443;
+
+/// What the operator asked for on the command line.
+///
+/// Every optional field is prompted for when standard input is a terminal, and
+/// required otherwise, so one code path serves both an interactive operator and
+/// a provisioning script.
+#[derive(Debug, Default)]
+pub struct AddListener {
+    pub listen_addr: Option<SocketAddr>,
+    pub mode: Option<AuthMode>,
+    pub shards: Option<usize>,
+    pub username: Option<String>,
+    pub password_hash: Option<String>,
+    /// Read the password from standard input and hash it.
+    pub password_stdin: bool,
+    /// Write `enabled = false`, for a listener on a trusted network.
+    pub disable_auth: bool,
+    /// Do not try to bind the new address before writing it.
+    pub no_bind_check: bool,
+    /// Print the block that would be appended and leave the file alone.
+    pub dry_run: bool,
+    /// Skip the confirmation prompt.
+    pub assume_yes: bool,
+}
+
+/// Append one `[[listeners]]` block to `config_path`.
+///
+/// The configuration is re-read here rather than taken from the caller, and
+/// `--cert` / `--key` overrides are deliberately not applied: what is validated
+/// has to be the file exactly as the service will read it.
+pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<()> {
+    // Held until this function returns, so a prompt that waits for an operator
+    // cannot overlap with a second run of this command. A dry run changes
+    // nothing and takes no lock, so it still works on a read-only copy.
+    let _lock = (!request.dry_run)
+        .then(|| EditLock::acquire(config_path))
+        .transpose()?;
+
+    let text = std::fs::read_to_string(config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let config = config::parse_toml(&text)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    // A file that is already invalid cannot say whether the new listener is the
+    // thing that broke it, and appending to it would produce a file that still
+    // does not start.
+    validate_config(&config).with_context(|| {
+        format!(
+            "{} is not a valid configuration on its own, so a new listener cannot be \
+             validated against it; nothing was written",
+            config_path.display()
+        )
+    })?;
+
+    // A piped password owns standard input, so there is no terminal left to
+    // prompt on and every other value has to come from a flag.
+    let interactive = std::io::stdin().is_terminal() && !request.password_stdin;
+
+    let listen_addr = match request.listen_addr {
+        Some(addr) => addr,
+        None if interactive => prompt_listen_addr(&config)?,
+        None => bail!("--listen-addr is required when standard input is not a terminal"),
+    };
+
+    let mode = match request.mode {
+        Some(mode) => mode,
+        None if request.disable_auth => AuthMode::Basic,
+        None if interactive => prompt_mode(&config)?,
+        None => bail!("--mode is required when standard input is not a terminal"),
+    };
+
+    // Credentials belong to one mode. Silently dropping them would leave an
+    // operator believing a certificate listener also accepts a password.
+    if mode == AuthMode::ClientCert
+        && (request.username.is_some() || request.password_hash.is_some() || request.password_stdin)
+    {
+        bail!(
+            "--username, --password-hash, and --password-stdin apply to --mode basic; \
+             a client_cert listener authenticates against the [[clients]] roster, so \
+             enroll the client instead"
+        );
+    }
+
+    let shards = match request.shards {
+        Some(shards) => shards,
+        None if interactive => prompt_shards()?,
+        None => 1,
+    };
+
+    let mut generated_password: Option<Zeroizing<String>> = None;
+    let auth = if request.disable_auth {
+        AuthSection {
+            enabled: false,
+            mode,
+            username: String::new(),
+            password_hash: String::new(),
+        }
+    } else {
+        match mode {
+            AuthMode::ClientCert => AuthSection {
+                enabled: true,
+                mode,
+                username: String::new(),
+                password_hash: String::new(),
+            },
+            AuthMode::Basic => {
+                let username = match request.username.clone() {
+                    Some(username) => {
+                        auth::check_username(&username)?;
+                        username
+                    }
+                    None if interactive => prompt_username()?,
+                    None => bail!("--username is required when standard input is not a terminal"),
+                };
+                let (password_hash, generated) = resolve_password(&request, interactive)?;
+                generated_password = generated;
+                AuthSection {
+                    enabled: true,
+                    mode,
+                    username,
+                    password_hash,
+                }
+            }
+        }
+    };
+
+    let listener = ListenerSection {
+        listen_addr,
+        shards,
+        auth,
+    };
+
+    let block = listener_toml_block(&listener);
+    let merged = append_block(&text, &block);
+    verify_merge(&config, &listener, &merged)?;
+
+    // The same check `check-config` runs, on the file as it would be after the
+    // edit: address overlap with an existing listener, a shard count that
+    // cannot be honoured, an unusable password hash, a certificate listener
+    // with no roster behind it.
+    validate_config(&config::parse_toml(&merged)?).with_context(|| {
+        format!(
+            "the new listener would not start alongside the existing ones; \
+             {} is unchanged",
+            config_path.display()
+        )
+    })?;
+
+    if !request.no_bind_check {
+        probe_listen_addr(listen_addr).with_context(|| {
+            format!(
+                "the new listener would not bind, and a listener that cannot bind stops \
+                 the whole server — including the sockets that work today; {} is unchanged \
+                 (pass --no-bind-check if the address only becomes available later)",
+                config_path.display()
+            )
+        })?;
+    }
+
+    if request.dry_run {
+        print!("{block}");
+        eprintln!("# --dry-run: {} was not modified", config_path.display());
+        return Ok(());
+    }
+
+    if interactive && !request.assume_yes {
+        eprint!(
+            "\n{block}\nAppend this listener to {}? [Y/n] ",
+            config_path.display()
+        );
+        if !read_confirmation()? {
+            eprintln!("nothing was written");
+            return Ok(());
+        }
+    }
+
+    write_in_place(config_path, &text, &merged)?;
+
+    println!(
+        "added listener {listen_addr} auth={} shards={shards} to {}",
+        auth_label(&listener.auth),
+        config_path.display()
+    );
+    if let Some(password) = generated_password {
+        println!(
+            "generated password for {}: {}",
+            listener.auth.username,
+            password.as_str()
+        );
+        println!("this password is not stored anywhere; copy it now");
+    }
+    // A new socket is bound at startup, so unlike a roster change this cannot
+    // be picked up by the running process. The unit the installer writes is
+    // `masque`, not the program name.
+    println!(
+        "restart the server to bind it (systemd: systemctl restart masque), then check \
+         that it came up; SIGHUP reloads only the [[clients]] roster"
+    );
+    if listen_addr.port() != 0 {
+        println!(
+            "the firewall has to allow UDP {} as well",
+            listen_addr.port()
+        );
+    }
+
+    Ok(())
+}
+
+/// Bind the new address once, before it is written down.
+///
+/// `validate_config` is deliberately side-effect-free and therefore silent
+/// about the one failure that hurts most here: an address something else
+/// already holds. The server binds every listener at startup and exits if one
+/// fails, so writing an occupied address turns the next restart into an outage
+/// of the listeners that were working.
+///
+/// This is a probe, not a reservation. The port is free at this instant; a
+/// service started in between can still take it.
+fn probe_listen_addr(addr: SocketAddr) -> anyhow::Result<()> {
+    // Port 0 asks the kernel for whichever port is free at startup, so there is
+    // nothing to probe and no address to be in use.
+    if addr.port() == 0 {
+        return Ok(());
+    }
+
+    // Deliberately without SO_REUSEPORT: a listener that binds with it would
+    // join an existing group and silently take a share of another socket's
+    // traffic, which is exactly what has to be reported rather than allowed.
+    match std::net::UdpSocket::bind(addr) {
+        Ok(socket) => {
+            drop(socket);
+            Ok(())
+        }
+        // A privileged port without the privilege to bind it says nothing about
+        // the server, which holds CAP_NET_BIND_SERVICE. Report and continue.
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!(
+                "warning: cannot test {addr} as this user ({e}); the service binds it with \
+                 CAP_NET_BIND_SERVICE, so this was not checked"
+            );
+            Ok(())
+        }
+        Err(e) => Err(e).with_context(|| format!("failed to bind {addr}")),
+    }
+}
+
+/// How a listener's authentication reads once `enabled` is taken into account.
+fn auth_label(auth: &AuthSection) -> &'static str {
+    if auth.client_cert_enabled() {
+        "client_cert"
+    } else if auth.basic_enabled() {
+        "basic"
+    } else {
+        "disabled"
+    }
+}
+
+/// Render the `[[listeners]]` block for a new listener.
+///
+/// Credentials are emitted only for the mode that reads them: a `username` left
+/// beside `mode = "client_cert"` would look like a live Basic credential to
+/// whoever reads the file next.
+pub fn listener_toml_block(listener: &ListenerSection) -> String {
+    let mut block = String::from("# Added by `masque-server add-listener`.\n");
+    block.push_str("[[listeners]]\n");
+    block.push_str(&format!(
+        "listen_addr = {}\n",
+        toml_string(&listener.listen_addr.to_string())
+    ));
+    block.push_str(&format!("shards = {}\n", listener.shards));
+    block.push_str("\n[listeners.auth]\n");
+
+    if !listener.auth.enabled {
+        block.push_str("# Anyone who can reach this socket can use the proxy.\n");
+        block.push_str("enabled = false\n");
+        return block;
+    }
+
+    block.push_str("enabled = true\n");
+    match listener.auth.mode {
+        AuthMode::Basic => {
+            block.push_str("mode = \"basic\"\n");
+            block.push_str(&format!(
+                "username = {}\n",
+                toml_string(&listener.auth.username)
+            ));
+            block.push_str(&format!(
+                "password_hash = {}\n",
+                toml_string(&listener.auth.password_hash)
+            ));
+        }
+        AuthMode::ClientCert => {
+            block.push_str("mode = \"client_cert\"\n");
+        }
+    }
+    block
+}
+
+/// Append `block` to `text`, separated by exactly one blank line.
+fn append_block(text: &str, block: &str) -> String {
+    let mut merged = text.trim_end().to_owned();
+    if !merged.is_empty() {
+        merged.push_str("\n\n");
+    }
+    merged.push_str(block);
+    merged
+}
+
+/// Confirm that the merged text differs from the original by exactly one
+/// listener.
+///
+/// The append is textual, so this is what rules out the ways text and TOML
+/// disagree — a stray `[[listeners]]` inside a multi-line string, a file whose
+/// last table would swallow the new keys, an unterminated array.
+fn verify_merge(
+    original: &ServerConfig,
+    listener: &ListenerSection,
+    merged: &str,
+) -> anyhow::Result<()> {
+    let parsed = config::parse_toml(merged)
+        .context("the edited configuration would not parse; nothing was written")?;
+
+    let mut without_new = parsed.clone();
+    let appended = without_new.listeners.pop();
+
+    ensure!(
+        appended.as_ref() == Some(listener) && &without_new == original,
+        "the edit would have changed more than the new listener; nothing was written"
+    );
+    Ok(())
+}
+
+// ── Password handling ─────────────────────────────────────────────────
+
+/// Settle on the Argon2id hash to write, and the plaintext to show once when
+/// this command was the thing that invented it.
+fn resolve_password(
+    request: &AddListener,
+    interactive: bool,
+) -> anyhow::Result<(String, Option<Zeroizing<String>>)> {
+    if let Some(hash) = &request.password_hash {
+        return Ok((hash.clone(), None));
+    }
+
+    if request.password_stdin {
+        let mut password = Zeroizing::new(String::new());
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut password)?;
+        let password = Zeroizing::new(trim_newline(&password).to_owned());
+        check_password(&password)?;
+        return Ok((auth::hash_password(password.as_bytes())?, None));
+    }
+
+    if interactive {
+        let password = prompt_password()?;
+        if let Some(password) = password {
+            return Ok((auth::hash_password(password.as_bytes())?, None));
+        }
+    }
+
+    // Nothing was supplied. A generated password is the safe default — the
+    // alternative is a listener that cannot start — but it exists only in this
+    // output, so the caller prints it exactly once.
+    let password = generate_password()?;
+    Ok((auth::hash_password(password.as_bytes())?, Some(password)))
+}
+
+/// A random password, hex encoded, matching what the installer generates.
+fn generate_password() -> anyhow::Result<Zeroizing<String>> {
+    use ring::rand::SecureRandom as _;
+
+    let mut bytes = Zeroizing::new([0u8; GENERATED_PASSWORD_BYTES]);
+    ring::rand::SystemRandom::new()
+        .fill(&mut bytes[..])
+        .map_err(|_| anyhow::anyhow!("the system random number generator is unavailable"))?;
+
+    let mut password = Zeroizing::new(String::with_capacity(GENERATED_PASSWORD_BYTES * 2));
+    for byte in bytes.iter() {
+        password.push_str(&format!("{byte:02x}"));
+    }
+    Ok(password)
+}
+
+fn check_password(password: &str) -> anyhow::Result<()> {
+    if password.is_empty() {
+        bail!("the password must not be empty");
+    }
+    if password.chars().any(char::is_control) {
+        bail!("the password must not contain control characters");
+    }
+    Ok(())
+}
+
+fn trim_newline(value: &str) -> &str {
+    let value = value.strip_suffix('\n').unwrap_or(value);
+    value.strip_suffix('\r').unwrap_or(value)
+}
+
+// ── Prompts ───────────────────────────────────────────────────────────
+//
+// Prompts and their echoes go to standard error, so `--dry-run | tee` and the
+// final summary on standard output stay usable in a pipeline.
+
+fn prompt_listen_addr(config: &ServerConfig) -> anyhow::Result<SocketAddr> {
+    let suggestion = suggest_listen_addr(config);
+    prompt_until_valid(
+        "Listen address (ip:port)",
+        &suggestion.to_string(),
+        |line| {
+            line.parse::<SocketAddr>().map_err(|e| {
+                anyhow::anyhow!("{e}; write an address and port, for example 0.0.0.0:4443")
+            })
+        },
+    )
+}
+
+/// An address the file does not already use.
+///
+/// Same IP as the first listener, because that is the interface the operator
+/// already decided to expose, and the first free port at or above the
+/// suggestion. Overlap is refused later anyway; this only keeps the default
+/// from being one that would be.
+fn suggest_listen_addr(config: &ServerConfig) -> SocketAddr {
+    let mut addr = config
+        .listeners
+        .first()
+        .map(|listener| listener.listen_addr)
+        .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], SUGGESTED_PORT)));
+
+    let used = |port: u16| {
+        config
+            .listeners
+            .iter()
+            .any(|listener| listener.listen_addr.port() == port)
+    };
+
+    let mut port = SUGGESTED_PORT;
+    while used(port) && port < u16::MAX {
+        port += 1;
+    }
+    addr.set_port(port);
+    addr
+}
+
+fn prompt_mode(config: &ServerConfig) -> anyhow::Result<AuthMode> {
+    // Suggest the mode the file does not serve yet: a second listener is
+    // almost always added to accept the other kind of client.
+    let suggestion = if config
+        .listeners
+        .iter()
+        .any(|listener| listener.auth.client_cert_enabled())
+    {
+        "basic"
+    } else {
+        "client_cert"
+    };
+
+    prompt_until_valid(
+        "Authentication mode (basic | client_cert)",
+        suggestion,
+        |line| match line {
+            "basic" => Ok(AuthMode::Basic),
+            "client_cert" | "client-cert" | "cert" => Ok(AuthMode::ClientCert),
+            other => bail!("unknown mode {other:?}; write basic or client_cert"),
+        },
+    )
+}
+
+fn prompt_shards() -> anyhow::Result<usize> {
+    prompt_until_valid("Event loops for this listener (shards)", "1", |line| {
+        let shards: usize = line.parse().context("shards must be a whole number")?;
+        ensure!(
+            shards > 0,
+            "shards must be at least 1 alongside other listeners"
+        );
+        Ok(shards)
+    })
+}
+
+fn prompt_username() -> anyhow::Result<String> {
+    prompt_until_valid("Basic authentication username", "masque", |line| {
+        auth::check_username(line)?;
+        Ok(line.to_owned())
+    })
+}
+
+/// Read a password twice without echoing it, or `None` to generate one.
+fn prompt_password() -> anyhow::Result<Option<Zeroizing<String>>> {
+    let password = read_hidden_line("Password (empty to generate a strong one): ")?;
+    if password.is_empty() {
+        return Ok(None);
+    }
+    check_password(&password)?;
+
+    let repeat = read_hidden_line("Repeat password: ")?;
+    if repeat.as_str() != password.as_str() {
+        bail!("the passwords did not match; nothing was written");
+    }
+    Ok(Some(password))
+}
+
+fn read_confirmation() -> anyhow::Result<bool> {
+    let line = read_line()?;
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "" | "y" | "yes"
+    ))
+}
+
+/// Prompt until `parse` accepts an answer, reporting each rejection in place.
+fn prompt_until_valid<T>(
+    label: &str,
+    default: &str,
+    parse: impl Fn(&str) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    loop {
+        eprint!("{label} [{default}]: ");
+        let line = read_line()?;
+        let answer = if line.trim().is_empty() {
+            default
+        } else {
+            line.trim()
+        };
+        match parse(answer) {
+            Ok(value) => return Ok(value),
+            Err(e) => eprintln!("  {e:#}"),
+        }
+    }
+}
+
+fn read_line() -> anyhow::Result<String> {
+    std::io::stderr().flush()?;
+    let mut line = String::new();
+    // End of input during a prompt means the caller is not answering, and
+    // looping on it forever would spin.
+    if std::io::stdin().read_line(&mut line)? == 0 {
+        bail!("standard input ended before the question was answered; nothing was written");
+    }
+    Ok(line)
+}
+
+#[cfg(unix)]
+fn read_hidden_line(prompt: &str) -> anyhow::Result<Zeroizing<String>> {
+    use std::os::fd::AsRawFd as _;
+
+    /// Restores the terminal on every exit path, including an error return.
+    struct EchoOff {
+        fd: i32,
+        saved: libc::termios,
+    }
+
+    impl Drop for EchoOff {
+        fn drop(&mut self) {
+            // SAFETY: `saved` was filled by tcgetattr on this same descriptor.
+            unsafe { libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.saved) };
+        }
+    }
+
+    eprint!("{prompt}");
+    std::io::stderr().flush()?;
+
+    let fd = std::io::stdin().as_raw_fd();
+    let mut saved = std::mem::MaybeUninit::<libc::termios>::uninit();
+    // SAFETY: writes a termios into our own uninitialised storage.
+    let _guard = if unsafe { libc::tcgetattr(fd, saved.as_mut_ptr()) } == 0 {
+        // SAFETY: tcgetattr returned success, so the value is initialised.
+        let saved = unsafe { saved.assume_init() };
+        let mut quiet = saved;
+        quiet.c_lflag &= !libc::ECHO;
+        // SAFETY: `quiet` is a complete termios for this descriptor.
+        unsafe { libc::tcsetattr(fd, libc::TCSAFLUSH, &quiet) };
+        Some(EchoOff { fd, saved })
+    } else {
+        None
+    };
+
+    let mut line = Zeroizing::new(String::new());
+    if std::io::stdin().read_line(&mut line)? == 0 {
+        bail!("standard input ended before the password was entered; nothing was written");
+    }
+    // The newline the operator typed was not echoed, so the next output would
+    // otherwise continue on the prompt's line.
+    eprintln!();
+    Ok(Zeroizing::new(trim_newline(&line).to_owned()))
+}
+
+#[cfg(not(unix))]
+fn read_hidden_line(prompt: &str) -> anyhow::Result<Zeroizing<String>> {
+    eprint!("{prompt}");
+    std::io::stderr().flush()?;
+    let mut line = Zeroizing::new(String::new());
+    if std::io::stdin().read_line(&mut line)? == 0 {
+        bail!("standard input ended before the password was entered; nothing was written");
+    }
+    Ok(Zeroizing::new(trim_newline(&line).to_owned()))
+}
+
+// ── Writing ───────────────────────────────────────────────────────────
+
+/// Replace a configuration file with new contents, atomically, provided it is
+/// still the file that was read.
+///
+/// Written to a sibling temporary file and renamed, so a crash or a full disk
+/// leaves the previous configuration intact rather than a half-written one that
+/// the next start would reject. Mode and ownership are carried over: the file
+/// holds a password hash, and a service that runs as another user still has to
+/// be able to read it.
+///
+/// `expected` is the text this edit was built on. Anything that changed the
+/// file since — an editor, a script appending `[[clients]]`, an operator on
+/// another session — would be silently discarded by the rename, so it aborts
+/// instead. The advisory lock does not cover this: it binds only other runs of
+/// this command.
+fn write_in_place(path: &Path, expected: &str, contents: &str) -> anyhow::Result<()> {
+    // Follow symlinks rather than replacing them: an operator who points
+    // /etc/masque/masque.toml at a file kept elsewhere means to edit the target.
+    let path = std::fs::canonicalize(path)
+        .with_context(|| format!("failed to resolve {}", path.display()))?;
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "masque.toml".into());
+    let metadata = std::fs::metadata(&path)
+        .with_context(|| format!("failed to inspect {}", path.display()))?;
+
+    let current = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to re-read {}", path.display()))?;
+    if current != expected {
+        bail!(
+            "{} changed while this edit was being prepared, and applying it would discard \
+             that change; nothing was written, so run the command again",
+            path.display()
+        );
+    }
+
+    let temp = TempPath(dir.join(format!(".{name}.new.{}", std::process::id())));
+
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        // Owner-only until the original file's mode is applied below, so the
+        // password hash is never briefly world-readable.
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temp.0)
+        .with_context(|| format!("failed to create {}", temp.0.display()))?;
+
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write {}", temp.0.display()))?;
+    #[cfg(unix)]
+    preserve_owner(&file, &metadata)?;
+    file.set_permissions(metadata.permissions())
+        .with_context(|| format!("failed to set the mode of {}", temp.0.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync {}", temp.0.display()))?;
+    drop(file);
+
+    std::fs::rename(&temp.0, &path)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    temp.keep();
+
+    // Make the rename itself durable, so a crash cannot resurrect the old file.
+    if let Ok(dir) = std::fs::File::open(dir) {
+        let _ = dir.sync_all();
+    }
+    Ok(())
+}
+
+/// Give the replacement the owner the original had.
+///
+/// Only matters when the editor is root and the file belongs to the service
+/// user: a configuration the service cannot read is a server that will not
+/// start, which is exactly what this command exists to prevent.
+#[cfg(unix)]
+fn preserve_owner(file: &std::fs::File, original: &std::fs::Metadata) -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::fs::MetadataExt as _;
+
+    let current = file.metadata()?;
+    if current.uid() == original.uid() && current.gid() == original.gid() {
+        return Ok(());
+    }
+
+    // SAFETY: a descriptor we own, with ids read from the file being replaced.
+    let changed = unsafe { libc::fchown(file.as_raw_fd(), original.uid(), original.gid()) };
+    if changed != 0 {
+        return Err(std::io::Error::last_os_error()).context(
+            "failed to keep the configuration file's owner; run this as root or as the \
+             file's owner",
+        );
+    }
+    Ok(())
+}
+
+/// An advisory lock held for one edit, from the first read to the rename.
+///
+/// Two operators adding a listener at the same time would each read the file,
+/// each validate their own listener against it, and the second rename would
+/// drop the first listener without any error. The window is as long as an
+/// interactive session, so it is wide enough to hit.
+///
+/// The lock lives beside the configuration rather than on it: the file itself
+/// is replaced by a rename, so a lock taken on its inode would stop describing
+/// the path halfway through. `flock` is released by the kernel when the process
+/// exits, so an interrupted edit cannot leave the file locked; the lock file is
+/// left in place, since unlinking it is what makes such schemes racy.
+struct EditLock {
+    #[cfg(unix)]
+    file: std::fs::File,
+}
+
+impl EditLock {
+    #[cfg(unix)]
+    fn acquire(config_path: &Path) -> anyhow::Result<Self> {
+        use std::os::fd::AsRawFd as _;
+
+        let path = lock_path(config_path);
+        let mut options = OpenOptions::new();
+        options.write(true).create(true).truncate(false);
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&path)
+            .with_context(|| format!("failed to open the edit lock {}", path.display()))?;
+
+        // SAFETY: a descriptor this function owns.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::WouldBlock {
+                bail!(
+                    "another masque-server is editing {}; finish or cancel it first",
+                    config_path.display()
+                );
+            }
+            return Err(error).with_context(|| format!("failed to lock {}", path.display()));
+        }
+
+        Ok(Self { file })
+    }
+
+    /// Without `flock` there is no lock to take, and the compare-and-swap in
+    /// [`write_in_place`] is what keeps a concurrent edit from being lost.
+    #[cfg(not(unix))]
+    fn acquire(_config_path: &Path) -> anyhow::Result<Self> {
+        Ok(Self {})
+    }
+}
+
+#[cfg(unix)]
+impl Drop for EditLock {
+    fn drop(&mut self) {
+        use std::os::fd::AsRawFd as _;
+        // SAFETY: our own descriptor, still open until this returns.
+        unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+#[cfg(unix)]
+fn lock_path(config_path: &Path) -> PathBuf {
+    let name = config_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "masque.toml".into());
+    config_path.with_file_name(format!(".{name}.lock"))
+}
+
+/// A temporary file that is removed unless the rename claimed it.
+struct TempPath(PathBuf);
+
+impl TempPath {
+    fn keep(self) {
+        std::mem::forget(self);
+    }
+}
+
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.0).ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASIC_CONFIG: &str = r#"# A deployed file is mostly comments.
+[tls]
+cert_path = "certs/server.crt"
+
+[[listeners]]
+listen_addr = "0.0.0.0:443"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "basic"
+username = "alice"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
+"#;
+
+    fn client_cert_listener(port: u16) -> ListenerSection {
+        ListenerSection {
+            listen_addr: format!("0.0.0.0:{port}").parse().unwrap(),
+            shards: 1,
+            auth: AuthSection {
+                enabled: true,
+                mode: AuthMode::ClientCert,
+                username: String::new(),
+                password_hash: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn appended_listener_parses_back_to_what_was_asked_for() {
+        let listener = client_cert_listener(4443);
+        let merged = append_block(BASIC_CONFIG, &listener_toml_block(&listener));
+
+        let parsed = config::parse_toml(&merged).unwrap();
+        assert_eq!(parsed.listeners.len(), 2);
+        assert_eq!(parsed.listeners[1], listener);
+    }
+
+    /// The edit is textual, so the comments an operator relies on must survive
+    /// it. That is the whole reason the file is not re-serialised.
+    #[test]
+    fn appending_keeps_the_existing_text_and_its_comments() {
+        let merged = append_block(
+            BASIC_CONFIG,
+            &listener_toml_block(&client_cert_listener(4443)),
+        );
+        assert!(merged.starts_with("# A deployed file is mostly comments.\n"));
+        assert!(merged.contains("username = \"alice\""));
+    }
+
+    #[test]
+    fn a_basic_listener_carries_its_own_credentials() {
+        let listener = ListenerSection {
+            listen_addr: "127.0.0.1:8443".parse().unwrap(),
+            shards: 2,
+            auth: AuthSection {
+                enabled: true,
+                mode: AuthMode::Basic,
+                username: "bob".into(),
+                password_hash: "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash".into(),
+            },
+        };
+        let parsed =
+            config::parse_toml(&append_block(BASIC_CONFIG, &listener_toml_block(&listener)))
+                .unwrap();
+        assert_eq!(parsed.listeners[1], listener);
+    }
+
+    /// A certificate listener reads no username or password, and leaving one in
+    /// the file would read as a live Basic credential.
+    #[test]
+    fn a_certificate_listener_writes_no_credentials() {
+        let block = listener_toml_block(&client_cert_listener(4443));
+        assert!(!block.contains("username"));
+        assert!(!block.contains("password_hash"));
+    }
+
+    #[test]
+    fn a_disabled_listener_states_only_that_it_is_disabled() {
+        let listener = ListenerSection {
+            listen_addr: "127.0.0.1:8443".parse().unwrap(),
+            shards: 1,
+            auth: AuthSection {
+                enabled: false,
+                mode: AuthMode::Basic,
+                username: String::new(),
+                password_hash: String::new(),
+            },
+        };
+        let block = listener_toml_block(&listener);
+        assert!(block.contains("enabled = false"));
+        assert!(!block.contains("mode ="));
+
+        let parsed = config::parse_toml(&append_block(BASIC_CONFIG, &block)).unwrap();
+        assert!(!parsed.listeners[1].auth.enabled);
+    }
+
+    /// A file that does not end in a newline is still a valid TOML file, and
+    /// appending to it must not glue the block onto its last line.
+    #[test]
+    fn appending_repairs_a_missing_trailing_newline() {
+        let without_newline = BASIC_CONFIG.trim_end();
+        let merged = append_block(
+            without_newline,
+            &listener_toml_block(&client_cert_listener(4443)),
+        );
+        assert!(config::parse_toml(&merged).is_ok());
+        assert!(merged.contains("$hash\"\n\n# Added by"));
+    }
+
+    #[test]
+    fn the_merge_check_accepts_exactly_one_new_listener() {
+        let original = config::parse_toml(BASIC_CONFIG).unwrap();
+        let listener = client_cert_listener(4443);
+        let merged = append_block(BASIC_CONFIG, &listener_toml_block(&listener));
+        verify_merge(&original, &listener, &merged).unwrap();
+    }
+
+    /// The guard against a textual append that changes something else: here the
+    /// block lands on a file whose parsed form no longer matches.
+    #[test]
+    fn the_merge_check_rejects_a_changed_original() {
+        let original = config::parse_toml(BASIC_CONFIG).unwrap();
+        let listener = client_cert_listener(4443);
+        let tampered = append_block(
+            &BASIC_CONFIG.replace("username = \"alice\"", "username = \"mallory\""),
+            &listener_toml_block(&listener),
+        );
+
+        let error = verify_merge(&original, &listener, &tampered).unwrap_err();
+        assert!(
+            error.to_string().contains("more than the new listener"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn the_suggested_port_skips_the_ports_already_in_use() {
+        let mut config = config::parse_toml(BASIC_CONFIG).unwrap();
+        config.listeners.push(client_cert_listener(SUGGESTED_PORT));
+        assert_eq!(suggest_listen_addr(&config).port(), SUGGESTED_PORT + 1);
+        assert_eq!(
+            suggest_listen_addr(&config).ip(),
+            config.listeners[0].listen_addr.ip()
+        );
+    }
+
+    #[test]
+    fn generated_passwords_are_hex_and_unique() {
+        let first = generate_password().unwrap();
+        let second = generate_password().unwrap();
+        assert_eq!(first.len(), GENERATED_PASSWORD_BYTES * 2);
+        assert!(first.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(first.as_str(), second.as_str());
+    }
+
+    /// A directory of this test's own, since these tests write files and run in
+    /// parallel inside one process.
+    fn scratch_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("masque-edit-{}-{label}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// The file holds a password hash, so an edit must not widen who can read
+    /// it — and must not narrow it either, or the service loses access.
+    #[cfg(unix)]
+    #[test]
+    fn rewriting_keeps_the_original_file_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = scratch_dir("mode");
+        let path = dir.join("masque.toml");
+        std::fs::write(&path, BASIC_CONFIG).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        write_in_place(&path, BASIC_CONFIG, "replaced\n").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "replaced\n");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o640);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The rename is a whole-file replacement, so anything written between the
+    /// read and the write would be discarded without a trace. Refuse instead.
+    #[test]
+    fn rewriting_refuses_a_file_that_changed_since_it_was_read() {
+        let dir = scratch_dir("concurrent");
+        let path = dir.join("masque.toml");
+        std::fs::write(&path, BASIC_CONFIG).unwrap();
+
+        let by_someone_else = format!("{BASIC_CONFIG}\n[[clients]]\nname = \"phone\"\n");
+        std::fs::write(&path, &by_someone_else).unwrap();
+
+        let error = write_in_place(&path, BASIC_CONFIG, "replaced\n").unwrap_err();
+        assert!(
+            error.to_string().contains("changed while this edit"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            by_someone_else,
+            "the other edit must survive"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Two operators editing at once is the case the compare-and-swap above
+    /// reports late and this reports early, before either has typed anything.
+    #[cfg(unix)]
+    #[test]
+    fn one_edit_locks_out_another() {
+        let dir = scratch_dir("lock");
+        let path = dir.join("masque.toml");
+        std::fs::write(&path, BASIC_CONFIG).unwrap();
+
+        let held = EditLock::acquire(&path).unwrap();
+        let error = EditLock::acquire(&path)
+            .err()
+            .expect("a second edit must not take the lock");
+        assert!(
+            error
+                .to_string()
+                .contains("another masque-server is editing"),
+            "unexpected error: {error}"
+        );
+
+        drop(held);
+        EditLock::acquire(&path).expect("the lock is released with the edit");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `validate_config` cannot see an occupied port, and a listener that fails
+    /// to bind takes the whole server down with it at the next start.
+    #[test]
+    fn the_bind_probe_reports_an_address_already_in_use() {
+        let occupied = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let addr = occupied.local_addr().unwrap();
+        assert!(probe_listen_addr(addr).is_err());
+
+        drop(occupied);
+        probe_listen_addr(addr).expect("a free address passes");
+    }
+
+    /// Port 0 has nothing to probe: the kernel picks a free port when the
+    /// server binds, which is a different port every time.
+    #[test]
+    fn the_bind_probe_accepts_an_ephemeral_port() {
+        probe_listen_addr("127.0.0.1:0".parse().unwrap()).unwrap();
+    }
+}

--- a/src/enroll.rs
+++ b/src/enroll.rs
@@ -232,7 +232,7 @@ pub fn client_config_json(
 }
 
 /// Quote a value as a TOML basic string.
-fn toml_string(value: &str) -> String {
+pub(crate) fn toml_string(value: &str) -> String {
     let mut out = String::with_capacity(value.len() + 2);
     out.push('"');
     for c in value.chars() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod capsule;
 pub mod client_identity;
 pub mod config;
+pub mod config_edit;
 pub mod connection;
 pub mod datagram;
 pub mod enroll;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use zeroize::Zeroizing;
 
 use masque::auth;
 use masque::config::{self, ServerConfig};
+use masque::config_edit;
 use masque::enroll;
 use masque::server::{Server, validate_config};
 
@@ -72,6 +73,98 @@ enum Command {
         #[arg(long, short)]
         out: Option<PathBuf>,
     },
+    /// Append a `[[listeners]]` block to the configuration file.
+    ///
+    /// Anything not given as a flag is prompted for when standard input is a
+    /// terminal, and required otherwise, so the same command serves an operator
+    /// and a provisioning script.
+    ///
+    /// Before writing, the merged file is validated the way `check-config`
+    /// validates one, and the new address is bound once to see that it is free.
+    /// Whatever fails, the file is left exactly as it was. The bind test
+    /// describes the moment it ran, so it narrows the risk of the restart
+    /// rather than removing it: check that the server came up afterwards.
+    ///
+    /// A new socket is bound at startup, so a restart is required — SIGHUP
+    /// reloads only the `[[clients]]` roster.
+    AddListener {
+        /// Address and port for the new socket, for example `0.0.0.0:4443`.
+        #[arg(long)]
+        listen_addr: Option<SocketAddr>,
+
+        /// Authentication this socket demands. One mode per listener: the mode
+        /// decides which TLS context is built before clients connect.
+        #[arg(long, value_enum)]
+        mode: Option<AuthModeArg>,
+
+        /// Event loops for this listener. Defaults to 1.
+        #[arg(long)]
+        shards: Option<usize>,
+
+        /// Basic username.
+        #[arg(long)]
+        username: Option<String>,
+
+        /// Argon2id PHC hash, as printed by `hash-password`.
+        #[arg(long, conflicts_with = "password_stdin")]
+        password_hash: Option<String>,
+
+        /// Read the password from standard input and hash it here.
+        #[arg(long)]
+        password_stdin: bool,
+
+        /// Write `enabled = false`. Anyone who reaches the socket may use the
+        /// proxy, so this is for a listener on a trusted network only.
+        ///
+        /// Conflicts with `--mode`: a listener that demands nothing has no
+        /// authentication mode to pick, and writing one down would describe a
+        /// requirement that is not enforced.
+        #[arg(long, conflicts_with_all = ["mode", "username", "password_hash", "password_stdin"])]
+        disable_auth: bool,
+
+        /// Do not try to bind the new address before writing it.
+        ///
+        /// The bind test is what catches an address something else already
+        /// holds. Skip it when the address only becomes available later, for
+        /// example a floating address, or when the service runs in another
+        /// network namespace.
+        #[arg(long)]
+        no_bind_check: bool,
+
+        /// Print the block that would be appended and leave the file alone.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip the confirmation prompt.
+        #[arg(long, short)]
+        yes: bool,
+    },
+}
+
+/// `--mode` on the command line.
+///
+/// Separate from [`config::AuthMode`] so the configuration model stays free of
+/// command-line parsing; the two are mapped in one place below.
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum AuthModeArg {
+    /// RFC 7617 `Proxy-Authorization`, checked per request.
+    Basic,
+    /// A TLS client certificate, matched against the `[[clients]]` roster.
+    ///
+    /// Accepts the configuration file's own spelling as well: an operator who
+    /// has read `mode = "client_cert"` should not have to discover that the
+    /// flag wants a hyphen.
+    #[value(alias = "client_cert")]
+    ClientCert,
+}
+
+impl From<AuthModeArg> for config::AuthMode {
+    fn from(mode: AuthModeArg) -> Self {
+        match mode {
+            AuthModeArg::Basic => config::AuthMode::Basic,
+            AuthModeArg::ClientCert => config::AuthMode::ClientCert,
+        }
+    }
 }
 
 /// How a listener's authentication reads in `check-config` output.
@@ -205,8 +298,45 @@ async fn main() -> anyhow::Result<()> {
 
     // Load config.
     let config_exists = cli.config.exists();
-    if matches!(cli.command, Some(Command::CheckConfig)) && !config_exists {
+    if matches!(
+        cli.command,
+        Some(Command::CheckConfig | Command::AddListener { .. })
+    ) && !config_exists
+    {
         anyhow::bail!("configuration file not found: {}", cli.config.display());
+    }
+
+    // Editing runs before the load below on purpose: it re-reads the file
+    // itself, and validates it exactly as the service will read it rather than
+    // with this invocation's --cert/--key overrides applied.
+    if let Some(Command::AddListener {
+        listen_addr,
+        mode,
+        shards,
+        username,
+        password_hash,
+        password_stdin,
+        disable_auth,
+        no_bind_check,
+        dry_run,
+        yes,
+    }) = cli.command
+    {
+        return config_edit::add_listener(
+            &cli.config,
+            config_edit::AddListener {
+                listen_addr,
+                mode: mode.map(Into::into),
+                shards,
+                username,
+                password_hash,
+                password_stdin,
+                disable_auth,
+                no_bind_check,
+                dry_run,
+                assume_yes: yes,
+            },
+        );
     }
     let mut cfg = if config_exists {
         let toml_str = std::fs::read_to_string(&cli.config)?;

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -281,11 +281,40 @@ fn generates_a_password_when_a_script_supplies_none() {
         "the generated password is the only copy, so it has to be printed: {stdout}"
     );
     assert!(
+        stdout.find("generated password for carol:") < stdout.find("added listener"),
+        "the only password copy must be delivered before its hash is committed: {stdout}"
+    );
+    assert!(
         fixture.config().listeners[1]
             .auth
             .password_hash
             .starts_with("$argon2id$")
     );
+}
+
+/// A dry-run block is often redirected for review or provisioning. Generating
+/// a password but returning before printing its only copy would make that block
+/// impossible to authenticate to.
+#[test]
+fn dry_run_refuses_to_generate_an_unrecoverable_password() {
+    let fixture = Fixture::new(false);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8461",
+        "--mode",
+        "basic",
+        "--username",
+        "dave",
+        "--dry-run",
+    ]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--dry-run cannot generate a Basic password"),
+        "unexpected diagnostic: {stderr}"
+    );
+    fixture.assert_unchanged();
 }
 
 #[test]

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -1,0 +1,546 @@
+//! `add-listener` edits a deployed configuration file, so the guarantee under
+//! test is what survives the edit: the file either gains exactly one working
+//! listener, or is left byte for byte as it was.
+
+use std::io::Write as _;
+use std::net::UdpSocket;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::asn1::Asn1Time;
+use boring::bn::BigNum;
+use boring::ec::{EcGroup, EcKey};
+use boring::hash::MessageDigest;
+use boring::nid::Nid;
+use boring::pkey::{PKey, Private};
+use boring::x509::{X509Builder, X509NameBuilder};
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        static SEQUENCE: AtomicU32 = AtomicU32::new(0);
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "masque-add-listener-{}-{nonce}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+fn p256_key() -> PKey<Private> {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+}
+
+fn write_server_identity(dir: &Path) -> (PathBuf, PathBuf) {
+    let key = p256_key();
+    let mut name = X509NameBuilder::new().unwrap();
+    name.append_entry_by_text("CN", "localhost").unwrap();
+    let name = name.build();
+
+    let mut cert = X509Builder::new().unwrap();
+    cert.set_version(2).unwrap();
+    cert.set_serial_number(&BigNum::from_u32(1).unwrap().to_asn1_integer().unwrap())
+        .unwrap();
+    cert.set_subject_name(&name).unwrap();
+    cert.set_issuer_name(&name).unwrap();
+    cert.set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .unwrap();
+    cert.set_not_after(&Asn1Time::days_from_now(1).unwrap())
+        .unwrap();
+    cert.set_pubkey(&key).unwrap();
+    cert.sign(&key, MessageDigest::sha256()).unwrap();
+
+    let cert_path = dir.join("server.crt");
+    let key_path = dir.join("server.key");
+    std::fs::write(&cert_path, cert.build().to_pem().unwrap()).unwrap();
+    std::fs::write(
+        &key_path,
+        key.ec_key().unwrap().private_key_to_pem().unwrap(),
+    )
+    .unwrap();
+    (cert_path, key_path)
+}
+
+/// A single Basic listener, with the comments a deployed file carries and a
+/// roster entry ready for a certificate listener.
+fn basic_config_text(cert_path: &Path, key_path: &Path, with_client: bool) -> String {
+    let password_hash = masque::auth::hash_password(b"correct horse battery staple").unwrap();
+    let roster = if with_client {
+        format!(
+            "\n[[clients]]\nname = \"laptop\"\npublic_key = \"{}\"\n",
+            STANDARD.encode(p256_key().public_key_to_der().unwrap())
+        )
+    } else {
+        String::new()
+    };
+
+    format!(
+        r#"# Deployed configuration. The comments explain the tuning knobs.
+[tls]
+cert_path = "{}"
+key_path = "{}"
+
+[ip_proxy]
+enabled = false
+
+[[listeners]]
+listen_addr = "127.0.0.1:8449"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "basic"
+username = "alice"
+password_hash = "{password_hash}"
+{roster}"#,
+        cert_path.display(),
+        key_path.display()
+    )
+}
+
+struct Fixture {
+    _dir: TempDir,
+    config_path: PathBuf,
+    original: String,
+}
+
+impl Fixture {
+    fn new(with_client: bool) -> Self {
+        let dir = TempDir::new();
+        let (cert_path, key_path) = write_server_identity(dir.path());
+        let config_path = dir.path().join("masque.toml");
+        let original = basic_config_text(&cert_path, &key_path, with_client);
+        std::fs::write(&config_path, &original).unwrap();
+        Self {
+            _dir: dir,
+            config_path,
+            original,
+        }
+    }
+
+    fn add_listener(&self, args: &[&str]) -> std::process::Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_masque-server"));
+        command
+            .arg("--config")
+            .arg(&self.config_path)
+            .arg("add-listener")
+            .args(args);
+        command.output().unwrap()
+    }
+
+    fn text(&self) -> String {
+        std::fs::read_to_string(&self.config_path).unwrap()
+    }
+
+    fn config(&self) -> masque::config::ServerConfig {
+        masque::config::parse_toml(&self.text()).unwrap()
+    }
+
+    fn assert_unchanged(&self) {
+        assert_eq!(
+            self.text(),
+            self.original,
+            "a rejected edit must leave the file exactly as it was"
+        );
+    }
+}
+
+#[test]
+fn adds_a_certificate_listener_beside_a_basic_one() {
+    let fixture = Fixture::new(true);
+    let output =
+        fixture.add_listener(&["--listen-addr", "127.0.0.1:8450", "--mode", "client-cert"]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = fixture.config();
+    assert_eq!(config.listeners.len(), 2);
+    assert_eq!(
+        config.listeners[1].listen_addr.to_string(),
+        "127.0.0.1:8450"
+    );
+    assert!(config.listeners[1].auth.client_cert_enabled());
+    assert_eq!(config.listeners[1].shards, 1);
+    // The first listener is untouched, comments and all.
+    assert!(config.listeners[0].auth.basic_enabled());
+    assert!(fixture.text().starts_with("# Deployed configuration."));
+
+    // The edited file is what the server would read, so the preflight it ships
+    // with has to agree.
+    let check = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&fixture.config_path)
+        .arg("check-config")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&check.stdout);
+    assert!(check.status.success(), "check-config rejected the edit");
+    assert!(stdout.contains("listener 127.0.0.1:8450 auth=client_cert shards=1"));
+}
+
+#[test]
+fn adds_a_basic_listener_with_a_password_read_from_stdin() {
+    let fixture = Fixture::new(false);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&fixture.config_path)
+        .arg("add-listener")
+        .args([
+            "--listen-addr",
+            "127.0.0.1:8451",
+            "--mode",
+            "basic",
+            "--username",
+            "bob",
+            "--password-stdin",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"a-strong-password\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = fixture.config();
+    assert_eq!(config.listeners.len(), 2);
+    assert_eq!(config.listeners[1].auth.username, "bob");
+    assert!(
+        config.listeners[1]
+            .auth
+            .password_hash
+            .starts_with("$argon2id$"),
+        "the password must be written as an Argon2id hash, never in the clear"
+    );
+    assert!(
+        !fixture.text().contains("a-strong-password"),
+        "the plaintext password must not reach the file"
+    );
+}
+
+/// Without a flag or a terminal there is no password to write, and a Basic
+/// listener with none cannot start. One is generated and printed instead — the
+/// same choice the installer makes.
+#[test]
+fn generates_a_password_when_a_script_supplies_none() {
+    let fixture = Fixture::new(false);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8452",
+        "--mode",
+        "basic",
+        "--username",
+        "carol",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("generated password for carol:"),
+        "the generated password is the only copy, so it has to be printed: {stdout}"
+    );
+    assert!(
+        fixture.config().listeners[1]
+            .auth
+            .password_hash
+            .starts_with("$argon2id$")
+    );
+}
+
+#[test]
+fn refuses_an_address_that_overlaps_the_existing_listener() {
+    let fixture = Fixture::new(true);
+    let output =
+        fixture.add_listener(&["--listen-addr", "127.0.0.1:8449", "--mode", "client-cert"]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("two listeners are configured for"),
+        "unexpected diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fixture.assert_unchanged();
+}
+
+/// A certificate listener with an empty roster is refused at startup, so
+/// writing one would produce a file that takes the working listener down with
+/// it at the next restart.
+#[test]
+fn refuses_a_certificate_listener_with_no_roster() {
+    let fixture = Fixture::new(false);
+    let output =
+        fixture.add_listener(&["--listen-addr", "127.0.0.1:8453", "--mode", "client-cert"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("enroll-client"),
+        "the error has to name the fix: {stderr}"
+    );
+    fixture.assert_unchanged();
+}
+
+/// The configuration file spells this mode `client_cert`, so the flag takes
+/// that spelling too rather than insisting on clap's hyphenated form.
+#[test]
+fn mode_accepts_the_configuration_files_spelling() {
+    let fixture = Fixture::new(true);
+    let output =
+        fixture.add_listener(&["--listen-addr", "127.0.0.1:8456", "--mode", "client_cert"]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(fixture.config().listeners[1].auth.client_cert_enabled());
+}
+
+/// `check-config` cannot see an occupied port, so writing one would turn the
+/// next restart into an outage of the listeners that work today.
+#[test]
+fn refuses_an_address_that_is_already_bound() {
+    let fixture = Fixture::new(true);
+    let occupied = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let addr = occupied.local_addr().unwrap().to_string();
+
+    let output = fixture.add_listener(&["--listen-addr", &addr, "--mode", "client-cert"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("would not bind"),
+        "unexpected diagnostic: {stderr}"
+    );
+    fixture.assert_unchanged();
+}
+
+/// The bind test is a probe of this moment, so an address that only exists
+/// later — a floating address, another network namespace — has to remain
+/// writable on purpose.
+#[test]
+fn skips_the_bind_test_when_told_to() {
+    let fixture = Fixture::new(true);
+    let occupied = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let addr = occupied.local_addr().unwrap().to_string();
+
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        &addr,
+        "--mode",
+        "client-cert",
+        "--no-bind-check",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.config().listeners.len(), 2);
+}
+
+/// A certificate listener reads no password, so accepting one would leave the
+/// operator believing the socket also takes those credentials.
+#[test]
+fn refuses_credentials_that_the_chosen_mode_ignores() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8457",
+        "--mode",
+        "client-cert",
+        "--username",
+        "bob",
+    ]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("apply to --mode basic"),
+        "unexpected diagnostic: {stderr}"
+    );
+    fixture.assert_unchanged();
+}
+
+/// A listener that demands nothing has no authentication mode, and writing one
+/// down would describe a requirement nothing enforces.
+#[test]
+fn refuses_a_mode_alongside_disabled_authentication() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8458",
+        "--mode",
+        "basic",
+        "--disable-auth",
+    ]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "unexpected diagnostic: {stderr}"
+    );
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn writes_a_listener_that_demands_nothing_when_asked() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&["--listen-addr", "127.0.0.1:8459", "--disable-auth"]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = fixture.config();
+    assert!(!config.listeners[1].auth.enabled);
+
+    let check = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&fixture.config_path)
+        .arg("check-config")
+        .output()
+        .unwrap();
+    assert!(check.status.success());
+    assert!(
+        String::from_utf8_lossy(&check.stdout)
+            .contains("listener 127.0.0.1:8459 auth=disabled shards=1")
+    );
+}
+
+/// One edit at a time. Two operators would each validate against the file they
+/// read, and the second rename would drop the first listener without an error.
+#[cfg(unix)]
+#[test]
+fn refuses_to_edit_a_file_another_edit_holds() {
+    use std::os::fd::AsRawFd as _;
+
+    let fixture = Fixture::new(true);
+    let lock_path = fixture.config_path.with_file_name(".masque.toml.lock");
+    let lock = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    // SAFETY: a descriptor this test owns, released when the file is dropped.
+    assert_eq!(
+        unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0
+    );
+
+    let output =
+        fixture.add_listener(&["--listen-addr", "127.0.0.1:8460", "--mode", "client-cert"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("another masque-server is editing"),
+        "unexpected diagnostic: {stderr}"
+    );
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn dry_run_prints_the_block_without_touching_the_file() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8454",
+        "--mode",
+        "client-cert",
+        "--dry-run",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[[listeners]]"));
+    assert!(stdout.contains("listen_addr = \"127.0.0.1:8454\""));
+    fixture.assert_unchanged();
+}
+
+/// Prompting needs a terminal. A script that leaves a value out gets an error
+/// naming the flag, not a command that blocks forever waiting on a pipe.
+#[test]
+fn requires_flags_when_standard_input_is_not_a_terminal() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&["--mode", "client-cert"]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--listen-addr is required"),
+        "unexpected diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    fixture.assert_unchanged();
+}
+
+#[test]
+fn reports_a_missing_configuration_file_instead_of_creating_one() {
+    let dir = TempDir::new();
+    let missing = dir.path().join("absent.toml");
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&missing)
+        .arg("add-listener")
+        .args(["--listen-addr", "127.0.0.1:8455", "--mode", "client-cert"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("configuration file not found"),
+        "unexpected diagnostic: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!missing.exists());
+}

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -32,6 +32,7 @@ cleanup() {
     rm -f -- \
         "$BIN_PATH" \
         "$CONFIG_PATH" \
+        /etc/masque/.masque.toml.lock \
         "$UNIT_PATH" \
         /etc/masque/certs/server.crt \
         /etc/masque/certs/server.key
@@ -168,14 +169,45 @@ grep -q '^listener 0.0.0.0:8449 auth=basic shards=1$' "$TEST_TMP/dual-check.log"
     die "the Basic listener was not reported by check-config"
 grep -q '^listener 0.0.0.0:8450 auth=client_cert shards=1$' "$TEST_TMP/dual-check.log" ||
     die "the certificate listener was not reported by check-config"
+# The installed binary must be able to add a third listener to the file the
+# installer wrote, in place, without an operator editing TOML.
+config_owner_before=$(stat -c '%U:%G %a' "$CONFIG_PATH")
+"$BIN_PATH" --config "$CONFIG_PATH" add-listener \
+    --listen-addr 0.0.0.0:8451 --mode client_cert --yes \
+    >"$TEST_TMP/add-listener.log" 2>&1 ||
+    die "add-listener failed; see $TEST_TMP/add-listener.log"
+[ "$(grep -c '^\[\[listeners\]\]$' "$CONFIG_PATH")" -eq 3 ] ||
+    die "add-listener did not append a third listener"
+grep -q '^username = "proxy-user"$' "$CONFIG_PATH" ||
+    die "add-listener lost the Basic credentials already in the file"
+grep -q '^\[quic\]$' "$CONFIG_PATH" ||
+    die "add-listener lost the sections the installer wrote"
+# The file holds a password hash and is read by the service account, so an
+# in-place edit must not change who owns it or who may read it.
+[ "$(stat -c '%U:%G %a' "$CONFIG_PATH")" = "$config_owner_before" ] ||
+    die "add-listener changed the configuration file's owner or mode"
+"$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/added-check.log" 2>&1 ||
+    die "the configuration failed check-config after add-listener"
+grep -q '^listener 0.0.0.0:8451 auth=client_cert shards=1$' "$TEST_TMP/added-check.log" ||
+    die "the added listener was not reported by check-config"
+
+added_config_sha=$(sha256sum "$CONFIG_PATH" | awk '{print $1}')
+
 # A reinstall over it is an upgrade, and must report both modes rather than one.
 MASQUE_START_SERVICE=0 "$PACKAGE_DIR/install.sh" \
     >"$TEST_TMP/dual-upgrade.log" 2>&1 ||
     die "upgrading over the dual configuration failed"
 grep -q 'Authentication: basic + client_cert' "$TEST_TMP/dual-upgrade.log" ||
     die "the upgrade summary did not report both authentication modes"
+# An upgrade keeps what the operator added, including a listener this installer
+# never writes on its own.
+assert_sha_unchanged "$CONFIG_PATH" "$added_config_sha"
+grep -q '^listener 0.0.0.0:8451 auth=client_cert shards=1$' "$TEST_TMP/dual-upgrade.log" ||
+    die "the upgrade summary did not report the added listener"
+grep -q 'add-listener' "$TEST_TMP/dual-upgrade.log" ||
+    die "the upgrade summary did not name the command that adds a listener"
 
-rm -f -- "$CONFIG_PATH"
+rm -f -- "$CONFIG_PATH" "$(dirname "$CONFIG_PATH")/.masque.toml.lock"
 
 # An incompatible existing configuration must fail before replacement.
 write_old_installation


### PR DESCRIPTION
## Summary

- add a safe `masque-server add-listener` command for Basic and client-certificate listeners
- integrate listener creation with the one-command installer and document the workflow
- protect configuration updates with locking, final content checks, recoverable password delivery, and fail-closed terminal handling
- prepare the v0.3.1 release

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --locked`
- `cargo test --workspace --all-targets --all-features --locked`
- `shellcheck install-latest.sh deploy/install.sh scripts/*.sh tests/*.sh tests/e2e/*.sh`
- `sh -n install-latest.sh deploy/install.sh tests/install-upgrade.sh`