### PR TITLE
fix: drain all shards on service shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Check shell scripts
         run: |
-          sh -n install-latest.sh deploy/install.sh tests/install-upgrade.sh
+          sh -n install-latest.sh deploy/install.sh \
+            tests/install-upgrade.sh tests/systemd-shutdown.sh
           shellcheck install-latest.sh deploy/install.sh scripts/*.sh \
             tests/*.sh tests/e2e/*.sh
 
@@ -131,6 +132,10 @@ jobs:
 
       - name: Run workspace tests
         run: cargo test --workspace --locked
+
+      - name: Test systemd shutdown signals
+        if: runner.os == 'Linux'
+        run: MASQUE_TEST_BIN="$PWD/target/debug/masque-server" tests/systemd-shutdown.sh
 
       - name: Test installer upgrade safety
         if: runner.os == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.3.2 - 2026-08-20
+
+### Fixed
+
+- SIGINT and SIGTERM are now received once at the server level and broadcast
+  to every shard, so `systemctl stop` and `systemctl restart` run the bounded
+  QUIC drain instead of terminating the process before it can send GOAWAY and
+  CONNECTION_CLOSE.
+- The systemd unit explicitly uses SIGTERM and leaves ten seconds for the
+  server's five-second drain before escalating. Linux CI starts a real
+  two-shard server and verifies that both SIGTERM and SIGINT drain every shard
+  and exit successfully.
+
 ## 0.3.1 - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"

--- a/deploy/systemd/masque.service
+++ b/deploy/systemd/masque.service
@@ -14,6 +14,11 @@ ExecStart=/usr/local/bin/masque-server --config /etc/masque/masque.toml
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=2s
+# The server handles SIGTERM by sending GOAWAY/CONNECTION_CLOSE to every shard
+# and draining for at most five seconds. Leave time for that bounded shutdown
+# before systemd escalates to SIGKILL.
+KillSignal=SIGTERM
+TimeoutStopSec=10s
 LimitNOFILE=1048576
 
 # Port 443 and CONNECT-IP TUN setup without running the process as root.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,7 +274,7 @@ the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
-configuration is compatible with masque-server 0.3.1: /etc/masque/masque.toml
+configuration is compatible with masque-server 0.3.2: /etc/masque/masque.toml
 listener 0.0.0.0:443 auth=basic shards=1
 listener 0.0.0.0:4443 auth=client_cert shards=1
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,7 +90,7 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
     sh
 ```
 
-`MASQUE_VERSION=0.3.1` selects `v0.3.1`. This is also how to install a
+`MASQUE_VERSION=0.3.2` selects `v0.3.2`. This is also how to install a
 prerelease explicitly; automatic resolution deliberately chooses only GitHub's
 latest stable release. Authentication, listen, TLS-source, and client
 provisioning variables apply only when `/etc/masque/masque.toml` does not yet
@@ -230,6 +230,17 @@ If it failed to bind, the journal names the address, and the previous
 configuration is one `[[listeners]]` block away — remove the appended block and
 restart. Keep the usual configuration backups; this command edits in place and
 does not keep a copy.
+
+## Service lifecycle
+
+`systemctl stop` and `systemctl restart` send SIGTERM. The server receives that
+signal once and broadcasts the shutdown request to every shard, sends HTTP/3
+GOAWAY and QUIC CONNECTION_CLOSE, and drains existing connections for at most
+five seconds. The packaged unit sets `TimeoutStopSec=10s`, leaving a second
+five-second margin before systemd may escalate to SIGKILL.
+
+SIGINT follows the same path for foreground runs. SIGHUP remains distinct: it
+reloads only the `[[clients]]` roster and does not stop the service.
 
 ## Upgrade
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,6 +13,7 @@
 | Network benchmark | `scripts/network-bench.sh` | Local direct-vs-MASQUE throughput and RTT |
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
 | Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth, CONNECT-IP setup, and both authentication modes served from one process |
+| Service shutdown | `tests/systemd-shutdown.sh` | Real SIGTERM/SIGINT handling and every-shard drain; Linux exercises two shards |
 | Config preflight | `cargo test --test check_config` | `check-config` accepts what a server accepts, including multi-listener files |
 | Config editing | `cargo test --test add_listener` | `add-listener` writes a listener that starts, or leaves the file untouched |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 use std::sync::{Mutex, RwLock};
 
 use anyhow::Context as _;
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, watch};
 
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
@@ -812,17 +812,29 @@ impl Server {
             Self::spawn_roster_reloader(Arc::clone(&shard.shared));
         }
 
+        // Install one process-wide signal listener before any shard starts.
+        // Every shard receives the same latched watch value, so one SIGINT or
+        // SIGTERM starts every drain even if a shard was not polling its event
+        // loop at the instant the signal arrived.
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let shutdown_listener = spawn_shutdown_notifier(shutdown_tx)
+            .context("failed to install shutdown signal handlers")?;
+        debug!("shutdown signal handlers installed");
+
         // A single shard keeps the current behaviour of running on the caller's
         // task, which keeps the common case free of a spawn and a join.
         if self.shards.len() == 1 {
-            return self.shards[0].run().await;
+            let outcome = self.shards[0].run(shutdown_rx).await;
+            shutdown_listener.abort();
+            return outcome;
         }
 
         let mut tasks = tokio::task::JoinSet::new();
         for mut shard in self.shards.drain(..) {
+            let shutdown_rx = shutdown_rx.clone();
             tasks.spawn(async move {
                 let index = shard.index;
-                let result = shard.run().await;
+                let result = shard.run(shutdown_rx).await;
                 (index, result)
             });
         }
@@ -845,8 +857,80 @@ impl Server {
                 }
             }
         }
+        shutdown_listener.abort();
         outcome
     }
+}
+
+/// Register one listener for the process shutdown signals and latch the result
+/// into a watch channel shared by every shard.
+///
+/// Keeping the task alive after the first signal means a second signal is not
+/// silently swallowed while the bounded drain is still in progress. systemd
+/// will still enforce `TimeoutStopSec` and send SIGKILL if that bound is ever
+/// exceeded.
+#[cfg(unix)]
+fn spawn_shutdown_notifier(
+    shutdown_tx: watch::Sender<bool>,
+) -> std::io::Result<tokio::task::JoinHandle<()>> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sigint = signal(SignalKind::interrupt())?;
+    let mut sigterm = signal(SignalKind::terminate())?;
+
+    Ok(tokio::spawn(async move {
+        let mut requested = false;
+        loop {
+            let signal = tokio::select! {
+                _ = sigint.recv() => "SIGINT",
+                _ = sigterm.recv() => "SIGTERM",
+            };
+
+            if requested {
+                warn!(
+                    signal,
+                    "additional shutdown signal received; drain already in progress"
+                );
+                continue;
+            }
+
+            requested = true;
+            info!(signal, "shutdown signal received, draining shards");
+            if shutdown_tx.send(true).is_err() {
+                return;
+            }
+        }
+    }))
+}
+
+#[cfg(not(unix))]
+fn spawn_shutdown_notifier(
+    shutdown_tx: watch::Sender<bool>,
+) -> std::io::Result<tokio::task::JoinHandle<()>> {
+    Ok(tokio::spawn(async move {
+        let mut requested = false;
+        loop {
+            if let Err(error) = tokio::signal::ctrl_c().await {
+                error!(%error, "cannot listen for Ctrl-C; shutting down safely");
+                let _ = shutdown_tx.send(true);
+                return;
+            }
+
+            if requested {
+                warn!("additional Ctrl-C received; drain already in progress");
+                continue;
+            }
+
+            requested = true;
+            info!(
+                signal = "Ctrl-C",
+                "shutdown signal received, draining shards"
+            );
+            if shutdown_tx.send(true).is_err() {
+                return;
+            }
+        }
+    }))
 }
 
 /// Resolve the configured shard count, where 0 means "one per core".
@@ -1469,7 +1553,7 @@ impl Shard {
     }
 
     /// Run the server event loop.
-    pub async fn run(&mut self) -> anyhow::Result<()> {
+    pub async fn run(&mut self, mut shutdown: watch::Receiver<bool>) -> anyhow::Result<()> {
         let mut out = vec![0u8; MAX_DATAGRAM_SIZE];
         let mut dgram_buf = vec![0u8; MAX_DATAGRAM_SIZE];
         let mut tun_recv = TunRecvBatch::new(self.config.ip_proxy.tun_mtu);
@@ -1533,7 +1617,7 @@ impl Shard {
 
             let event = if let Some(timeout) = timeout {
                 tokio::select! {
-                    _ = tokio::signal::ctrl_c(), if !shutting_down => {
+                    _ = shutdown.wait_for(|requested| *requested), if !shutting_down => {
                         Event::Shutdown
                     }
                     response = self.udp_response_rx.recv(), if !shutting_down => {
@@ -1572,7 +1656,11 @@ impl Shard {
 
             match event {
                 Event::Shutdown => {
-                    info!("shutdown signal received, draining connections...");
+                    info!(
+                        shard = self.index,
+                        connections = self.connections.len(),
+                        "shard draining connections"
+                    );
                     shutting_down = true;
                     drain_deadline = Some(Instant::now() + DRAIN_TIMEOUT);
 
@@ -1749,7 +1837,7 @@ impl Shard {
             // the drain deadline is reached.
             if shutting_down {
                 if self.connections.is_empty() {
-                    info!("all connections drained, exiting");
+                    info!(shard = self.index, "all connections drained, exiting");
                     return Ok(());
                 }
                 if let Some(deadline) = drain_deadline

--- a/tests/systemd-shutdown.sh
+++ b/tests/systemd-shutdown.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env sh
+# Exercise the production stop signal against a real server. Linux uses two
+# shards to prove the process-wide broadcast; platforms without SO_REUSEPORT
+# use one. The GitHub Linux runner is not booted with systemd as PID 1, so
+# sending the unit's configured KillSignal is the closest test of the
+# service-manager boundary.
+set -eu
+
+die() {
+    echo "systemd shutdown test: $*" >&2
+    exit 1
+}
+
+case "$(uname -s)" in
+    Linux) EXPECTED_SHARDS=2 ;;
+    Darwin) EXPECTED_SHARDS=1 ;;
+    *) die "unsupported test platform" ;;
+esac
+
+CANDIDATE=${MASQUE_TEST_BIN:-target/debug/masque-server}
+[ -x "$CANDIDATE" ] || die "MASQUE_TEST_BIN must name an executable"
+
+grep -q '^KillSignal=SIGTERM$' deploy/systemd/masque.service ||
+    die "the systemd unit does not send SIGTERM"
+grep -q '^TimeoutStopSec=10s$' deploy/systemd/masque.service ||
+    die "the systemd unit does not leave time for the bounded drain"
+
+TEST_TMP=$(mktemp -d /tmp/masque-systemd-shutdown.XXXXXX)
+SERVER_PID=
+
+cleanup() {
+    cleanup_status=$?
+    trap - EXIT
+    set +e
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill -KILL "$SERVER_PID" 2>/dev/null
+        wait "$SERVER_PID" 2>/dev/null
+    fi
+    rm -rf -- "$TEST_TMP"
+    exit "$cleanup_status"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+    -days 1 -subj /CN=localhost \
+    -keyout "$TEST_TMP/server.key" \
+    -out "$TEST_TMP/server.crt" >/dev/null 2>&1
+
+cat >"$TEST_TMP/masque.toml" <<EOF
+[tls]
+cert_path = "$TEST_TMP/server.crt"
+key_path = "$TEST_TMP/server.key"
+
+[ip_proxy]
+enabled = false
+
+[[listeners]]
+listen_addr = "127.0.0.1:0"
+shards = $EXPECTED_SHARDS
+
+[listeners.auth]
+enabled = false
+EOF
+
+run_signal_case() {
+    signal=$1
+    log=$TEST_TMP/$signal.log
+
+    RUST_LOG=masque=debug "$CANDIDATE" --config "$TEST_TMP/masque.toml" \
+        >"$log" 2>&1 &
+    SERVER_PID=$!
+
+    attempts=0
+    until grep -q 'shutdown signal handlers installed' "$log"; do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            wait "$SERVER_PID" || true
+            SERVER_PID=
+            sed -n '1,200p' "$log" >&2
+            die "server exited before installing signal handlers"
+        fi
+        attempts=$((attempts + 1))
+        [ "$attempts" -lt 100 ] || die "server did not become ready"
+        sleep 0.1
+    done
+
+    kill "-$signal" "$SERVER_PID"
+
+    attempts=0
+    while kill -0 "$SERVER_PID" 2>/dev/null; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge 100 ]; then
+            sed -n '1,200p' "$log" >&2
+            die "server did not exit after $signal"
+        fi
+        sleep 0.1
+    done
+
+    if wait "$SERVER_PID"; then
+        status=0
+    else
+        status=$?
+    fi
+    SERVER_PID=
+    [ "$status" -eq 0 ] || {
+        sed -n '1,200p' "$log" >&2
+        die "server exited with status $status after $signal"
+    }
+
+    grep -q "$signal" "$log" || die "the central listener did not report $signal"
+    [ "$(grep -c 'shutdown signal received, draining shards' "$log")" -eq 1 ] ||
+        die "$signal did not start exactly one global shutdown"
+    [ "$(grep -c 'shard draining connections' "$log")" -eq "$EXPECTED_SHARDS" ] ||
+        die "$signal did not reach all $EXPECTED_SHARDS shards"
+    [ "$(grep -c 'all connections drained, exiting' "$log")" -eq "$EXPECTED_SHARDS" ] ||
+        die "all $EXPECTED_SHARDS shards did not complete their drain after $signal"
+}
+
+run_signal_case TERM
+run_signal_case INT
+
+echo "SIGTERM and SIGINT drained every shard cleanly"


### PR DESCRIPTION
## Summary

- receive SIGINT and SIGTERM once at the server level and broadcast a latched shutdown request to every shard
- let systemd send SIGTERM and allow ten seconds for the bounded five-second QUIC drain
- add a real-process signal test that exercises two shards on Linux
- prepare the v0.3.2 patch release

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --locked`
- `cargo test --workspace --all-targets --all-features --locked`
- `MASQUE_TEST_BIN="/Users/zibin/Dev/open_sources/masque-server/target/debug/masque-server" tests/systemd-shutdown.sh`
- `shellcheck install-latest.sh deploy/install.sh scripts/*.sh tests/*.sh tests/e2e/*.sh`