### PR TITLE
feat: add target UDP GSO and shard watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.4.1 - 2026-08-20
+
+### Added
+
+- CONNECT-UDP can opt into target-side Linux UDP segmentation offload with
+  `udp_proxy.enable_udp_gso`. Large equal-sized datagrams are submitted as one
+  scatter/gather super-packet without a userspace concatenation copy; small
+  datagrams retain the existing `sendmmsg` path, and explicit offload errors
+  disable GSO for that tunnel before retrying normally.
+- Each proxy shard publishes a once-per-second heartbeat and event-loop lag.
+  `/readyz` now fails when any shard is stale, and the packaged systemd unit
+  uses a 30-second watchdog that is pinged only while every shard is making
+  progress.
+- Prometheus exposition includes current shard heartbeat age plus current and
+  process-maximum event-loop lag. Collection remains optional and loopback
+  only.
+
+### Changed
+
+- The network benchmark accepts `MASQUE_BENCH_TARGET_GSO=0|1` for repeatable
+  target-egress A/B tests. In three alternating 5-second runs on the qualifying
+  Ubuntu loopback host, 1200-byte CONNECT-UDP application goodput improved from
+  an average 1.063 to 1.427 Gbit/s (34%) while 64-byte throughput remained
+  effectively unchanged. This validates the local Linux packet path; it is not
+  an estimate of external-network throughput.
+- Installation output and documentation identify Prometheus rules and Grafana
+  JSON as optional static assets. The installer does not install or start a
+  Prometheus or Grafana service on the VPS.
+
 ## 0.4.0 - 2026-08-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ a staging environment.
 - Bounded queues and backpressure across authentication and tunnel I/O
 - Linux `recvmmsg`/`sendmmsg`, UDP GRO, optional UDP GSO, and TUN offload
 - Multi-core sharding with `SO_REUSEPORT`
-- Loopback health/readiness endpoints, low-overhead Prometheus metrics,
-  packaged alert rules and a Grafana dashboard
-- Optional JSON logs and native systemd readiness notification
+- Optional loopback health/readiness endpoints and low-overhead Prometheus
+  metrics, with packaged static alert rules and a Grafana dashboard JSON
+- Optional JSON logs plus native systemd readiness and shard-liveness watchdog
 - Static Linux x86_64 release archives with a systemd installer
 
 ## Quick start
@@ -127,6 +127,9 @@ tar xzf masque-vVERSION-linux-x86_64.tar.gz
 cd masque-vVERSION-linux-x86_64
 sudo ./install.sh
 ```
+
+The monitoring files are optional static assets. Installation does not install
+or start Prometheus or Grafana on the server.
 
 The package installer creates an unprivileged `masque` system user, lets new
 installations choose either authentication mode, and enables the service. Set

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -110,6 +110,11 @@ deny_targets = [
 [udp_proxy]
 enabled = true
 uri_template = "/.well-known/masque/udp/{target_host}/{target_port}/"
+# This controls the UDP socket from the proxy to each target. It is separate
+# from quic.enable_udp_gso because the target and client egress paths can differ.
+# Leave it off until an external-path A/B test confirms no throughput or loss
+# regression on the target egress path.
+enable_udp_gso = false
 allow_targets = ["0.0.0.0/0", "::/0"]
 deny_targets = [
     "127.0.0.0/8",

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -663,8 +663,8 @@ echo "  Configuration:  $CONFIG_PATH"
 echo "  Authentication: $AUTH_MODE"
 echo "  Service:        $SERVICE_RESULT"
 echo "  Logs:           journalctl -u masque -f"
-echo "  Prometheus:     $PROMETHEUS_RULES_PATH"
-echo "  Grafana:        $GRAFANA_DASHBOARD_PATH"
+echo "  Prometheus rules (optional): $PROMETHEUS_RULES_PATH"
+echo "  Grafana JSON (optional):     $GRAFANA_DASHBOARD_PATH"
 
 # The per-socket truth behind the summary line above, so a server that
 # authenticates on one port and not another cannot read as if it did both.

--- a/deploy/systemd/masque.service
+++ b/deploy/systemd/masque.service
@@ -7,6 +7,10 @@ After=network-online.target
 [Service]
 Type=notify
 NotifyAccess=main
+# The process pings only while every proxy shard completes its heartbeat. A
+# wedged event loop therefore becomes a supervised failure, not a live-looking
+# process that accepts no useful traffic.
+WatchdogSec=30s
 User=masque
 Group=masque
 ExecStart=/usr/local/bin/masque-server --config /etc/masque/masque.toml

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,9 @@ No connection is concurrently mutated by two shards.
 When configured, a separate loopback TCP task serves health, readiness, and
 Prometheus requests. Shards update fixed atomic counters in batches and never
 format metrics or acquire the scrape-side listener-list lock. systemd readiness
-uses the same lifecycle state: ready after every socket is bound, not ready as
-soon as the bounded drain begins.
+uses the lifecycle state plus one heartbeat store per shard per second: ready
+after every socket is bound, not ready when a shard is stale or as soon as the
+bounded drain begins. The packaged watchdog uses the same liveness decision.
 
 ## Source layout
 
@@ -62,9 +63,9 @@ soon as the bounded drain begins.
 | `src/connection.rs` | Per-client QUIC/H3 state and deferred sends |
 | `src/metrics.rs` | Low-cardinality atomic counters and Prometheus rendering |
 | `src/observability.rs` | Bounded loopback health/readiness/metrics HTTP endpoint |
-| `src/systemd.rs` | Dependency-free systemd readiness notification |
+| `src/systemd.rs` | Dependency-free systemd readiness and watchdog notification |
 | `src/net/quic.rs` | QUIC UDP receive/send batching, GSO/GRO, and portable fallbacks |
-| `src/net/target_udp.rs` | Batched target UDP I/O and truncation detection |
+| `src/net/target_udp.rs` | Batched target UDP I/O, GSO, and truncation detection |
 | `src/tunnel/tcp.rs` | TCP connection setup and bounded bidirectional relay |
 | `src/tunnel/udp.rs` | Per-target CONNECT-UDP state and send staging |
 | `src/tunnel/ip.rs` | CONNECT-IP assignment and activity state |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,7 +292,7 @@ the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
-configuration is compatible with masque-server 0.4.0: /etc/masque/masque.toml
+configuration is compatible with masque-server 0.4.1: /etc/masque/masque.toml
 listener 0.0.0.0:443 auth=basic shards=1
 listener 0.0.0.0:4443 auth=client_cert shards=1
 ```
@@ -545,13 +545,19 @@ management networks denied unless access is intentional.
 [udp_proxy]
 enabled = true
 uri_template = "/.well-known/masque/udp/{target_host}/{target_port}/"
+enable_udp_gso = false
 allow_targets = ["0.0.0.0/0", "::/0"]
 deny_targets = ["127.0.0.0/8", "10.0.0.0/8", "::1/128"]
 ```
 
 The template must retain `{target_host}` and `{target_port}`. Apply the same
 internal-network restrictions used for TCP unless UDP access is intentionally
-different.
+different. `enable_udp_gso` batches equal-sized large client payloads into
+Linux UDP super-packets without first copying them into one contiguous
+userspace buffer. Small payloads continue through `sendmmsg`, where segmentation
+overhead would outweigh the saved kernel work. It is independent of
+`quic.enable_udp_gso`; keep it disabled until the target egress path has passed
+a loss and throughput A/B test.
 
 ## CONNECT-IP
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,7 +92,7 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
     sh
 ```
 
-`MASQUE_VERSION=0.4.0` selects `v0.4.0`. This is also how to install a
+`MASQUE_VERSION=0.4.1` selects `v0.4.1`. This is also how to install a
 prerelease explicitly; automatic resolution deliberately chooses only GitHub's
 latest stable release. Authentication, listen, TLS-source, and client
 provisioning variables apply only when `/etc/masque/masque.toml` does not yet
@@ -246,6 +246,8 @@ five-second margin before systemd may escalate to SIGKILL.
 
 systemd considers startup complete only after the process has bound every
 proxy listener and the optional observability endpoint and sent `READY=1`.
+The packaged unit also sets `WatchdogSec=30s`; pings stop if any shard misses
+its five-second liveness window, allowing systemd to restart a wedged process.
 Graceful shutdown sends `STOPPING=1` as readiness changes to false.
 
 SIGINT follows the same path for foreground runs. SIGHUP remains distinct: it
@@ -277,8 +279,9 @@ connectivity and throughput smoke test. Keep independent backups as part of
 normal operations even though the installer performs a temporary transactional
 rollback around the binary, unit, and packaged monitoring-asset replacement.
 
-For health checks, Prometheus scraping, alert rules, and the installed Grafana
-dashboard, see [Observability](observability.md).
+For optional health checks, Prometheus scraping, alert rules, and the dashboard
+JSON, see [Observability](observability.md). The installer copies those static
+assets but never installs or starts Prometheus or Grafana on the server.
 
 ## Diagnostics
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -19,11 +19,12 @@ through a firewall rule or unauthenticated reverse proxy.
 | Path | Success | Meaning |
 | --- | --- | --- |
 | `/healthz` | `200 ok` | The process and operational HTTP task are alive |
-| `/readyz` | `200 ready` | All proxy sockets are bound and the server is accepting traffic |
+| `/readyz` | `200 ready` | All proxy sockets are bound and every shard heartbeat is current |
 | `/metrics` | `200` | Prometheus text exposition |
 
-`/readyz` returns `503` before readiness and as soon as graceful shutdown
-starts. `/healthz` and `/metrics` remain available during the bounded drain.
+`/readyz` returns `503` before readiness, when any proxy shard has made no
+event-loop progress for five seconds, and as soon as graceful shutdown starts.
+`/healthz` and `/metrics` remain available during the bounded drain.
 Only `GET` and `HEAD` are accepted, requests time out after two seconds, request
 headers are capped at 8 KiB, and concurrency is bounded.
 
@@ -36,6 +37,11 @@ curl --fail http://127.0.0.1:9090/metrics
 ```
 
 ## Prometheus
+
+The installer does not install or start Prometheus or Grafana. It only writes
+optional rule and dashboard files; a lightweight VPS can run masque-server by
+itself and leave `[observability]` disabled. If collection is desired, run the
+collector elsewhere and reach loopback through an authenticated tunnel.
 
 Add the endpoint as a static target in the Prometheus instance running on the
 host:
@@ -86,6 +92,9 @@ All metric names start with `masque_`.
 | `masque_process_start_time_seconds` | gauge | — | Process start as a Unix timestamp |
 | `masque_process_uptime_seconds` | gauge | — | Current process uptime |
 | `masque_listener_shards` | gauge | `listener`, `auth` | Event loops assigned to the listener |
+| `masque_shard_heartbeat_age_seconds` | gauge | `listener`, `auth`, `shard` | Time since the shard last made event-loop progress |
+| `masque_event_loop_lag_seconds` | gauge | `listener`, `auth`, `shard` | Latest one-second heartbeat scheduling delay |
+| `masque_event_loop_lag_max_seconds` | gauge | `listener`, `auth`, `shard` | Largest heartbeat delay since startup |
 | `masque_connections_active` | gauge | `listener`, `auth` | Live QUIC connections |
 | `masque_connections_accepted_total` | counter | `listener`, `auth` | Accepted connection objects |
 | `masque_connections_rejected_total` | counter | `listener`, `auth`, `reason` | Connections rejected at a resource limit |
@@ -113,7 +122,9 @@ per datagram. Connection counts use object lifetime, while tunnel gauges are
 published once after a connection's event-loop work. Scraping is the only path
 that formats text or takes the listener-list read lock. Each shard owns its
 counter allocation, so event-loop cores never contend on a shared metric cache
-line; when `[observability]` is absent, collection performs no counter atomics.
+line. When `[observability]` is absent, traffic collection performs no counter
+atomics; each shard still performs one heartbeat store per second for readiness
+and systemd watchdog supervision.
 
 ## Logs and systemd readiness
 
@@ -127,7 +138,8 @@ masque-server --log-format json --config /etc/masque/masque.toml
 `RUST_LOG` and `-v` keep their existing filtering behavior. For the packaged
 service, add `--log-format json` to an `ExecStart` override when desired.
 
-The supplied unit uses `Type=notify`. The process sends `READY=1` only after all
-proxy sockets and the optional operational socket are bound, and sends
-`STOPPING=1` when graceful draining begins. Manual foreground runs need no
-special environment; notification is a no-op when `NOTIFY_SOCKET` is absent.
+The supplied unit uses `Type=notify` and `WatchdogSec=30s`. The process sends
+`READY=1` only after all proxy sockets and the optional operational socket are
+bound, sends watchdog pings only while every shard heartbeat is current, and
+sends `STOPPING=1` when graceful draining begins. Manual foreground runs need
+no special environment; notification is a no-op when `NOTIFY_SOCKET` is absent.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -33,7 +33,11 @@ Batching never sends a packet before the time supplied by quiche.
 Client bursts are staged per tunnel during one shard iteration and submitted
 with a direct `SYS_sendmmsg`. Target responses are drained with
 `SYS_recvmmsg`. On non-Linux systems, Tokio sends and receives individual
-datagrams.
+datagrams. When `udp_proxy.enable_udp_gso = true`, equal-sized large client
+payloads are submitted as scatter/gather segments of one UDP super-packet,
+avoiding a userspace concatenation copy. Small payloads remain on `sendmmsg`;
+an explicit kernel error disables GSO on that tunnel and retries through
+`sendmmsg`.
 
 Static releases use musl. Its public 64-bit `sendmmsg` wrapper loops through
 `sendmsg` to handle ABI differences, so both Linux send adapters deliberately
@@ -66,6 +70,7 @@ Important settings:
 | `listeners[].shards` | Aggregate multi-connection CPU parallelism for that listener |
 | `quic.enable_udp_gso` | QUIC send syscall and per-packet overhead |
 | `quic.enable_udp_gro` | QUIC receive syscall overhead |
+| `udp_proxy.enable_udp_gso` | Client-to-target UDP kernel overhead |
 | `quic.max_datagram_size` | Packet size and PMTU ceiling |
 | `quic.initial_max_*` | Initial bandwidth-delay window |
 | `quic.max_*_window` | Autotuning ceiling and memory bound |
@@ -89,10 +94,13 @@ MASQUE_BENCH_DURATION_SECS=10 \
 MASQUE_BENCH_WINDOW=256 \
 MASQUE_BENCH_EXPIRY_MS=1000 \
 MASQUE_BENCH_RTT_SAMPLES=100 \
+MASQUE_BENCH_TARGET_GSO=1 \
 scripts/network-bench.sh
 ```
 
-Set `MASQUE_BENCH_OBSERVABILITY=1` to enable the loopback endpoint and metric
+Use `MASQUE_BENCH_TARGET_GSO=0` and `1` in alternating runs to compare the
+target-side path; it defaults to `0`. Set
+`MASQUE_BENCH_OBSERVABILITY=1` to enable the loopback endpoint and metric
 updates during an A/B run; the default `0` measures the uninstrumented packet
 path.
 

--- a/scripts/network-bench.sh
+++ b/scripts/network-bench.sh
@@ -25,6 +25,15 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+case "${MASQUE_BENCH_TARGET_GSO:-0}" in
+    0) TARGET_GSO_TOML=false ;;
+    1) TARGET_GSO_TOML=true ;;
+    *)
+        echo "MASQUE_BENCH_TARGET_GSO must be 0 or 1" >&2
+        exit 2
+        ;;
+esac
+
 bash scripts/gen-certs.sh "$BENCH_DIR/certs"
 
 cat >"$BENCH_DIR/masque.toml" <<EOF
@@ -54,6 +63,7 @@ deny_targets = []
 
 [udp_proxy]
 enabled = true
+enable_udp_gso = $TARGET_GSO_TOML
 allow_targets = ["127.0.0.0/8"]
 deny_targets = []
 

--- a/src/address_pool.rs
+++ b/src/address_pool.rs
@@ -186,10 +186,10 @@ impl AddressPool {
         if self.is_gateway(&addr) {
             return Err(PoolError::AlreadyAllocated(addr));
         }
-        if !self
+        if self
             .reserved
             .get(&addr)
-            .is_some_and(|reserved_owner| reserved_owner == owner)
+            .is_none_or(|reserved_owner| reserved_owner != owner)
         {
             return Err(PoolError::NotReserved(addr));
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,6 +216,10 @@ pub struct UdpProxySection {
     pub uri_template: String,
     pub allow_targets: Vec<String>,
     pub deny_targets: Vec<String>,
+    /// Use UDP segmentation offload when relaying large client datagrams to
+    /// targets on Linux. Kept separate from the outer QUIC socket because the
+    /// two egress paths can have different offload support.
+    pub enable_udp_gso: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -360,6 +364,7 @@ impl Default for UdpProxySection {
             uri_template: "/.well-known/masque/udp/{target_host}/{target_port}/".into(),
             allow_targets: vec!["0.0.0.0/0".into()],
             deny_targets: vec!["127.0.0.0/8".into(), "10.0.0.0/8".into(), "::1/128".into()],
+            enable_udp_gso: false,
         }
     }
 }
@@ -702,11 +707,13 @@ discover_pmtu = true
 enabled = false
 allow_targets = ["192.168.0.0/16"]
 deny_targets = []
+enable_udp_gso = true
 "#,
         );
         assert!(!cfg.udp_proxy.enabled);
         assert_eq!(cfg.udp_proxy.allow_targets, vec!["192.168.0.0/16"]);
         assert!(cfg.udp_proxy.deny_targets.is_empty());
+        assert!(cfg.udp_proxy.enable_udp_gso);
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -9,9 +9,13 @@ use std::fmt::Write as _;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const RELAXED: Ordering = Ordering::Relaxed;
+/// A shard that has not completed an event-loop round within this interval is
+/// not ready. The normal heartbeat is once per second, leaving enough margin
+/// for scheduler jitter without hiding a genuinely stuck shard.
+const SHARD_STALE_AFTER: Duration = Duration::from_secs(5);
 
 /// Process-wide metrics and readiness state.
 pub(crate) struct Metrics {
@@ -52,7 +56,8 @@ impl Metrics {
         auth: &'static str,
         shards: usize,
     ) -> Vec<Arc<ShardMetrics>> {
-        let listener = ListenerMetrics::new(addr, auth, shards, self.enabled);
+        let listener =
+            ListenerMetrics::new(addr, auth, shards, self.enabled, self.elapsed_millis());
         let shard_metrics = listener.shards.clone();
         self.listeners
             .write()
@@ -71,7 +76,27 @@ impl Metrics {
     }
 
     pub(crate) fn is_ready(&self) -> bool {
-        self.ready.load(Ordering::Acquire)
+        self.is_ready_at(self.elapsed_millis())
+    }
+
+    fn is_ready_at(&self, now_millis: u64) -> bool {
+        if !self.ready.load(Ordering::Acquire) {
+            return false;
+        }
+
+        let stale_after = SHARD_STALE_AFTER.as_millis() as u64;
+        self.listeners
+            .read()
+            .expect("metrics listener list poisoned")
+            .iter()
+            .flat_map(|listener| &listener.shards)
+            .all(|shard| {
+                now_millis.saturating_sub(shard.last_heartbeat_millis.load(RELAXED)) <= stale_after
+            })
+    }
+
+    pub(crate) fn elapsed_millis(&self) -> u64 {
+        self.started.elapsed().as_millis().min(u64::MAX as u128) as u64
     }
 
     pub(crate) fn record_roster_reload(&self, success: bool) {
@@ -113,7 +138,7 @@ impl Metrics {
         metric_header(
             &mut out,
             "masque_server_ready",
-            "Whether all proxy listeners are ready to accept traffic.",
+            "Whether proxy startup is complete and every shard heartbeat is current.",
             "gauge",
         );
         writeln!(out, "masque_server_ready {}", u8::from(self.is_ready())).unwrap();
@@ -174,13 +199,14 @@ impl Metrics {
         )
         .unwrap();
 
+        let now_millis = self.elapsed_millis();
         let listeners = self
             .listeners
             .read()
             .expect("metrics listener list poisoned");
         render_listener_headers(&mut out);
         for listener in listeners.iter() {
-            listener.render(&mut out);
+            listener.render(&mut out, now_millis);
         }
         out
     }
@@ -193,7 +219,13 @@ struct ListenerMetrics {
 }
 
 impl ListenerMetrics {
-    fn new(addr: SocketAddr, auth: &'static str, shards: usize, enabled: bool) -> Self {
+    fn new(
+        addr: SocketAddr,
+        auth: &'static str,
+        shards: usize,
+        enabled: bool,
+        now_millis: u64,
+    ) -> Self {
         Self {
             label: format!(
                 "listener=\"{}\",auth=\"{}\"",
@@ -201,7 +233,7 @@ impl ListenerMetrics {
                 escape_label(auth)
             ),
             shards: (0..shards)
-                .map(|_| Arc::new(ShardMetrics::new(enabled)))
+                .map(|_| Arc::new(ShardMetrics::new(enabled, now_millis)))
                 .collect(),
         }
     }
@@ -213,7 +245,7 @@ impl ListenerMetrics {
             .sum()
     }
 
-    fn render(&self, out: &mut String) {
+    fn render(&self, out: &mut String, now_millis: u64) {
         let label = &self.label;
         writeln!(
             out,
@@ -221,6 +253,28 @@ impl ListenerMetrics {
             self.shards.len()
         )
         .unwrap();
+        for (index, shard) in self.shards.iter().enumerate() {
+            let heartbeat_age = now_millis.saturating_sub(shard.last_heartbeat_millis.load(RELAXED))
+                as f64
+                / 1_000.0;
+            let lag = shard.event_loop_lag_micros.load(RELAXED) as f64 / 1_000_000.0;
+            let lag_max = shard.event_loop_lag_max_micros.load(RELAXED) as f64 / 1_000_000.0;
+            writeln!(
+                out,
+                "masque_shard_heartbeat_age_seconds{{{label},shard=\"{index}\"}} {heartbeat_age:.6}"
+            )
+            .unwrap();
+            writeln!(
+                out,
+                "masque_event_loop_lag_seconds{{{label},shard=\"{index}\"}} {lag:.6}"
+            )
+            .unwrap();
+            writeln!(
+                out,
+                "masque_event_loop_lag_max_seconds{{{label},shard=\"{index}\"}} {lag_max:.6}"
+            )
+            .unwrap();
+        }
         render_value(
             out,
             "masque_connections_active",
@@ -328,6 +382,12 @@ impl ListenerMetrics {
 /// scrape reads across these allocations.
 pub(crate) struct ShardMetrics {
     enabled: bool,
+    /// Monotonic process-relative timestamp. Updated once per second even when
+    /// Prometheus metrics are disabled because readiness and systemd watchdog
+    /// supervision depend on it.
+    last_heartbeat_millis: AtomicU64,
+    event_loop_lag_micros: AtomicU64,
+    event_loop_lag_max_micros: AtomicU64,
     connections_active: AtomicU64,
     connections_accepted: AtomicU64,
     connections_rejected_limit: AtomicU64,
@@ -349,9 +409,12 @@ pub(crate) struct ShardMetrics {
 }
 
 impl ShardMetrics {
-    fn new(enabled: bool) -> Self {
+    fn new(enabled: bool, now_millis: u64) -> Self {
         Self {
             enabled,
+            last_heartbeat_millis: AtomicU64::new(now_millis),
+            event_loop_lag_micros: AtomicU64::new(0),
+            event_loop_lag_max_micros: AtomicU64::new(0),
             connections_active: AtomicU64::new(0),
             connections_accepted: AtomicU64::new(0),
             connections_rejected_limit: AtomicU64::new(0),
@@ -375,6 +438,20 @@ impl ShardMetrics {
 
     pub(crate) fn enabled(&self) -> bool {
         self.enabled
+    }
+
+    /// Publish liveness once per maintenance interval rather than on every
+    /// packet batch, keeping this out of the high-throughput hot path.
+    pub(crate) fn record_heartbeat(&self, now_millis: u64, lag: Duration) {
+        self.last_heartbeat_millis.store(now_millis, RELAXED);
+        if !self.enabled {
+            return;
+        }
+
+        let lag_micros = lag.as_micros().min(u64::MAX as u128) as u64;
+        self.event_loop_lag_micros.store(lag_micros, RELAXED);
+        self.event_loop_lag_max_micros
+            .fetch_max(lag_micros, RELAXED);
     }
 
     pub(crate) fn connection_opened(&self) {
@@ -554,6 +631,21 @@ fn render_listener_headers(out: &mut String) {
             "gauge",
         ),
         (
+            "masque_shard_heartbeat_age_seconds",
+            "Seconds since a proxy shard last completed its event-loop heartbeat.",
+            "gauge",
+        ),
+        (
+            "masque_event_loop_lag_seconds",
+            "Delay of the latest scheduled proxy-shard heartbeat.",
+            "gauge",
+        ),
+        (
+            "masque_event_loop_lag_max_seconds",
+            "Largest scheduled proxy-shard heartbeat delay since process start.",
+            "gauge",
+        ),
+        (
             "masque_connections_active",
             "Currently active QUIC connections.",
             "gauge",
@@ -656,6 +748,7 @@ mod tests {
         listener.record_send_batch(3, 3600);
         listener.update_tunnels([0, 0, 0], [1, 2, 1]);
         listener.record_auth_success();
+        listener.record_heartbeat(metrics.elapsed_millis(), Duration::from_millis(25));
         shards[1].connection_opened();
 
         let rendered = metrics.render();
@@ -670,6 +763,9 @@ mod tests {
         ));
         assert!(rendered.contains(
             "masque_tunnels_active{listener=\"127.0.0.1:8449\",auth=\"basic\",protocol=\"udp\"} 2"
+        ));
+        assert!(rendered.contains(
+            "masque_event_loop_lag_seconds{listener=\"127.0.0.1:8449\",auth=\"basic\",shard=\"0\"} 0.025000"
         ));
         assert!(!rendered.contains("username="));
         assert!(!rendered.contains("target="));
@@ -699,12 +795,30 @@ mod tests {
         shard.record_receive_batch(8, 9600);
         shard.record_send_batch(8, 9600);
         shard.update_tunnels([0; 3], [1; 3]);
+        shard.record_heartbeat(123, Duration::from_millis(25));
         let _pending = shard.auth_pending_guard();
 
         assert_eq!(shard.connections_active.load(RELAXED), 0);
         assert_eq!(shard.quic_receive_packets.load(RELAXED), 0);
         assert_eq!(shard.quic_send_packets.load(RELAXED), 0);
         assert_eq!(shard.auth_pending.load(RELAXED), 0);
+        assert_eq!(shard.last_heartbeat_millis.load(RELAXED), 123);
+        assert_eq!(shard.event_loop_lag_micros.load(RELAXED), 0);
+    }
+
+    #[test]
+    fn readiness_fails_closed_when_any_shard_heartbeat_is_stale() {
+        let metrics = Metrics::new(false);
+        let shards = metrics.register_listener("127.0.0.1:8449".parse().unwrap(), "basic", 1);
+        let registered_at = shards[0].last_heartbeat_millis.load(RELAXED);
+        let stale_after = SHARD_STALE_AFTER.as_millis() as u64;
+        metrics.set_ready(true);
+
+        assert!(metrics.is_ready_at(registered_at + stale_after));
+        assert!(!metrics.is_ready_at(registered_at + stale_after + 1));
+
+        shards[0].record_heartbeat(registered_at + stale_after + 1, Duration::ZERO);
+        assert!(metrics.is_ready_at(registered_at + stale_after + 1));
     }
 
     #[test]

--- a/src/net/target_udp.rs
+++ b/src/net/target_udp.rs
@@ -10,6 +10,147 @@
 /// Datagrams moved per syscall in either direction.
 pub const TARGET_BATCH_SIZE: usize = 16;
 
+#[cfg(target_os = "linux")]
+const UDP_MAX_GSO_PAYLOAD: usize = 65_507;
+
+/// `sendmmsg` already amortizes the syscall for small datagrams. Below this
+/// size, building a UDP_SEGMENT message costs more than the kernel work it
+/// saves on the Linux loopback path used by the benchmark suite.
+#[cfg(target_os = "linux")]
+const UDP_MIN_GSO_SEGMENT_SIZE: usize = 512;
+
+#[cfg(target_os = "linux")]
+const CONTROL_WORDS: usize = 4;
+
+#[cfg(target_os = "linux")]
+#[repr(C, align(8))]
+#[derive(Clone, Copy, Default)]
+struct ControlBuffer {
+    words: [usize; CONTROL_WORDS],
+}
+
+#[cfg(target_os = "linux")]
+impl ControlBuffer {
+    fn set_udp_segment(&mut self, segment_size: u16) -> usize {
+        self.words.fill(0);
+
+        // SAFETY: ControlBuffer is suitably aligned and large enough for one
+        // cmsghdr plus a u16 payload, as asserted by the test below.
+        unsafe {
+            let header = self.words.as_mut_ptr().cast::<libc::cmsghdr>();
+            (*header).cmsg_level = libc::IPPROTO_UDP;
+            (*header).cmsg_type = libc::UDP_SEGMENT;
+            (*header).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as _;
+            libc::CMSG_DATA(header).cast::<u16>().write(segment_size);
+
+            libc::CMSG_SPACE(std::mem::size_of::<u16>() as _) as usize
+        }
+    }
+}
+
+/// One kernel message in a target-side UDP send batch.
+///
+/// With GSO, several payload vectors become scatter/gather segments of one
+/// UDP super-packet. The kernel splits their concatenated contents back into
+/// datagrams without a userspace copy.
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct SendGroup {
+    first: usize,
+    segments: usize,
+    segment_size: usize,
+}
+
+#[cfg(target_os = "linux")]
+fn plan_send(payloads: &[Vec<u8>], enable_gso: bool) -> ([SendGroup; TARGET_BATCH_SIZE], usize) {
+    let mut groups = [SendGroup::default(); TARGET_BATCH_SIZE];
+    let count = payloads.len().min(TARGET_BATCH_SIZE);
+    let mut group_count = 0;
+    let mut first = 0;
+
+    while first < count {
+        let segment_size = payloads[first].len();
+        let mut segments = 1;
+        let mut total = segment_size;
+
+        if enable_gso
+            && segment_size >= UDP_MIN_GSO_SEGMENT_SIZE
+            && segment_size <= u16::MAX as usize
+        {
+            while first + segments < count && segments < TARGET_BATCH_SIZE {
+                let next = payloads[first + segments].len();
+                if next == 0 || next > segment_size || total + next > UDP_MAX_GSO_PAYLOAD {
+                    break;
+                }
+
+                // Equal segments may continue the aggregate. One shorter
+                // segment is a legal tail, but it must end this message so the
+                // following datagram cannot be merged behind it.
+                segments += 1;
+                total += next;
+                if next < segment_size {
+                    break;
+                }
+            }
+        }
+
+        groups[group_count] = SendGroup {
+            first,
+            segments,
+            segment_size,
+        };
+        group_count += 1;
+        first += segments;
+    }
+
+    (groups, group_count)
+}
+
+/// Probe whether Linux accepts UDP segmentation offload on this socket.
+///
+/// The option is reset immediately: actual super-packets carry a per-message
+/// `UDP_SEGMENT` control message.
+#[cfg(target_os = "linux")]
+pub fn detect_udp_gso(fd: std::os::fd::RawFd, segment_size: usize) -> bool {
+    let segment_size = segment_size.min(u16::MAX as usize) as libc::c_int;
+    let disabled: libc::c_int = 0;
+
+    // SAFETY: Both values are valid integer socket-option payloads and `fd`
+    // belongs to a live UDP socket.
+    unsafe {
+        if libc::setsockopt(
+            fd,
+            libc::IPPROTO_UDP,
+            libc::UDP_SEGMENT,
+            (&segment_size as *const libc::c_int).cast(),
+            std::mem::size_of_val(&segment_size) as libc::socklen_t,
+        ) != 0
+        {
+            return false;
+        }
+
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_UDP,
+            libc::UDP_SEGMENT,
+            (&disabled as *const libc::c_int).cast(),
+            std::mem::size_of_val(&disabled) as libc::socklen_t,
+        ) == 0
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn is_udp_gso_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::EINVAL)
+            | Some(libc::EIO)
+            | Some(libc::EMSGSIZE)
+            | Some(libc::ENOPROTOOPT)
+            | Some(libc::EOPNOTSUPP)
+    )
+}
+
 /// Reusable storage for one batched read from a target socket.
 pub struct TargetRecvBatch {
     buffers: Vec<Vec<u8>>,
@@ -138,40 +279,13 @@ pub unsafe fn recv_mmsg(
     Ok(received)
 }
 
-/// Send a batch of datagrams on a connected socket in one syscall.
-///
-/// Returns how many were accepted; the caller re-queues or drops the rest.
-///
-/// # Safety
-///
-/// `fd` must be a live, connected, nonblocking UDP socket.
 #[cfg(target_os = "linux")]
-pub unsafe fn send_mmsg(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::io::Result<usize> {
-    use std::os::raw::c_void;
-
-    let count = payloads.len().min(TARGET_BATCH_SIZE);
-    if count == 0 {
-        return Ok(0);
-    }
-
-    // SAFETY: Zero is a valid initial representation for these C I/O structs.
-    let mut iovecs: [libc::iovec; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
-    // SAFETY: See above.
-    let mut headers: [libc::mmsghdr; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
-
-    for (index, payload) in payloads.iter().take(count).enumerate() {
-        iovecs[index] = libc::iovec {
-            iov_base: payload.as_ptr().cast_mut().cast::<c_void>(),
-            iov_len: payload.len(),
-        };
-        let header = &mut headers[index].msg_hdr;
-        // Connected socket, so the destination is implicit.
-        header.msg_iov = &mut iovecs[index];
-        header.msg_iovlen = 1;
-        header.msg_flags = 0;
-    }
-
-    // SAFETY: Every header points at live storage above for the duration of
+unsafe fn raw_send_mmsg(
+    fd: std::os::fd::RawFd,
+    headers: &mut [libc::mmsghdr; TARGET_BATCH_SIZE],
+    count: usize,
+) -> std::io::Result<usize> {
+    // SAFETY: The caller keeps every buffer referenced by `headers` alive for
     // this nonblocking call. Issued as a raw syscall because musl's `sendmmsg`
     // wrapper degrades into a loop of `sendmsg`.
     let result = unsafe {
@@ -186,8 +300,99 @@ pub unsafe fn send_mmsg(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::io
     if result < 0 {
         Err(std::io::Error::last_os_error())
     } else {
-        Ok(result as usize)
+        Ok((result as usize).min(count))
     }
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn send_mmsg_plain(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::io::Result<usize> {
+    use std::os::raw::c_void;
+
+    // Keep the disabled and small-datagram path equivalent to the original
+    // sendmmsg adapter: one setup pass and no GSO planning or control buffers.
+    // SAFETY: Zero is a valid initial representation for these C I/O structs.
+    let mut iovecs: [libc::iovec; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
+    // SAFETY: See above.
+    let mut headers: [libc::mmsghdr; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
+
+    for (index, payload) in payloads.iter().enumerate() {
+        iovecs[index] = libc::iovec {
+            iov_base: payload.as_ptr().cast_mut().cast::<c_void>(),
+            iov_len: payload.len(),
+        };
+        headers[index].msg_hdr.msg_iov = &mut iovecs[index];
+        headers[index].msg_hdr.msg_iovlen = 1;
+    }
+
+    // SAFETY: Every header points at the live iovec and payload storage above.
+    unsafe { raw_send_mmsg(fd, &mut headers, payloads.len()) }
+}
+
+/// Send a batch of datagrams on a connected socket in one syscall.
+///
+/// Returns how many logical datagrams were accepted; the caller drops the
+/// rest. With GSO enabled, several logical datagrams can be accepted as one
+/// kernel message.
+///
+/// # Safety
+///
+/// `fd` must be a live, connected, nonblocking UDP socket.
+#[cfg(target_os = "linux")]
+pub unsafe fn send_mmsg(
+    fd: std::os::fd::RawFd,
+    payloads: &[Vec<u8>],
+    enable_gso: bool,
+) -> std::io::Result<usize> {
+    use std::os::raw::c_void;
+
+    let count = payloads.len().min(TARGET_BATCH_SIZE);
+    if count == 0 {
+        return Ok(0);
+    }
+    let payloads = &payloads[..count];
+
+    // Batches normally carry one traffic shape. If the first segment is small,
+    // retain the exact low-overhead sendmmsg path for the whole batch; a later
+    // large datagram can start a GSO batch on the next event-loop round.
+    if !enable_gso || payloads[0].len() < UDP_MIN_GSO_SEGMENT_SIZE {
+        // SAFETY: This function carries the same live-socket contract.
+        return unsafe { send_mmsg_plain(fd, payloads) };
+    }
+
+    let (groups, group_count) = plan_send(payloads, true);
+
+    // SAFETY: Zero is a valid initial representation for these C I/O structs.
+    let mut iovecs: [libc::iovec; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
+    // SAFETY: See above.
+    let mut headers: [libc::mmsghdr; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
+    let mut controls = [ControlBuffer::default(); TARGET_BATCH_SIZE];
+
+    for (index, payload) in payloads.iter().take(count).enumerate() {
+        iovecs[index] = libc::iovec {
+            iov_base: payload.as_ptr().cast_mut().cast::<c_void>(),
+            iov_len: payload.len(),
+        };
+    }
+
+    for (index, group) in groups.iter().take(group_count).enumerate() {
+        let header = &mut headers[index].msg_hdr;
+        // Connected socket, so the destination is implicit.
+        header.msg_iov = &mut iovecs[group.first];
+        header.msg_iovlen = group.segments;
+        if group.segments > 1 {
+            let control_len = controls[index].set_udp_segment(group.segment_size as u16);
+            header.msg_control = controls[index].words.as_mut_ptr().cast::<c_void>();
+            header.msg_controllen = control_len as _;
+        }
+        header.msg_flags = 0;
+    }
+
+    // SAFETY: Every header points at live iovec, payload, and control storage.
+    let sent_messages = unsafe { raw_send_mmsg(fd, &mut headers, group_count) }?;
+    Ok(groups[..sent_messages]
+        .iter()
+        .map(|group| group.segments)
+        .sum())
 }
 
 #[cfg(test)]
@@ -226,6 +431,130 @@ mod tests {
         batch.set_single(4);
 
         assert_eq!(batch.datagrams(1).count(), 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gso_plan_groups_equal_segments_and_a_short_tail() {
+        let payloads = vec![vec![1; 1_200], vec![2; 1_200], vec![3; 600], vec![4; 1_200]];
+        let (groups, count) = plan_send(&payloads, true);
+
+        assert_eq!(
+            &groups[..count],
+            &[
+                SendGroup {
+                    first: 0,
+                    segments: 3,
+                    segment_size: 1_200,
+                },
+                SendGroup {
+                    first: 3,
+                    segments: 1,
+                    segment_size: 1_200,
+                },
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn non_gso_plan_keeps_every_datagram_separate() {
+        let payloads = vec![vec![1; 1_200], vec![2; 1_200], vec![3; 600]];
+        let (groups, count) = plan_send(&payloads, false);
+
+        assert_eq!(count, 3);
+        assert!(groups[..count].iter().all(|group| group.segments == 1));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gso_plan_keeps_small_datagrams_on_the_sendmmsg_path() {
+        let payloads = vec![vec![1; 64], vec![2; 64], vec![3; 32]];
+        let (groups, count) = plan_send(&payloads, true);
+
+        assert_eq!(count, 3);
+        assert!(groups[..count].iter().all(|group| group.segments == 1));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gso_plan_keeps_an_empty_datagram_separate() {
+        let payloads = vec![vec![1; 1_200], vec![], vec![2; 1_200]];
+        let (groups, count) = plan_send(&payloads, true);
+
+        assert_eq!(count, 3);
+        assert!(groups[..count].iter().all(|group| group.segments == 1));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn control_buffer_fits_udp_segment_message() {
+        // SAFETY: The argument is a small constant payload length.
+        let required = unsafe { libc::CMSG_SPACE(std::mem::size_of::<u16>() as _) as usize };
+        assert!(std::mem::size_of::<ControlBuffer>() >= required);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn gso_scatter_gather_preserves_datagram_boundaries() {
+        use std::os::fd::AsRawFd as _;
+
+        let receiver = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        sender.connect(receiver.local_addr().unwrap()).unwrap();
+        sender.set_nonblocking(true).unwrap();
+        if !detect_udp_gso(sender.as_raw_fd(), 1_200) {
+            return;
+        }
+
+        let payloads = vec![vec![1; 1_200], vec![2; 1_200], vec![3; 600]];
+        // SAFETY: `sender` is live, connected, and nonblocking.
+        let sent = unsafe { send_mmsg(sender.as_raw_fd(), &payloads, true) }.unwrap();
+        assert_eq!(sent, payloads.len());
+
+        let expected = [(1_200, 1), (1_200, 2), (600, 3)];
+        let mut buffer = [0; 1_500];
+        for (len, byte) in expected {
+            let received = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                receiver.recv(&mut buffer),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(received, len);
+            assert!(buffer[..received].iter().all(|value| *value == byte));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn gso_enabled_small_datagrams_use_plain_sendmmsg() {
+        use std::os::fd::AsRawFd as _;
+
+        let receiver = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        sender.connect(receiver.local_addr().unwrap()).unwrap();
+        sender.set_nonblocking(true).unwrap();
+
+        let payloads = vec![vec![1; 64], vec![2; 64], vec![3; 32]];
+        // SAFETY: `sender` is live, connected, and nonblocking.
+        let sent = unsafe { send_mmsg(sender.as_raw_fd(), &payloads, true) }.unwrap();
+        assert_eq!(sent, payloads.len());
+
+        let expected = [(64, 1), (64, 2), (32, 3)];
+        let mut buffer = [0; 128];
+        for (len, byte) in expected {
+            let received = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                receiver.recv(&mut buffer),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(received, len);
+            assert!(buffer[..received].iter().all(|value| *value == byte));
+        }
     }
 
     /// A response too large for a QUIC DATAGRAM cannot reach the client, and

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -874,6 +874,8 @@ impl Server {
 
     /// Run every shard until they all stop.
     pub async fn run(&mut self) -> anyhow::Result<()> {
+        let watchdog_timeout =
+            systemd::watchdog_timeout().context("invalid systemd watchdog environment")?;
         if let Some(shard) = self.shards.first() {
             Self::spawn_roster_reloader(Arc::clone(&shard.shared));
         }
@@ -889,10 +891,16 @@ impl Server {
 
         let observability_task = self.observability.take().map(ObservabilityServer::spawn);
         self.metrics.set_ready(true);
+        let watchdog_task = watchdog_timeout.map(|timeout| {
+            spawn_systemd_watchdog(timeout, Arc::clone(&self.metrics), shutdown_rx.clone())
+        });
         if let Err(error) = systemd::notify("READY=1\nSTATUS=Ready to serve MASQUE traffic") {
             self.metrics.begin_shutdown();
             shutdown_listener.abort();
             if let Some(task) = observability_task {
+                task.abort();
+            }
+            if let Some(task) = watchdog_task {
                 task.abort();
             }
             return Err(error).context("failed to notify systemd that the server is ready");
@@ -927,6 +935,9 @@ impl Server {
             shutdown_listener.abort();
             readiness_task.abort();
             if let Some(task) = observability_task {
+                task.abort();
+            }
+            if let Some(task) = watchdog_task {
                 task.abort();
             }
             return outcome;
@@ -982,8 +993,59 @@ impl Server {
         if let Some(task) = observability_task {
             task.abort();
         }
+        if let Some(task) = watchdog_task {
+            task.abort();
+        }
         outcome
     }
+}
+
+/// Ping systemd only while every proxy shard is making progress. If one shard
+/// stops completing its once-per-second heartbeat, readiness fails and pings
+/// are withheld so `WatchdogSec` can restart the process.
+fn spawn_systemd_watchdog(
+    timeout: Duration,
+    metrics: Arc<Metrics>,
+    mut shutdown: watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    let interval = systemd::watchdog_ping_interval(timeout);
+    info!(
+        timeout_secs = timeout.as_secs_f64(),
+        ping_interval_secs = interval.as_secs_f64(),
+        "systemd watchdog enabled"
+    );
+
+    tokio::spawn(async move {
+        let start = tokio::time::Instant::now() + interval;
+        let mut ticker = tokio::time::interval_at(start, interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut withheld = false;
+
+        loop {
+            tokio::select! {
+                result = shutdown.wait_for(|requested| *requested) => {
+                    let _ = result;
+                    return;
+                }
+                _ = ticker.tick() => {
+                    if !metrics.is_ready() {
+                        if !withheld {
+                            warn!("withholding systemd watchdog ping because a shard is stale");
+                            withheld = true;
+                        }
+                        continue;
+                    }
+
+                    withheld = false;
+                    match systemd::notify("WATCHDOG=1") {
+                        Ok(true) => {}
+                        Ok(false) => warn!("WATCHDOG_USEC is set but NOTIFY_SOCKET is absent"),
+                        Err(error) => warn!(%error, "failed to ping systemd watchdog"),
+                    }
+                }
+            }
+        }
+    })
 }
 
 /// Register one listener for the process shutdown signals and latch the result
@@ -1736,6 +1798,8 @@ impl Shard {
         let mut drain_deadline: Option<Instant> = None;
         const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
         let mut next_idle_sweep = Instant::now() + IDLE_SWEEP_INTERVAL;
+        self.metrics
+            .record_heartbeat(self.shared.metrics.elapsed_millis(), Duration::ZERO);
         // The roster generation this shard has already enforced.
         let mut applied_roster_generation = self.shared.clients.generation();
         // The connections serviced in the current round. Held across
@@ -1929,6 +1993,9 @@ impl Shard {
             // stays in the past and pins the wakeup above to zero.
             let now = Instant::now();
             if now >= next_idle_sweep {
+                let event_loop_lag = now.saturating_duration_since(next_idle_sweep);
+                self.metrics
+                    .record_heartbeat(self.shared.metrics.elapsed_millis(), event_loop_lag);
                 next_idle_sweep = now + IDLE_SWEEP_INTERVAL;
                 if !shutting_down {
                     // Cheap in the common case: one atomic read, and a scan
@@ -2416,6 +2483,7 @@ impl Shard {
             .quic
             .max_datagram_size
             .clamp(1, MAX_DATAGRAM_SIZE);
+        let enable_target_udp_gso = self.config.udp_proxy.enable_udp_gso;
         for (stream_id, target) in pending_udp_setups {
             if client.tunnel_count() >= max_tunnels {
                 warn!(
@@ -2468,6 +2536,21 @@ impl Shard {
                                 }
                                 continue;
                             }
+                            #[cfg(target_os = "linux")]
+                            let target_udp_gso = if enable_target_udp_gso {
+                                use std::os::fd::AsRawFd as _;
+                                target_udp::detect_udp_gso(
+                                    std_sock.as_raw_fd(),
+                                    target_datagram_size,
+                                )
+                            } else {
+                                false
+                            };
+                            #[cfg(not(target_os = "linux"))]
+                            let target_udp_gso = {
+                                let _ = enable_target_udp_gso;
+                                false
+                            };
                             let recv_std = match std_sock.try_clone() {
                                 Ok(socket) => socket,
                                 Err(e) => {
@@ -2529,11 +2612,17 @@ impl Shard {
                                         }
                                     });
                                     let tunnel = UdpTunnel::from_socket(
-                                        stream_id, addr, std_sock, socket, recv_task,
+                                        stream_id,
+                                        addr,
+                                        std_sock,
+                                        socket,
+                                        recv_task,
+                                        target_udp_gso,
                                     );
                                     info!(
                                         stream_id,
                                         target = %addr,
+                                        udp_gso = target_udp_gso,
                                         "UDP tunnel established"
                                     );
                                     client.udp_tunnels.insert(stream_id, tunnel);

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -9,6 +9,60 @@ pub(crate) fn notify(message: &str) -> std::io::Result<bool> {
     imp::notify(message)
 }
 
+/// Return systemd's service watchdog timeout when this process is the service
+/// main PID. An absent or zero `WATCHDOG_USEC` means watchdog supervision is
+/// disabled, including for manual launches.
+pub(crate) fn watchdog_timeout() -> std::io::Result<Option<std::time::Duration>> {
+    parse_watchdog(
+        std::env::var_os("WATCHDOG_USEC").as_deref(),
+        std::env::var_os("WATCHDOG_PID").as_deref(),
+        std::process::id(),
+    )
+}
+
+/// Ping well before the deadline. Very small synthetic values are clamped to
+/// one nanosecond so a positive interval cannot create a zero-duration Tokio
+/// timer.
+pub(crate) fn watchdog_ping_interval(timeout: std::time::Duration) -> std::time::Duration {
+    timeout
+        .checked_div(3)
+        .filter(|interval| !interval.is_zero())
+        .unwrap_or(std::time::Duration::from_nanos(1))
+}
+
+fn parse_watchdog(
+    usec: Option<&std::ffi::OsStr>,
+    pid: Option<&std::ffi::OsStr>,
+    current_pid: u32,
+) -> std::io::Result<Option<std::time::Duration>> {
+    use std::io::{Error, ErrorKind};
+
+    if let Some(pid) = pid {
+        let pid = pid
+            .to_str()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidData, "WATCHDOG_PID is not UTF-8"))?
+            .parse::<u32>()
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "WATCHDOG_PID is not an integer"))?;
+        if pid != current_pid {
+            return Ok(None);
+        }
+    }
+
+    let Some(usec) = usec else {
+        return Ok(None);
+    };
+    let usec = usec
+        .to_str()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "WATCHDOG_USEC is not UTF-8"))?
+        .parse::<u64>()
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "WATCHDOG_USEC is not an integer"))?;
+    if usec == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(std::time::Duration::from_micros(usec)))
+}
+
 #[cfg(unix)]
 mod imp {
     use std::ffi::OsStr;
@@ -99,6 +153,54 @@ mod imp {
             let read = receiver.recv(&mut buf).unwrap();
             assert_eq!(&buf[..read], b"READY=1");
         }
+    }
+}
+
+#[cfg(test)]
+mod watchdog_tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use std::time::Duration;
+
+    #[test]
+    fn absent_or_zero_watchdog_is_disabled() {
+        assert_eq!(parse_watchdog(None, None, 42).unwrap(), None);
+        assert_eq!(
+            parse_watchdog(Some(OsStr::new("0")), None, 42).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn watchdog_is_scoped_to_the_service_main_pid() {
+        assert_eq!(
+            parse_watchdog(Some(OsStr::new("30000000")), Some(OsStr::new("41")), 42).unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_watchdog(Some(OsStr::new("30000000")), Some(OsStr::new("42")), 42).unwrap(),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn malformed_watchdog_environment_is_rejected() {
+        assert!(parse_watchdog(Some(OsStr::new("later")), None, 42).is_err());
+        assert!(
+            parse_watchdog(Some(OsStr::new("30000000")), Some(OsStr::new("main")), 42).is_err()
+        );
+    }
+
+    #[test]
+    fn watchdog_ping_is_safely_ahead_of_the_deadline() {
+        assert_eq!(
+            watchdog_ping_interval(Duration::from_secs(30)),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            watchdog_ping_interval(Duration::from_micros(1)),
+            Duration::from_nanos(333)
+        );
     }
 }
 

--- a/src/tunnel/udp.rs
+++ b/src/tunnel/udp.rs
@@ -10,6 +10,8 @@ use std::time::Instant;
 use tokio::net::UdpSocket;
 use tokio::task::JoinHandle;
 use tracing::debug;
+#[cfg(target_os = "linux")]
+use tracing::warn;
 
 #[cfg(target_os = "linux")]
 use crate::net::target_udp;
@@ -40,6 +42,9 @@ pub struct UdpTunnel {
     /// staging them turns what was a syscall per datagram into one per burst.
     send_stage: Vec<Vec<u8>>,
     staged: usize,
+    /// Whether target-side UDP segmentation offload is active on Linux.
+    #[cfg(target_os = "linux")]
+    udp_gso: bool,
 }
 
 impl UdpTunnel {
@@ -76,6 +81,8 @@ impl UdpTunnel {
             recv_task: None,
             send_stage: Vec::new(),
             staged: 0,
+            #[cfg(target_os = "linux")]
+            udp_gso: false,
         })
     }
 
@@ -85,7 +92,11 @@ impl UdpTunnel {
         send_socket: std::net::UdpSocket,
         socket: Arc<UdpSocket>,
         recv_task: JoinHandle<()>,
+        udp_gso: bool,
     ) -> Self {
+        #[cfg(not(target_os = "linux"))]
+        let _ = udp_gso;
+
         Self {
             stream_id,
             socket,
@@ -95,6 +106,8 @@ impl UdpTunnel {
             recv_task: Some(recv_task),
             send_stage: Vec::new(),
             staged: 0,
+            #[cfg(target_os = "linux")]
+            udp_gso,
         }
     }
 
@@ -154,9 +167,33 @@ impl UdpTunnel {
         {
             use std::os::fd::AsRawFd;
             // SAFETY: The socket is live, connected, and nonblocking.
-            let sent = unsafe {
-                target_udp::send_mmsg(self.send_socket.as_raw_fd(), &self.send_stage[..staged])
-            }?;
+            let sent = match unsafe {
+                target_udp::send_mmsg(
+                    self.send_socket.as_raw_fd(),
+                    &self.send_stage[..staged],
+                    self.udp_gso,
+                )
+            } {
+                Ok(sent) => sent,
+                Err(error) if self.udp_gso && target_udp::is_udp_gso_error(&error) => {
+                    self.udp_gso = false;
+                    warn!(
+                        stream_id = self.stream_id,
+                        %error,
+                        "target UDP GSO unavailable, falling back to sendmmsg"
+                    );
+                    // SAFETY: The socket is still live, connected, and
+                    // nonblocking; no message was accepted on the failed call.
+                    unsafe {
+                        target_udp::send_mmsg(
+                            self.send_socket.as_raw_fd(),
+                            &self.send_stage[..staged],
+                            false,
+                        )
+                    }?
+                }
+                Err(error) => return Err(error),
+            };
             if sent < staged {
                 debug!(
                     stream_id = self.stream_id,

--- a/tests/systemd-shutdown.sh
+++ b/tests/systemd-shutdown.sh
@@ -28,6 +28,8 @@ grep -q '^Type=notify$' deploy/systemd/masque.service ||
     die "the systemd unit does not wait for application readiness"
 grep -q '^NotifyAccess=main$' deploy/systemd/masque.service ||
     die "the systemd unit accepts readiness from more than the main process"
+grep -q '^WatchdogSec=30s$' deploy/systemd/masque.service ||
+    die "the systemd unit does not supervise proxy-shard liveness"
 
 TEST_TMP=$(mktemp -d /tmp/masque-systemd-shutdown.XXXXXX)
 SERVER_PID=


### PR DESCRIPTION
## Summary

- Add opt-in target-side Linux UDP segmentation offload for CONNECT-UDP. Large compatible datagrams use scatter/gather UDP_SEGMENT batches, while small datagrams retain the existing raw sendmmsg path.
- Add one-second proxy-shard heartbeats, readiness failure for stale shards, Prometheus lag metrics, and systemd watchdog supervision.
- Clarify that the packaged Prometheus rules and Grafana dashboard JSON are optional static assets; the installer does not install or start either service.
- Prepare version 0.4.1 and document the new configuration and operations behavior.

## Correctness and resource bounds

- GSO is disabled by default and detected per connected target socket. Explicit offload errors disable it for that tunnel and retry through sendmmsg.
- Batches remain bounded at 16 logical datagrams and 65,507 aggregate payload bytes. Scatter/gather avoids a new concatenation allocation or copy.
- No queue, connection, tunnel, or task limit is increased. No new per-packet task is created.
- Heartbeats add one relaxed atomic store per shard per second. Traffic counters remain inactive when observability is disabled.
- Readiness and watchdog use the same five-second stale-shard decision. The packaged service pings systemd within a 30-second watchdog deadline.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — 370 tests passed
- [x] `cargo +1.88.0 check --workspace --locked`
- [x] Shell syntax and ShellCheck
- [x] Relevant Linux GSO datagram-boundary and fallback-path tests
- [x] Linux end-to-end CONNECT-UDP benchmark

Three alternating five-second runs on the Ubuntu loopback host at 1200 bytes:

| Build | Results (Gbit/s) | Mean |
| --- | --- | --- |
| Exact v0.4.0 | 1.032 / 1.049 / 1.042 | 1.041 |
| v0.4.1, target GSO off | 1.085 / 1.038 / 1.065 | 1.063 |
| v0.4.1, target GSO on | 1.428 / 1.432 / 1.422 | 1.427 |

The measured GSO uplift is 34%. This validates the local Linux packet path only and is not an estimate of external-network throughput.

## Compatibility

- Protocol behavior is unchanged.
- Existing configuration remains valid because `udp_proxy.enable_udp_gso` defaults to `false`.
- Enabling target-side GSO is an explicit operator choice and is independent of `quic.enable_udp_gso`.
- Package upgrades replace the systemd unit and add `WatchdogSec=30s`; no Prometheus or Grafana daemon is deployed.