### PR TITLE
fix: compile target UDP GSO with musl

### DIFF
--- a/src/net/target_udp.rs
+++ b/src/net/target_udp.rs
@@ -378,7 +378,12 @@ pub unsafe fn send_mmsg(
         let header = &mut headers[index].msg_hdr;
         // Connected socket, so the destination is implicit.
         header.msg_iov = &mut iovecs[group.first];
-        header.msg_iovlen = group.segments;
+        // glibc exposes msg_iovlen as size_t while musl uses the kernel ABI's
+        // int. The batch bound makes this conversion infallible on both.
+        header.msg_iovlen = group
+            .segments
+            .try_into()
+            .expect("target UDP send batch fits msg_iovlen");
         if group.segments > 1 {
             let control_len = controls[index].set_udp_segment(group.segment_size as u16);
             header.msg_control = controls[index].words.as_mut_ptr().cast::<c_void>();

--- a/src/net/target_udp.rs
+++ b/src/net/target_udp.rs
@@ -379,11 +379,19 @@ pub unsafe fn send_mmsg(
         // Connected socket, so the destination is implicit.
         header.msg_iov = &mut iovecs[group.first];
         // glibc exposes msg_iovlen as size_t while musl uses the kernel ABI's
-        // int. The batch bound makes this conversion infallible on both.
-        header.msg_iovlen = group
-            .segments
-            .try_into()
-            .expect("target UDP send batch fits msg_iovlen");
+        // int. Keep the assignments separate so each target sees its native
+        // type and glibc Clippy does not flag an identity conversion.
+        #[cfg(target_env = "musl")]
+        {
+            header.msg_iovlen = group
+                .segments
+                .try_into()
+                .expect("target UDP send batch fits msg_iovlen");
+        }
+        #[cfg(not(target_env = "musl"))]
+        {
+            header.msg_iovlen = group.segments;
+        }
         if group.segments > 1 {
             let control_len = controls[index].set_udp_segment(group.segment_size as u16);
             header.msg_control = controls[index].words.as_mut_ptr().cast::<c_void>();


### PR DESCRIPTION
## Summary

Fix the v0.4.1 static Linux package build on musl. `libc::msghdr.msg_iovlen` is exposed as `usize` by glibc but `c_int` by musl, so the GSO scatter/gather group length now uses a checked conversion that compiles against both ABIs.

## Correctness and resource bounds

The value is bounded by `TARGET_BATCH_SIZE` (16), so conversion cannot fail on either supported ABI. Runtime packet behavior, batching, queues, buffers, tasks, connections, and tunnels are unchanged.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — 370 tests passed
- [x] `cargo +1.88.0 check --workspace --locked`
- [x] Built the complete `x86_64-unknown-linux-musl` archive with `scripts/package-linux.sh`
- [x] Verified archive checksum and confirmed the binary is a statically linked x86-64 ELF
- [x] Relevant E2E tests: unchanged from PR #10
- [x] Before/after benchmark: not applicable; this is an ABI-only compile fix

## Compatibility

No configuration, protocol, deployment, or upgrade behavior changes. This unblocks the v0.4.1 release artifact.