### PR TITLE
fix: harden v0.5.1 release and upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Check shell scripts
         run: |
           sh -n install-latest.sh deploy/install.sh \
-            tests/install-upgrade.sh tests/systemd-shutdown.sh
+            scripts/validate-release.sh tests/install-upgrade.sh \
+            tests/release-metadata.sh tests/systemd-shutdown.sh
+          sh tests/release-metadata.sh
           shellcheck install-latest.sh deploy/install.sh scripts/*.sh \
             tests/*.sh tests/e2e/*.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Validate release metadata
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: scripts/validate-release.sh "$GITHUB_REF_NAME"
+
       - name: Install native build tools
         run: |
           sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.5.1 - 2026-08-21
+
+### Fixed
+
+- Upgrades preserve the existing configuration without printing its full
+  contents into unattended installation logs. Fresh installations still show
+  the generated configuration with the password hash redacted.
+- Release builds now reject a tag that does not match both the Cargo package
+  version and a dated changelog heading, preventing incorrectly labelled
+  archives.
+- Installer regression tests now verify that an activated upgrade preserves
+  the configuration and TLS material as well as the rollback-managed files.
+
+## 0.5.0 - 2026-08-20
+
 ### Added
 
 - Prometheus now exposes target-to-HTTP/3 TCP relay batches, events, and bytes,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"

--- a/README.md
+++ b/README.md
@@ -98,15 +98,16 @@ random password when none is supplied. Client-certificate mode enrolls the first
 client, adds its `[[clients]]` entry, writes its secret JSON as mode `0600`, and
 prints the matching usque and mihomo configuration. Dual mode does both, writing
 a two-listener configuration that serves credentials on one port and
-certificates on another. At the end it prints the
-installed version, service state, and effective server configuration with the
-password hash redacted.
+certificates on another. At the end a fresh installation prints the installed
+version, service state, and effective server configuration with the password
+hash redacted.
 
 The same command is also the upgrade command. When
 `/etc/masque/masque.toml` already exists, the candidate binary checks that
 configuration without binding a port or creating a TUN, then upgrades the
 binary, systemd unit, and versioned monitoring assets. It never rewrites the
-TOML or referenced TLS files. An
+TOML or referenced TLS files, and it does not copy the existing configuration
+into unattended upgrade logs. An
 incompatible configuration aborts before replacement; a failed service restart
 restores the prior binary, unit, monitoring assets, and service state. See
 [Deployment](docs/deployment.md#one-command-install) for non-interactive

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -690,7 +690,12 @@ if [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
     fi
 fi
 
-print_redacted_config
+if [ "$CONFIG_CHANGED" -eq 1 ]; then
+    print_redacted_config
+else
+    echo
+    echo "Existing configuration was preserved and is not printed during upgrades."
+fi
 
 if [ -n "$ENROLL_OUTPUT" ]; then
     echo

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,7 +292,7 @@ the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
-configuration is compatible with masque-server 0.5.0: /etc/masque/masque.toml
+configuration is compatible with masque-server 0.5.1: /etc/masque/masque.toml
 listener 0.0.0.0:443 auth=basic shards=1
 listener 0.0.0.0:4443 auth=client_cert shards=1
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,7 +92,7 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
     sh
 ```
 
-`MASQUE_VERSION=0.5.0` selects `v0.5.0`. This is also how to install a
+`MASQUE_VERSION=0.5.1` selects `v0.5.1`. This is also how to install a
 prerelease explicitly; automatic resolution deliberately chooses only GitHub's
 latest stable release. Authentication, listen, TLS-source, and client
 provisioning variables apply only when `/etc/masque/masque.toml` does not yet
@@ -106,7 +106,8 @@ service untouched. On success, the binary, packaged systemd unit, Prometheus
 rules, and Grafana dashboard are upgraded; the TOML and every TLS path it
 references remain unchanged. If the requested service restart then fails, the
 installer restores the previous release-managed files, enabled state, and
-active state.
+active state. Upgrade output reports the resolved listener and authentication
+summary but does not print the existing configuration contents.
 
 Version 0.3 does not migrate the 0.2 single-listener format. Before upgrading,
 move every socket into `[[listeners]]` with an explicit `[listeners.auth]` and

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+die() {
+    echo "release metadata error: $*" >&2
+    exit 1
+}
+
+release_tag=${1:-}
+case "$release_tag" in
+    v[0-9]*) ;;
+    *) die "expected a tag beginning with 'v' followed by a digit" ;;
+esac
+
+release_version=${release_tag#v}
+case "$release_version" in
+    ""|*[!0-9A-Za-z.+-]*) die "invalid release version: $release_version" ;;
+esac
+
+manifest_path=${MASQUE_RELEASE_MANIFEST:-Cargo.toml}
+lock_path=${MASQUE_RELEASE_LOCK:-Cargo.lock}
+changelog_path=${MASQUE_RELEASE_CHANGELOG:-CHANGELOG.md}
+
+[ -r "$manifest_path" ] || die "cannot read manifest: $manifest_path"
+[ -r "$lock_path" ] || die "cannot read lockfile: $lock_path"
+[ -r "$changelog_path" ] || die "cannot read changelog: $changelog_path"
+
+manifest_version=$(awk '
+    /^\[package\]$/ { in_package=1; next }
+    /^\[/ { in_package=0 }
+    in_package && /^version[[:space:]]*=/ {
+        value=$0
+        sub(/^[^=]*=[[:space:]]*"/, "", value)
+        sub(/".*$/, "", value)
+        print value
+        exit
+    }
+' "$manifest_path")
+[ -n "$manifest_version" ] || die "could not find [package].version in $manifest_path"
+[ "$manifest_version" = "$release_version" ] ||
+    die "tag $release_tag does not match Cargo version $manifest_version"
+
+lock_version=$(awk '
+    /^\[\[package\]\]$/ { target=0; next }
+    /^name = "masque-server"$/ { target=1; next }
+    target && /^version = / {
+        value=$3
+        gsub(/"/, "", value)
+        print value
+        exit
+    }
+' "$lock_path")
+[ -n "$lock_version" ] || die "could not find masque-server in $lock_path"
+[ "$lock_version" = "$release_version" ] ||
+    die "tag $release_tag does not match lockfile version $lock_version"
+
+heading_prefix="## $release_version - "
+line_number=0
+unreleased_line=0
+release_line=0
+release_count=0
+release_date=
+while IFS= read -r line || [ -n "$line" ]; do
+    line_number=$((line_number + 1))
+    if [ "$line" = "## Unreleased" ] && [ "$unreleased_line" -eq 0 ]; then
+        unreleased_line=$line_number
+    fi
+    case "$line" in
+        "$heading_prefix"*)
+            release_count=$((release_count + 1))
+            release_line=$line_number
+            release_date=${line#"$heading_prefix"}
+            ;;
+    esac
+done <"$changelog_path"
+
+[ "$unreleased_line" -gt 0 ] || die "$changelog_path has no Unreleased heading"
+[ "$release_count" -eq 1 ] ||
+    die "$changelog_path must contain exactly one dated heading for $release_version"
+printf '%s\n' "$release_date" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' ||
+    die "the $release_version changelog heading has an invalid date"
+[ "$unreleased_line" -lt "$release_line" ] ||
+    die "the $release_version changelog heading must follow Unreleased"
+
+echo "Release metadata valid: $release_tag ($release_date)"

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -102,6 +102,8 @@ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
     -days 1 -subj /CN=localhost \
     -keyout /etc/masque/certs/server.key \
     -out /etc/masque/certs/server.crt >/dev/null 2>&1
+tls_cert_sha=$(sha256sum /etc/masque/certs/server.crt | awk '{print $1}')
+tls_key_sha=$(sha256sum /etc/masque/certs/server.key | awk '{print $1}')
 
 write_config() {
     cc_algorithm=$1
@@ -147,6 +149,18 @@ assert_sha_unchanged() {
     [ "$actual" = "$expected" ] || die "$path changed unexpectedly"
 }
 
+assert_upgrade_output_is_summary_only() {
+    log_path=$1
+    grep -q 'Existing configuration was preserved and is not printed during upgrades' \
+        "$log_path" || die "the upgrade did not explain that it suppressed the configuration"
+    ! grep -q 'Effective server configuration' "$log_path" ||
+        die "the upgrade printed the existing configuration"
+    ! grep -q 'private-upgrade-log-marker' "$log_path" ||
+        die "the upgrade copied an existing configuration marker into its output"
+    ! grep -q 'password_hash' "$log_path" ||
+        die "the upgrade printed an existing password hash field"
+}
+
 # A fresh dual installation writes a two-listener configuration and provisions
 # both authentication modes. This runs first, while the runner still has no
 # configuration; the upgrade cases below overwrite everything it leaves behind.
@@ -162,6 +176,10 @@ MASQUE_AUTH_MODE=dual \
     MASQUE_START_SERVICE=0 \
     "$PACKAGE_DIR/install.sh" >"$TEST_TMP/dual.log" 2>&1 ||
     die "fresh dual installation failed; see $TEST_TMP/dual.log"
+grep -q 'Effective server configuration (password hash redacted)' "$TEST_TMP/dual.log" ||
+    die "fresh installation did not print its generated configuration"
+grep -Eq 'password_hash[[:space:]]*=[[:space:]]*"<redacted>"' "$TEST_TMP/dual.log" ||
+    die "fresh installation did not redact its generated password hash"
 
 [ "$(grep -c '^\[\[listeners\]\]$' "$CONFIG_PATH")" -eq 2 ] ||
     die "dual mode did not write two listeners"
@@ -207,6 +225,7 @@ grep -q '^\[quic\]$' "$CONFIG_PATH" ||
 grep -q '^listener 0.0.0.0:8451 auth=client_cert shards=1$' "$TEST_TMP/added-check.log" ||
     die "the added listener was not reported by check-config"
 
+printf '\n# private-upgrade-log-marker\n' >>"$CONFIG_PATH"
 added_config_sha=$(sha256sum "$CONFIG_PATH" | awk '{print $1}')
 
 # A reinstall over it is an upgrade, and must report both modes rather than one.
@@ -218,6 +237,9 @@ grep -q 'Authentication: basic + client_cert' "$TEST_TMP/dual-upgrade.log" ||
 # An upgrade keeps what the operator added, including a listener this installer
 # never writes on its own.
 assert_sha_unchanged "$CONFIG_PATH" "$added_config_sha"
+assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
+assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
+assert_upgrade_output_is_summary_only "$TEST_TMP/dual-upgrade.log"
 grep -q '^listener 0.0.0.0:8451 auth=client_cert shards=1$' "$TEST_TMP/dual-upgrade.log" ||
     die "the upgrade summary did not report the added listener"
 grep -q 'add-listener' "$TEST_TMP/dual-upgrade.log" ||
@@ -248,8 +270,26 @@ valid_config_sha=$(sha256sum "$CONFIG_PATH" | awk '{print $1}')
 MOCK_ACTIVE=0 MOCK_ENABLED=0 MASQUE_START_SERVICE=0 \
     "$PACKAGE_DIR/install.sh" >"$TEST_TMP/staged.log" 2>&1
 assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
+assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
+assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
+assert_upgrade_output_is_summary_only "$TEST_TMP/staged.log"
 candidate_sha=$(sha256sum "$CANDIDATE" | awk '{print $1}')
 assert_sha_unchanged "$BIN_PATH" "$candidate_sha"
+
+# A successful activation restarts once and preserves operator-managed files.
+write_old_installation
+: >"$MOCK_STATE"
+MOCK_ACTIVE=1 MOCK_ENABLED=1 MASQUE_START_SERVICE=1 \
+    "$PACKAGE_DIR/install.sh" >"$TEST_TMP/activated.log" 2>&1
+[ "$(sed -n '1p' "$MOCK_STATE")" -eq 1 ] ||
+    die "successful activation did not restart the service exactly once"
+assert_sha_unchanged "$BIN_PATH" "$candidate_sha"
+assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
+assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
+assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
+assert_upgrade_output_is_summary_only "$TEST_TMP/activated.log"
+grep -q 'Service:        started or restarted' "$TEST_TMP/activated.log" ||
+    die "successful activation did not report the service result"
 
 # A failed activation restores every release-managed file and the prior service state.
 write_old_installation
@@ -268,6 +308,8 @@ assert_sha_unchanged "$UNIT_PATH" "$old_unit_sha"
 assert_sha_unchanged "$PROMETHEUS_RULES_PATH" "$old_rules_sha"
 assert_sha_unchanged "$GRAFANA_DASHBOARD_PATH" "$old_dashboard_sha"
 assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
+assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
+assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
 grep -q 'Previous binary, systemd unit, monitoring assets, and service state restored' \
     "$TEST_TMP/rollback.log" || die "rollback confirmation was not printed"
 

--- a/tests/release-metadata.sh
+++ b/tests/release-metadata.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+die() {
+    echo "release metadata test: $*" >&2
+    exit 1
+}
+
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/masque-release-metadata.XXXXXX")
+MANIFEST=$TEST_TMP/Cargo.toml
+LOCKFILE=$TEST_TMP/Cargo.lock
+CHANGELOG=$TEST_TMP/CHANGELOG.md
+VALIDATOR=$PWD/scripts/validate-release.sh
+
+cleanup() {
+    rm -rf -- "$TEST_TMP"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+write_manifest() {
+    version=$1
+    cat >"$MANIFEST" <<EOF
+[workspace]
+members = ["."]
+
+[package]
+name = "masque-server"
+version = "$version"
+EOF
+}
+
+write_lockfile() {
+    version=$1
+    cat >"$LOCKFILE" <<EOF
+version = 4
+
+[[package]]
+name = "masque-server"
+version = "$version"
+EOF
+}
+
+write_changelog() {
+    version=$1
+    date=$2
+    cat >"$CHANGELOG" <<EOF
+# Changelog
+
+## Unreleased
+
+## $version - $date
+
+### Fixed
+
+- Fixture.
+EOF
+}
+
+validate() {
+    MASQUE_RELEASE_MANIFEST=$MANIFEST \
+        MASQUE_RELEASE_LOCK=$LOCKFILE \
+        MASQUE_RELEASE_CHANGELOG=$CHANGELOG \
+        "$VALIDATOR" "$1"
+}
+
+expect_failure() {
+    label=$1
+    shift
+    if "$@" >"$TEST_TMP/failure.log" 2>&1; then
+        die "$label unexpectedly passed"
+    fi
+}
+
+write_manifest 0.5.1
+write_lockfile 0.5.1
+write_changelog 0.5.1 2026-08-21
+validate v0.5.1 >/dev/null || die "matching release metadata was rejected"
+
+expect_failure "mismatched tag" validate v0.5.0
+
+write_manifest 0.5.2
+expect_failure "mismatched manifest" validate v0.5.1
+write_manifest 0.5.1
+
+write_lockfile 0.5.0
+expect_failure "mismatched lockfile" validate v0.5.1
+write_lockfile 0.5.1
+
+write_changelog 0.5.1 not-a-date
+expect_failure "malformed changelog date" validate v0.5.1
+
+cat >"$CHANGELOG" <<'EOF'
+# Changelog
+
+## 0.5.1 - 2026-08-21
+
+## Unreleased
+EOF
+expect_failure "release before Unreleased" validate v0.5.1
+
+cat >"$CHANGELOG" <<'EOF'
+# Changelog
+
+## Unreleased
+
+## 0.5.1 - 2026-08-21
+
+## 0.5.1 - 2026-08-22
+EOF
+expect_failure "duplicate release heading" validate v0.5.1
+
+echo "release metadata validation passed"


### PR DESCRIPTION
## Summary

- archive the 0.5.0 notes correctly and prepare version 0.5.1
- keep existing configuration contents out of unattended upgrade logs
- reject release tags that disagree with Cargo or the dated changelog entry
- verify successful activation, configuration/TLS preservation, and rollback behavior in installer CI

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --locked`
- shell syntax, ShellCheck, and release-metadata failure fixtures
- Linux x86_64 musl static package build and checksum verification