### PR TITLE
feat: add HTTP/2 MASQUE compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.7.0 - 2026-08-21
+
+### Added
+
+- Listeners can select `transport = "http2"` to serve standard CONNECT and
+  CONNECT-UDP/CONNECT-IP over TCP/TLS with the `h2` ALPN, Extended CONNECT,
+  RFC 9297 DATAGRAM capsules, explicit flow-control limits, and bounded
+  graceful drain. HTTP/3 remains the performance default.
+- CONNECT-IP also accepts the deployed Cloudflare/usque HTTP/2 dialect: a
+  regular CONNECT carrying `cf-connect-proto: cf-connect-ip`, with Context ID
+  zero omitted from DATAGRAM capsule values.
+- `enroll-client` fills usque's `endpoint_h2_v4` / `endpoint_h2_v6` fields and
+  prints the matching `--http2` launch hint.
+- HTTP/2 listeners support the same per-request Basic authentication, TLS
+  client-certificate roster, target policy, global authentication queue, and
+  per-connection tunnel limits as HTTP/3. Roster reloads also disconnect
+  revoked HTTP/2 clients.
+- `add-listener` accepts `--transport http2|http3`, probes the corresponding TCP
+  or UDP socket, and writes the transport explicitly.
+- Real TLS/H2 integration tests cover TCP CONNECT, CONNECT-UDP, standards-based
+  CONNECT-IP, the usque-compatible H2 shape, Basic authentication, and
+  client-certificate authentication.
+
+### Changed
+
+- Listener-scoped Prometheus series carry a bounded `transport="http2|http3"`
+  label so identical TCP and UDP listen addresses remain distinguishable.
+- Capsule decoding rejects an oversized declared value before buffering its
+  body, bounding malformed HTTP/2 CONNECT-UDP and CONNECT-IP input.
+
+### Fixed
+
+- HTTP/2 CONNECT-IP now pumps request and response DATA independently, and its
+  bounded small-frame budget accounts for packetized TCP ACK bursts. A blocked
+  response window can no longer make h2 misclassify normal bulk traffic as
+  `too_many_data_frames` and reset the connection.
+
 ## 0.6.0 - 2026-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +603,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "h2"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +632,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
 
 [[package]]
 name = "indexmap"
@@ -733,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -741,6 +776,8 @@ dependencies = [
  "boring",
  "bytes",
  "clap",
+ "h2",
+ "http",
  "ipnet",
  "libc",
  "quiche",
@@ -750,6 +787,7 @@ dependencies = [
  "subtle",
  "thiserror",
  "tokio",
+ "tokio-boring",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1344,6 +1382,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-boring"
+version = "4.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b5955a3dc76ca07e3401e07d35f98c968e28f1a6126b552a51fa4bccd75528"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1401,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
-description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/3"
+description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"
 license = "MIT"
 repository = "https://github.com/Vincent-bin/masque-server"
 readme = "README.md"
-keywords = ["masque", "http3", "quic", "proxy", "vpn"]
+keywords = ["masque", "http2", "http3", "quic", "proxy"]
 categories = ["network-programming", "command-line-utilities"]
 publish = false
 default-run = "masque-server"
@@ -33,6 +33,8 @@ base64 = "0.22.1"
 boring = "4.3"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
+h2 = "0.4.18"
+http = "1"
 ipnet = "2"
 quiche = "0.29.3"
 ring = "0.17"
@@ -40,6 +42,7 @@ serde = { version = "1", features = ["derive"] }
 subtle = "2.6"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tokio-boring = "4.19"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # MASQUE Server
 
-A high-performance MASQUE proxy server written in Rust. It carries TCP, UDP,
-and IP traffic over HTTP/3 using standard CONNECT, CONNECT-UDP, and CONNECT-IP.
+A high-performance MASQUE proxy server written in Rust. HTTP/3 carries TCP,
+UDP, and IP traffic using standard CONNECT, CONNECT-UDP, and CONNECT-IP;
+HTTP/2 provides a TCP/TLS compatibility transport for all three when a network
+blocks QUIC.
 
 The project is pre-1.0. Protocol behavior, configuration compatibility, and
 release packaging are tested, but operators should still validate upgrades in
@@ -12,6 +14,8 @@ a staging environment.
 - Standard CONNECT for TCP streams
 - CONNECT-UDP ([RFC 9298]) using HTTP Datagrams
 - CONNECT-IP ([RFC 9484]) with Linux TUN integration
+- HTTP/3 over UDP for performance, plus HTTP/2 Extended CONNECT and the
+  Cloudflare/usque CONNECT-IP dialect over TCP/TLS as compatibility fallbacks
 - HTTP Basic authentication with Argon2id password verification, or TLS client
   certificate authentication against a public-key roster
 - Multiple listeners in one process, each with its own Basic or client-certificate
@@ -33,8 +37,10 @@ Build the server:
 cargo build --release --bin masque-server
 ```
 
-Each `[[listeners]]` entry has an explicit `[listeners.auth]` table. For a
-`basic` listener, generate an Argon2id password hash:
+Each `[[listeners]]` entry chooses `transport = "http3"` (the default and
+recommended path) or `transport = "http2"`, and has an explicit
+`[listeners.auth]` table. For a `basic` listener, generate an Argon2id password
+hash:
 
 ```sh
 printf '%s' 'replace-this-password' | \
@@ -71,18 +77,19 @@ its own `[[listeners]]` entry in the same process; see
 [Listeners](docs/configuration.md#listeners).
 
 A second listener can be added to a deployed configuration without editing TOML
-by hand. This prompts for the address, the authentication mode, and any
-credentials, validates the merged file the way `check-config` does, test-binds
-the new address, and leaves the file untouched if anything is wrong:
+by hand. This prompts for the HTTP transport, address, authentication mode, and
+any credentials, validates the merged file the way `check-config` does,
+test-binds the new address, and leaves the file untouched if anything is wrong:
 
 ```sh
 masque-server --config /etc/masque/masque.toml add-listener
 ```
 
-Every value is also available as a flag for provisioning scripts. See
+Every value, including `--transport http2|http3`, is also available as a flag
+for provisioning scripts. See
 [Adding a listener](docs/configuration.md#adding-a-listener). A new socket is
-bound at startup, so open its UDP port, restart the service, and confirm it came
-up.
+bound at startup, so open UDP for HTTP/3 or TCP for HTTP/2, restart the service,
+and confirm it came up.
 
 ## One-command Linux install
 
@@ -195,9 +202,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a change.
 ## Platform support
 
 Linux is the production target and the only platform supporting CONNECT-IP,
-multi-shard listeners, UDP GSO/GRO, and batched target UDP I/O. macOS is useful
-for development and portable CONNECT/CONNECT-UDP tests, but it cannot exercise
-the Linux syscall and offload paths.
+multi-shard HTTP/3 listeners, UDP GSO/GRO, and batched target UDP I/O. HTTP/2
+protocol handling is portable, including CONNECT-IP capsule setup, but actual
+IP forwarding still needs Linux TUN and host routing. macOS is useful for the
+portable HTTP/2 and HTTP/3 paths, but it cannot exercise the Linux syscall,
+TUN, and offload paths.
 
 ## License
 

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -18,6 +18,10 @@ key_path = "/etc/masque/certs/server.key"
 
 [[listeners]]
 listen_addr = "0.0.0.0:443"
+# "http3" binds UDP/QUIC and is the preferred high-performance transport.
+# "http2" binds TCP/TLS for networks that block UDP; all three CONNECT forms
+# are supported, but datagrams then inherit TCP ordering and loss recovery.
+transport = "http3"
 # Independent event loops, each with its own SO_REUSEPORT socket and its own
 # share of the connections. A connection is always handled by one loop, so this
 # is what lets a CPU-bound server use more than one core. 0 = one per core for a
@@ -30,7 +34,7 @@ enabled = true
 # "client_cert" — a TLS client certificate, matched against [[clients]] below.
 #
 # Pick "client_cert" for VPN-style clients modelled on Cloudflare WARP MASQUE
-# (for example usque): they authenticate during the QUIC handshake and never
+# (for example usque): they authenticate during the TLS handshake and never
 # send Proxy-Authorization, so they cannot work against "basic".
 #
 # To serve both kinds of client, add the second listener shown at the end of
@@ -59,6 +63,20 @@ password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"
 # public_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE..."
 # ipv4 = "10.89.0.2"
 # ipv6 = "fd00:abcd::2"
+
+[http2]
+# Flow-control and resource bounds for listeners with transport = "http2".
+initial_stream_window = 1048576
+initial_connection_window = 16777216
+max_concurrent_streams = 128
+max_header_list_size = 8192
+max_send_buffer_size = 262144
+# h2's generic default is too small for CONNECT-IP bursts where each inner TCP
+# ACK occupies one small DATA frame. This remains a bounded per-connection
+# allowance; raising it trades memory-abuse resistance for burst tolerance.
+data_frame_budget = 262144
+# Maximum UDP payload or CONNECT-IP packet in one DATAGRAM capsule.
+max_datagram_size = 65527
 
 [quic]
 max_datagram_size = 1350
@@ -157,15 +175,18 @@ ipv6_pool = "fd00:abcd::/64"
 # shared — TLS files, proxy policies, one [[clients]] roster, one TUN device,
 # one CONNECT-IP address pool, and one routing table.
 #
-# Two listeners may not contend for the same address. That is refused at startup
-# rather than left to the kernel: a listener with shards > 1 binds with
-# SO_REUSEPORT, so a second listener on that address would join its
-# load-balancing group and be handed connections meant for the other mode.
+# Two listeners using the same transport may not contend for the same address.
+# That is refused at startup rather than left to the kernel: an HTTP/3 listener
+# with shards > 1 binds with SO_REUSEPORT, so another HTTP/3 listener on that
+# address would join its load-balancing group and receive the wrong clients.
+# An HTTP/2 and HTTP/3 listener may share a numeric port because TCP and UDP are
+# independent sockets.
 # Wildcards count — 0.0.0.0 claims every IPv4 address on its port, and :: is
 # assumed to claim IPv4 too, since IPV6_V6ONLY is the kernel's to decide.
 #
 # [[listeners]]
 # listen_addr = "0.0.0.0:4443"
+# transport = "http3"
 # shards = 1
 #
 # [listeners.auth]

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -243,7 +243,7 @@ choose_auth_mode() {
 # leaves an open proxy in place.
 detect_existing_auth_mode() {
     detected_modes=$(printf '%s\n' "$CHECK_CONFIG_OUTPUT" |
-        sed -n 's/^listener [^ ]* auth=\([a-z_]*\) .*$/\1/p' | sort -u)
+        sed -n 's/^listener .* auth=\([a-z_]*\) .*$/\1/p' | sort -u)
 
     AUTH_MODE=
     for detected_mode in $detected_modes; do
@@ -365,6 +365,7 @@ append_certificate_listener() {
 # the CONNECT-IP address pool — is shared by the one process.
 [[listeners]]
 listen_addr = "0.0.0.0:$cert_port"
+transport = "http3"
 shards = 1
 
 [listeners.auth]
@@ -373,7 +374,7 @@ mode = "client_cert"
 EOF
 }
 
-# Read and validate one UDP port.
+# Read and validate the numeric port for a fresh HTTP/3 listener.
 choose_listen_port() {
     port_prompt=$1
     port_default=$2
@@ -724,4 +725,4 @@ echo "Review $CONFIG_PATH, especially the proxy allow/deny policy."
 echo
 echo "To serve another authentication mode, or another port, add a listener:"
 echo "  masque-server --config $CONFIG_PATH add-listener"
-echo "Then open its UDP port in the firewall and run: systemctl restart masque"
+echo "Then open its UDP (http3) or TCP (http2) port and run: systemctl restart masque"

--- a/deploy/monitoring/grafana-dashboard.json
+++ b/deploy/monitoring/grafana-dashboard.json
@@ -300,14 +300,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (rate(masque_quic_receive_bytes_total{listener=~\"$listener\"}[$__rate_interval])) * 8",
+          "expr": "sum by (listener) (rate(masque_quic_receive_bytes_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval])) * 8",
           "legendFormat": "{{listener}} receive",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (rate(masque_quic_send_bytes_total{listener=~\"$listener\"}[$__rate_interval])) * 8",
+          "expr": "sum by (listener) (rate(masque_quic_send_bytes_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval])) * 8",
           "legendFormat": "{{listener}} send",
           "range": true,
           "refId": "B"
@@ -364,14 +364,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (rate(masque_quic_receive_packets_total{listener=~\"$listener\"}[$__rate_interval]))",
+          "expr": "sum by (listener) (rate(masque_quic_receive_packets_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval]))",
           "legendFormat": "{{listener}} receive",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (rate(masque_quic_send_packets_total{listener=~\"$listener\"}[$__rate_interval]))",
+          "expr": "sum by (listener) (rate(masque_quic_send_packets_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval]))",
           "legendFormat": "{{listener}} send",
           "range": true,
           "refId": "B"
@@ -426,8 +426,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener, protocol) (masque_tunnels_active{listener=~\"$listener\"})",
-          "legendFormat": "{{listener}} {{protocol}}",
+          "expr": "sum by (listener, transport, protocol) (masque_tunnels_active{listener=~\"$listener\"})",
+          "legendFormat": "{{listener}} {{transport}} {{protocol}}",
           "range": true,
           "refId": "A"
         }
@@ -482,8 +482,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener, result) (rate(masque_auth_attempts_total{listener=~\"$listener\"}[$__rate_interval]))",
-          "legendFormat": "{{listener}} {{result}}",
+          "expr": "sum by (listener, transport, result) (rate(masque_auth_attempts_total{listener=~\"$listener\"}[$__rate_interval]))",
+          "legendFormat": "{{listener}} {{transport}} {{result}}",
           "range": true,
           "refId": "A"
         }
@@ -538,8 +538,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener, reason) (rate(masque_packets_dropped_total{listener=~\"$listener\"}[$__rate_interval]))",
-          "legendFormat": "{{listener}} {{reason}}",
+          "expr": "sum by (listener, transport, reason) (rate(masque_packets_dropped_total{listener=~\"$listener\"}[$__rate_interval]))",
+          "legendFormat": "{{listener}} {{transport}} {{reason}}",
           "range": true,
           "refId": "A"
         }
@@ -593,15 +593,15 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (masque_auth_pending{listener=~\"$listener\"})",
-          "legendFormat": "{{listener}} pending",
+          "expr": "sum by (listener, transport) (masque_auth_pending{listener=~\"$listener\"})",
+          "legendFormat": "{{listener}} {{transport}} pending",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (masque_auth_running{listener=~\"$listener\"})",
-          "legendFormat": "{{listener}} running",
+          "expr": "sum by (listener, transport) (masque_auth_running{listener=~\"$listener\"})",
+          "legendFormat": "{{listener}} {{transport}} running",
           "range": true,
           "refId": "B"
         }
@@ -655,14 +655,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (rate(masque_quic_receive_packets_total{listener=~\"$listener\"}[$__rate_interval])) / clamp_min(sum by (listener) (rate(masque_quic_receive_batches_total{listener=~\"$listener\"}[$__rate_interval])), 0.001)",
+          "expr": "sum by (listener) (rate(masque_quic_receive_packets_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval])) / clamp_min(sum by (listener) (rate(masque_quic_receive_batches_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval])), 0.001)",
           "legendFormat": "{{listener}} receive",
           "range": true,
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "sum by (listener) (rate(masque_quic_send_packets_total{listener=~\"$listener\"}[$__rate_interval])) / clamp_min(sum by (listener) (rate(masque_quic_send_batches_total{listener=~\"$listener\"}[$__rate_interval])), 0.001)",
+          "expr": "sum by (listener) (rate(masque_quic_send_packets_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval])) / clamp_min(sum by (listener) (rate(masque_quic_send_batches_total{listener=~\"$listener\",transport=\"http3\"}[$__rate_interval])), 0.001)",
           "legendFormat": "{{listener}} send",
           "range": true,
           "refId": "B"
@@ -693,7 +693,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (listener, auth) (masque_listener_shards{listener=~\"$listener\"})",
+          "expr": "sum by (listener, transport, auth) (masque_listener_shards{listener=~\"$listener\"})",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",

--- a/deploy/monitoring/prometheus-rules.yml
+++ b/deploy/monitoring/prometheus-rules.yml
@@ -20,8 +20,8 @@ groups:
         annotations:
           summary: MASQUE listener rejected connections at its configured limit
           description: >-
-            Listener {{ $labels.listener }} rejected at least one new QUIC
-            connection during the last five minutes.
+            Listener {{ $labels.listener }} ({{ $labels.transport }}) rejected
+            at least one new connection during the last five minutes.
 
       - alert: MasqueAuthenticationOverloaded
         expr: increase(masque_auth_attempts_total{result="overloaded"}[5m]) > 0
@@ -31,17 +31,18 @@ groups:
         annotations:
           summary: MASQUE authentication queue is shedding work
           description: >-
-            Listener {{ $labels.listener }} exhausted its bounded password
-            verification queue. Check for abusive login traffic or CPU pressure.
+            Listener {{ $labels.listener }} ({{ $labels.transport }}) exhausted
+            its bounded password verification queue. Check for abusive login
+            traffic or CPU pressure.
 
       - alert: MasqueHighAuthenticationFailureRatio
         expr: |
-          sum by (instance, listener) (rate(masque_auth_attempts_total{result="failure"}[5m]))
+          sum by (instance, listener, transport) (rate(masque_auth_attempts_total{result="failure"}[5m]))
           /
-          clamp_min(sum by (instance, listener) (rate(masque_auth_attempts_total[5m])), 1)
+          clamp_min(sum by (instance, listener, transport) (rate(masque_auth_attempts_total[5m])), 1)
           > 0.20
           and
-          sum by (instance, listener) (rate(masque_auth_attempts_total[5m])) > 1
+          sum by (instance, listener, transport) (rate(masque_auth_attempts_total[5m])) > 1
         for: 10m
         labels:
           severity: warning
@@ -49,19 +50,20 @@ groups:
           summary: MASQUE listener has a high authentication failure ratio
           description: >-
             More than 20% of authentication attempts on listener
-            {{ $labels.listener }} failed while the attempt rate exceeded one
-            per second for ten minutes.
+            {{ $labels.listener }} ({{ $labels.transport }}) failed while the
+            attempt rate exceeded one per second for ten minutes.
 
       - alert: MasqueInternalPacketDrops
-        expr: sum by (instance, listener, reason) (rate(masque_packets_dropped_total[5m])) > 10
+        expr: sum by (instance, listener, transport, reason) (rate(masque_packets_dropped_total[5m])) > 10
         for: 5m
         labels:
           severity: warning
         annotations:
           summary: MASQUE internal queues are dropping packets
           description: >-
-            Listener {{ $labels.listener }} is dropping more than ten packets
-            per second in the {{ $labels.reason }} path.
+            Listener {{ $labels.listener }} ({{ $labels.transport }}) is
+            dropping more than ten packets per second in the
+            {{ $labels.reason }} path.
 
       - alert: MasqueForcedShutdown
         expr: increase(masque_forced_shutdowns_total[15m]) > 0

--- a/deploy/systemd/masque.service
+++ b/deploy/systemd/masque.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=MASQUE HTTP/3 CONNECT, CONNECT-UDP, and CONNECT-IP proxy
+Description=MASQUE HTTP/2 and HTTP/3 proxy server
 Documentation=https://github.com/Vincent-bin/masque-server
 Wants=network-online.target
 After=network-online.target

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
   resource bounds.
 - [Configuration](configuration.md): configuration reference and policy.
 - [Deployment](deployment.md): Linux installation and systemd operation.
-- [Protocols](protocols.md): supported MASQUE and HTTP/3 behavior.
+- [Protocols](protocols.md): supported MASQUE, HTTP/2, and HTTP/3 behavior.
 - [Performance](performance.md): fast paths, tuning, and benchmark rules.
 - [Observability](observability.md): health, readiness, Prometheus, Grafana,
   structured logs, and systemd notification.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,9 @@
 
 ## Goals
 
-MASQUE Server is a single-process HTTP/3 proxy optimized for bounded resource
-use and high UDP throughput. Its core rules are:
+MASQUE Server is a single-process HTTP/2 and HTTP/3 proxy optimized for bounded
+resource use and high UDP throughput. HTTP/3 is the performance path; HTTP/2
+is a compatibility path for TCP-only networks. Its core rules are:
 
 - one owner event loop mutates each QUIC connection;
 - slow setup work never blocks that event loop;
@@ -35,7 +36,8 @@ TUN packet ----------->|                       |
 ```
 
 `Server` validates configuration, creates shared policy and routing state, and
-starts one or more `Shard` instances. A shard owns:
+starts HTTP/3 `Shard` instances and HTTP/2 TCP accept loops. An HTTP/3 shard
+owns:
 
 - one QUIC UDP socket, bound with `SO_REUSEPORT` when its listener has more
   than one shard;
@@ -45,6 +47,16 @@ starts one or more `Shard` instances. A shard owns:
 - bounded receivers for setup and relay events.
 
 No connection is concurrently mutated by two shards.
+
+Each HTTP/2 listener has one asynchronous TCP accept loop. Every accepted TLS/H2
+connection and CONNECT stream runs in its own bounded Tokio task, with H2 flow
+control carrying backpressure to the target socket. CONNECT-UDP and CONNECT-IP
+DATA frames are incrementally decoded into DATAGRAM capsules. These tasks share
+the same target policies, authentication admission semaphores, certificate
+roster, address pool, TUN routing table, limits, and metrics registry as the
+HTTP/3 shards. A bounded per-stream channel connects an HTTP/2 CONNECT-IP task
+to the shared TUN read side; HTTP/2 never participates in QUIC connection-ID
+routing.
 
 When configured, a separate loopback TCP task serves health, readiness, and
 Prometheus requests. Shards update fixed atomic counters in batches and never
@@ -58,6 +70,7 @@ bounded drain begins. The packaged watchdog uses the same liveness decision.
 | Path | Responsibility |
 | --- | --- |
 | `src/server/mod.rs` | Server startup, shard event loop, and tunnel coordination |
+| `src/server/http2.rs` | TCP/TLS accept loop, H2 connections, CONNECT relays, DATAGRAM capsules, and IP/TUN task integration |
 | `src/server/request.rs` | CONNECT classification, auth precheck, and authorized dispatch |
 | `src/server/authentication.rs` | Bounded Argon2 scheduling, cancellation, and request resumption |
 | `src/connection.rs` | Per-client QUIC/H3 state and deferred sends |
@@ -104,9 +117,10 @@ bounded UDP batch, and reschedules their next deadlines.
 
 ## Listeners and sharding
 
-`shards = N` on a listener creates N independent event loops on that listener's
-address using `SO_REUSEPORT`. The kernel normally keeps a client 4-tuple on one
-of them.
+`shards = N` on an HTTP/3 listener creates N independent event loops on that
+listener's UDP address using `SO_REUSEPORT`. The kernel normally keeps a client
+4-tuple on one of them. An HTTP/2 listener must use `shards = 1`; its one TCP
+accept loop dispatches connections across the Tokio runtime instead.
 
 QUIC permits address migration, so a packet can arrive on a shard that does
 not own its connection. A shared connection-ID registry identifies the owner,
@@ -114,16 +128,17 @@ and the receiving shard forwards the packet through a bounded channel. TUN
 input uses the same ownership model. This keeps connection state single-owner
 without dropping legitimate migration traffic.
 
-One connection still uses one shard. Sharding improves aggregate throughput
-across multiple connections; it cannot parallelize a single QUIC connection.
+One HTTP/3 connection still uses one shard. Sharding improves aggregate
+throughput across multiple connections; it cannot parallelize a single QUIC
+connection.
 
 `[[listeners]]` runs one or more listeners in one process. Startup resolves each
-entry into a small listener plan containing its address, shard count, and
-authentication. Every shard also references the same process-wide
-`ServerConfig`, so proxy policies, QUIC/TLS tuning, limits, and CONNECT-IP state
-are shared rather than copied per listener. The authentication mode decides
-which TLS context `build_quic_config` returns, and that is fixed when the socket
-binds.
+entry into a small listener plan containing its transport, address, shard count,
+and authentication. Every worker references the same process-wide
+`ServerConfig`, so proxy policies, TLS tuning, limits, and authentication state
+are shared rather than copied per listener. QUIC tuning applies only to HTTP/3,
+and HTTP/2 flow-control tuning applies only to HTTP/2. The authentication mode
+decides which TLS context is built, and that is fixed when the socket binds.
 
 Shards are numbered across the whole server rather than within a listener,
 which is what lets the cross-shard queues, the connection-ID registry, and the
@@ -134,16 +149,19 @@ by its owner using that shard's own local address, so a reply always leaves the
 socket the connection actually lives on — including when the owner belongs to a
 different listener.
 
-One shard reads the TUN device and distributes packets to the connections that
-own their addresses. Shard 0 is an arbitrary but stable choice, unrelated to
-which listener it serves.
+One worker reads the TUN device and distributes packets to the connections that
+own their addresses. In a mixed or HTTP/3-only process, shard 0 is the arbitrary
+but stable reader and hands HTTP/2-owned packets to their bounded stream queue.
+In an HTTP/2-only process, a small dedicated dispatcher performs the same read
+and lookup. There is never more than one TUN reader.
 
 ## Authentication pipeline
 
 Credential processing is split into two stages:
 
-1. The shard synchronously validates the request shape, Basic scheme, username,
-   encoded length, and configured authentication state.
+1. The owning HTTP/2 task or HTTP/3 shard synchronously validates the request
+   shape, Basic scheme, username, encoded length, and configured authentication
+   state.
 2. Argon2id verification runs on Tokio's blocking pool under shared permits.
 
 The queue has a global bound as well as a per-connection bound. A request must
@@ -183,7 +201,9 @@ the portable socket API.
 The server allocates IPv4/IPv6 addresses, publishes them through
 `ADDRESS_ASSIGN`, and advertises routes with `ROUTE_ADVERTISEMENT`. Client
 packets are accepted only when their source matches the tunnel assignment.
-A shared routing table maps return traffic to the owning connection and shard.
+A shared routing table maps return traffic to its owning HTTP stream. HTTP/3
+owners are reached through a shard queue; HTTP/2 owners use a per-stream queue
+whose packet capacity is derived from the configured H2 send-buffer budget.
 
 CONNECT-IP requires Linux TUN support and `CAP_NET_ADMIN`. With TUN offload,
 the file descriptor carries virtio headers and GSO aggregates; setup falls back

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,10 +26,11 @@ masque-server enroll-client [OPTIONS] --name <NAME> --endpoint <ADDR:PORT>
   -V, --version             Print the server version
 ```
 
-`check-config` validates authentication, the TLS certificate/key pair, QUIC
-settings, client roster, and address pools without binding the UDP listener or
-creating a TUN device. It is suitable for upgrade preflight, but cannot detect
-runtime conditions such as an occupied port or unavailable kernel device.
+`check-config` validates authentication, the TLS certificate/key pair, HTTP/2
+and QUIC settings, client roster, and address pools without binding a listener
+socket or creating a TUN device. It is suitable for upgrade preflight, but
+cannot detect runtime conditions such as an occupied port or unavailable
+kernel device.
 
 `add-listener` appends a `[[listeners]]` block to the configuration file, and is
 described under [Adding a listener](#adding-a-listener).
@@ -64,7 +65,7 @@ max_tunnels_per_connection = 100
 | Key | Meaning |
 | --- | --- |
 | `idle_timeout_secs` | Inactive tunnel lifetime |
-| `max_connections` | Per-shard connection cap |
+| `max_connections` | Per-HTTP/3-shard or per-HTTP/2-listener connection cap |
 | `max_tunnels_per_connection` | CONNECT streams retained per connection |
 
 This section contains process-wide connection limits only. Socket addresses and
@@ -125,6 +126,7 @@ not authorize later streams that omit the header.
 ```toml
 [[listeners]]
 listen_addr = "0.0.0.0:443"
+transport = "http3"
 shards = 1
 
 [listeners.auth]
@@ -150,15 +152,16 @@ The server refuses to start if `username` is empty or contains `:`, or if
 
 ### `mode = "client_cert"`
 
-Clients authenticate once, with a TLS client certificate, during the QUIC
+Clients authenticate once, with a TLS client certificate, during the TLS
 handshake. Nothing is checked per request: every stream on an established
 connection is already authorized. Standard CONNECT and CONNECT-UDP keep working
-if their sections are enabled — the mode changes who may connect, not what they
-may ask for.
+alongside CONNECT-IP if their sections are enabled — the mode changes who may
+connect, not what they may ask for.
 
 ```toml
 [[listeners]]
 listen_addr = "0.0.0.0:443"
+transport = "http3"
 shards = 1
 
 [listeners.auth]
@@ -203,6 +206,10 @@ secret. Generating both spellings matters because the same key is encoded
 differently for each: usque takes the server key as PEM and addresses bare,
 mihomo takes it as bare base64 and addresses in CIDR form.
 
+The usque JSON fills both `endpoint_v4` / `endpoint_v6` and the corresponding
+`endpoint_h2_v4` / `endpoint_h2_v6` fields with the enrolled server address, so
+the same file works with its default HTTP/3 mode and its `--http2` fallback.
+
 The generated mihomo entry uses the active `ip_proxy.tun_mtu` value from the
 same server configuration, so a non-default MTU stays consistent on both ends.
 
@@ -231,6 +238,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$..."
 
 [[listeners]]
 listen_addr = "0.0.0.0:4443"
+transport = "http2"
 shards = 1
 
 [listeners.auth]
@@ -241,24 +249,29 @@ mode = "client_cert"
 | `[[listeners]]` key | Meaning |
 | --- | --- |
 | `listen_addr` | Required; there is no default, so a typo cannot silently land on someone else's port |
-| `shards` | Event loops for this listener; defaults to `1` |
+| `transport` | `http3` (default) binds UDP/QUIC; `http2` binds TCP/TLS |
+| `shards` | HTTP/3 event loops; defaults to `1`. HTTP/2 must use exactly `1` |
 | `[listeners.auth]` | Required; authentication is always explicit per socket |
 
-Everything else stays server-wide: TLS and QUIC settings, TCP/UDP target
+Everything else stays server-wide: TLS, HTTP/2 and QUIC settings, TCP/UDP target
 policies, connection limits, one `[[clients]]` roster, one TUN device, one
 CONNECT-IP address pool, and one routing table. That is the reason to run two
 listeners in one process rather than two processes — two processes would need
 two TUN devices and two address pools, and overlapping pools hand the same
 tunnel address to two clients.
 
-Use one shard until a benchmark shows one event loop is CPU-bound. Memory and
-the effective connection capacity increase with the shard count.
+Use one HTTP/3 shard until a benchmark shows one event loop is CPU-bound.
+Memory and the effective connection capacity increase with the shard count.
+HTTP/2 uses Tokio tasks for its TCP connections and therefore requires
+`shards = 1`.
 
-The server refuses to start when two listeners contend for the same address.
-This is not left to the kernel to report: a listener with more than one shard
-opens its socket with `SO_REUSEPORT`, so a second listener on that address would
-join the load-balancing group and be handed connections meant for the other
-authentication mode.
+The server refuses to start when two listeners using the same transport contend
+for the same address. This is not left to the kernel to report: an HTTP/3
+listener with more than one shard opens its UDP socket with `SO_REUSEPORT`, so a
+second HTTP/3 listener on that address would join the load-balancing group and
+be handed connections meant for the other authentication mode. One HTTP/2 and
+one HTTP/3 listener may intentionally use the same numeric IP and port because
+they bind independent TCP and UDP sockets.
 
 Wildcards count as contention. `0.0.0.0` claims every IPv4 address on its port,
 so it conflicts with `127.0.0.1` on that port. `::` is treated as claiming IPv4
@@ -280,11 +293,12 @@ and the live `listening` log lines report that address. `check-config` is
 side-effect-free and therefore reports the configured `:0`; no port has been
 selected until the server binds.
 
-`shards = 0` (one per core) is rejected when more than one listener is
-configured; give each listener an explicit count. The 32-shard cap applies to
-the server's total, not to any one listener. The budget for concurrent password
-verification is sized from the Basic listeners' shards alone, so adding a
-certificate listener does not widen what unauthenticated callers can demand.
+For HTTP/3, `shards = 0` (one per core) is rejected when more than one listener
+is configured; give each listener an explicit count. The 32-shard cap applies
+to the total HTTP/3 shard count, not to HTTP/2 connection tasks. The budget for
+concurrent password verification is sized from Basic listener workers alone,
+so adding a certificate listener does not widen what unauthenticated callers
+can demand.
 
 Run `masque-server --config masque.toml check-config` to validate a listener
 file before restarting. It prints the resolved listeners, with the shard counts
@@ -292,15 +306,16 @@ the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
-configuration is compatible with masque-server 0.6.0: /etc/masque/masque.toml
-listener 0.0.0.0:443 auth=basic shards=1
-listener 0.0.0.0:4443 auth=client_cert shards=1
+configuration is compatible with masque-server 0.7.0: /etc/masque/masque.toml
+listener 0.0.0.0:443 transport=http3 auth=basic shards=1
+listener 0.0.0.0:4443 transport=http2 auth=client_cert shards=1
 ```
 
 The usque JSON schema stores the endpoint IP but not its port, so enrollment
 also prints the matching launch argument — `--connect-port 443` for the example
 above, `--connect-port 8449` for a server on 8449. Omitting it silently falls
-back to the client's default port.
+back to the client's default port. Add `--http2` when selecting an HTTP/2
+listener.
 
 #### How the certificate is checked
 
@@ -397,10 +412,13 @@ masque-server --config /etc/masque/masque.toml add-listener
 ```
 
 ```
+Transport (http3 | http2) [http2]:
 Listen address (ip:port) [0.0.0.0:4443]:
 Authentication mode (basic | client_cert) [client_cert]:
-Event loops for this listener (shards) [1]:
 ```
+
+The shard prompt appears only for HTTP/3; HTTP/2 always uses one listener
+worker and schedules connections as Tokio tasks.
 
 A Basic listener also asks for a username and a password. The password is read
 without echo and confirmed; leaving it empty generates a strong one and prints
@@ -411,13 +429,16 @@ script must do — prompting requires a terminal, and without one a missing valu
 is an error rather than a hang:
 
 ```sh
-masque-server --config /etc/masque/masque.toml add-listener \
-    --listen-addr 0.0.0.0:4443 --mode client-cert --yes
+printf '%s' 'replace-this-password' | \
+  masque-server --config /etc/masque/masque.toml add-listener \
+    --transport http2 --listen-addr 0.0.0.0:443 \
+    --mode basic --password-stdin --username proxy-user --yes
 ```
 
 ```text
 add-listener options:
       --listen-addr <ADDR:PORT>  Address for the new socket
+      --transport <TRANSPORT>  http3 | http2 [scripted default: http3]
       --mode <MODE>         basic | client-cert
       --shards <N>          Event loops for this listener [default: 1]
       --username <NAME>     Basic username
@@ -477,9 +498,38 @@ Two ordering rules follow from the validation being real:
   explicit count first; that setting has no meaning once a second listener
   exists.
 
-A new socket is bound at startup, so restart the server afterwards, and open the
-new UDP port in the firewall. `SIGHUP` reloads the `[[clients]]` roster only —
-it never adds, removes, or rebinds a listener.
+A new socket is bound at startup, so restart the server afterwards, and open
+UDP for an HTTP/3 listener or TCP for an HTTP/2 listener. `SIGHUP` reloads the
+`[[clients]]` roster only — it never adds, removes, or rebinds a listener.
+
+## HTTP/2
+
+```toml
+[http2]
+initial_stream_window = 1048576
+initial_connection_window = 16777216
+max_concurrent_streams = 128
+max_header_list_size = 8192
+max_send_buffer_size = 262144
+data_frame_budget = 262144
+max_datagram_size = 65527
+```
+
+These values apply only to listeners with `transport = "http2"`:
+
+| Key | Meaning |
+| --- | --- |
+| `initial_stream_window` | Initial request-stream receive credit |
+| `initial_connection_window` | Initial aggregate receive credit per connection |
+| `max_concurrent_streams` | Concurrent request streams advertised per connection |
+| `max_header_list_size` | Maximum decoded request header list size |
+| `max_send_buffer_size` | Maximum response bytes buffered per stream by the H2 implementation |
+| `data_frame_budget` | Connection-level allowance for queued small DATA-frame overhead; `1..16777216`. Packetized CONNECT-IP needs more than h2's generic HTTP default, but raising it increases the memory an abusive connection can consume. |
+| `max_datagram_size` | Maximum UDP payload or IP packet carried in one DATAGRAM capsule; `1..65527` |
+
+HTTP/2 CONNECT-UDP and CONNECT-IP DATAGRAM capsules are reliable and ordered
+because they travel over TCP. Prefer HTTP/3 for normal operation and use
+HTTP/2 where UDP/QUIC is blocked.
 
 ## QUIC and UDP
 
@@ -573,11 +623,11 @@ ipv4_pool = "10.89.0.0/16"
 ipv6_pool = "fd00:abcd::/64"
 ```
 
-`connect_protocols` lists the accepted `:protocol` values. RFC 9484 registers
-`connect-ip`; Cloudflare's endpoint uses `cf-connect-ip` and clients built
-against it send only that. Both are accepted by default, which costs nothing
-because an RFC client never sends the second one. Narrow the list to
-`["connect-ip"]` to accept only standards-compliant clients.
+`connect_protocols` lists the accepted CONNECT-IP protocol identifiers. RFC
+9484 registers `connect-ip`; Cloudflare's HTTP/3 endpoint uses
+`:protocol = cf-connect-ip`, while its HTTP/2 dialect carries the same value in
+`cf-connect-proto`. Both identifiers are accepted by default. Narrow the list
+to `["connect-ip"]` to accept only standards-compliant clients.
 
 CONNECT-IP is Linux-only. Pools must not overlap host, container, VPN, or
 upstream networks. The host is responsible for routing, forwarding, firewall,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -168,8 +168,10 @@ changing production files.
 
 ## Network and firewall
 
-Open the configured UDP port, not TCP. For example, a server listening on 8449
-needs inbound UDP/8449.
+Open the socket protocol selected by each listener: `transport = "http3"`
+needs inbound UDP, while `transport = "http2"` needs inbound TCP. They may use
+the same numeric port because TCP and UDP are separate namespaces. For example,
+dual transport on port 8449 needs both UDP/8449 and TCP/8449.
 
 Standard CONNECT and CONNECT-UDP need ordinary outbound TCP/UDP access.
 CONNECT-IP additionally needs:
@@ -212,14 +214,14 @@ sudo masque-server --config /etc/masque/masque.toml add-listener
 sudo systemctl restart masque
 ```
 
-It prompts for the address, the authentication mode, and any credentials,
+It prompts for the transport, address, authentication mode, and any credentials,
 validates the merged file the way the upgrade preflight does, and test-binds the
 new address; anything wrong leaves the file byte for byte unchanged. The file is
 replaced atomically with its mode and owner preserved, so the service account
 keeps its access. Flags cover every value for unattended use; see
 [Adding a listener](configuration.md#adding-a-listener).
 
-Open the new UDP port in the firewall as well — see
+Open the new UDP or TCP port in the firewall as appropriate — see
 [Network and firewall](#network-and-firewall). A new socket is bound at startup,
 so the restart is required; `systemctl reload` only re-reads the `[[clients]]`
 roster.
@@ -240,10 +242,11 @@ does not keep a copy.
 ## Service lifecycle
 
 `systemctl stop` and `systemctl restart` send SIGTERM. The server receives that
-signal once and broadcasts the shutdown request to every shard, sends HTTP/3
-GOAWAY and QUIC CONNECTION_CLOSE, and drains existing connections for at most
-five seconds. The packaged unit sets `TimeoutStopSec=10s`, leaving a second
-five-second margin before systemd may escalate to SIGKILL.
+signal once and broadcasts the shutdown request to every worker. HTTP/3 sends
+GOAWAY and QUIC CONNECTION_CLOSE; HTTP/2 starts an H2 graceful shutdown. Both
+drain existing connections for at most five seconds. The packaged unit sets
+`TimeoutStopSec=10s`, leaving a second five-second margin before systemd may
+escalate to SIGKILL.
 
 systemd considers startup complete only after the process has bound every
 proxy listener and the optional observability endpoint and sent `READY=1`.
@@ -271,8 +274,8 @@ masque-server --config /etc/masque/masque.toml check-config
 
 This validates the parts of startup that do not need live resources. A 0.2
 configuration, a file that no longer satisfies fail-closed authentication, a bad
-certificate/key pair, an unsupported QUIC setting, or an invalid client/address
-pool therefore stops the upgrade before replacement. Edit and validate such a
+certificate/key pair, an unsupported HTTP/2 or QUIC setting, or an invalid
+client/address pool therefore stops the upgrade before replacement. Edit and validate such a
 configuration deliberately; the installer never migrates it automatically.
 
 After a successful upgrade, inspect service status and run a client
@@ -290,6 +293,7 @@ Confirm the listener and process:
 
 ```sh
 sudo ss -u -l -p | grep masque-server
+sudo ss -t -l -p | grep masque-server
 systemctl show masque -p MainPID -p ActiveState -p SubState
 ```
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,7 +1,7 @@
 # Observability
 
 MASQUE Server can expose a small HTTP/1 operational endpoint independently of
-its HTTP/3 proxy listeners. It is disabled unless configured and is restricted
+its HTTP/2 and HTTP/3 proxy listeners. It is disabled unless configured and is restricted
 to an IPv4 or IPv6 loopback address because it has no authentication layer.
 
 ```toml
@@ -19,10 +19,10 @@ through a firewall rule or unauthenticated reverse proxy.
 | Path | Success | Meaning |
 | --- | --- | --- |
 | `/healthz` | `200 ok` | The process and operational HTTP task are alive |
-| `/readyz` | `200 ready` | All proxy sockets are bound and every shard heartbeat is current |
+| `/readyz` | `200 ready` | All proxy sockets are bound and every listener worker heartbeat is current |
 | `/metrics` | `200` | Prometheus text exposition |
 
-`/readyz` returns `503` before readiness, when any proxy shard has made no
+`/readyz` returns `503` before readiness, when any proxy worker has made no
 event-loop progress for five seconds, and as soon as graceful shutdown starts.
 `/healthz` and `/metrics` remain available during the bounded drain.
 Only `GET` and `HEAD` are accepted, requests time out after two seconds, request
@@ -91,38 +91,39 @@ All metric names start with `masque_`.
 | `masque_server_ready` | gauge | — | `1` while ready, `0` while starting or draining |
 | `masque_process_start_time_seconds` | gauge | — | Process start as a Unix timestamp |
 | `masque_process_uptime_seconds` | gauge | — | Current process uptime |
-| `masque_listener_shards` | gauge | `listener`, `auth` | Event loops assigned to the listener |
-| `masque_shard_heartbeat_age_seconds` | gauge | `listener`, `auth`, `shard` | Time since the shard last made event-loop progress |
-| `masque_event_loop_lag_seconds` | gauge | `listener`, `auth`, `shard` | Latest one-second heartbeat scheduling delay |
-| `masque_event_loop_lag_max_seconds` | gauge | `listener`, `auth`, `shard` | Largest heartbeat delay since startup |
-| `masque_connections_active` | gauge | `listener`, `auth` | Live QUIC connections |
-| `masque_connections_accepted_total` | counter | `listener`, `auth` | Accepted connection objects |
-| `masque_connections_rejected_total` | counter | `listener`, `auth`, `reason` | Connections rejected at a resource limit |
-| `masque_quic_receive_batches_total` | counter | `listener`, `auth` | Non-empty network receive batches |
-| `masque_quic_receive_packets_total` | counter | `listener`, `auth` | Received QUIC UDP datagrams |
-| `masque_quic_receive_bytes_total` | counter | `listener`, `auth` | Received QUIC UDP bytes |
-| `masque_quic_send_batches_total` | counter | `listener`, `auth` | Successful network send batches |
-| `masque_quic_send_packets_total` | counter | `listener`, `auth` | Sent QUIC UDP datagrams |
-| `masque_quic_send_bytes_total` | counter | `listener`, `auth` | Sent QUIC UDP bytes |
-| `masque_quic_udp_gso_enabled` | gauge | `listener`, `auth` | Bound QUIC socket is using UDP GSO |
-| `masque_quic_udp_gro_enabled` | gauge | `listener`, `auth` | Bound QUIC socket is using UDP GRO |
-| `masque_tcp_relay_batches_total` | counter | `listener`, `auth` | Event-loop rounds consuming target TCP events |
-| `masque_tcp_relay_events_total` | counter | `listener`, `auth` | Target TCP events consumed by shards |
-| `masque_tcp_relay_bytes_total` | counter | `listener`, `auth` | Target TCP response bytes handed to shards |
-| `masque_tunnels_active` | gauge | `listener`, `auth`, `protocol` | Live `tcp`, `udp`, or `ip` tunnels |
-| `masque_auth_attempts_total` | counter | `listener`, `auth`, `result` | Successful, failed, or load-shed verification |
-| `masque_auth_pending` | gauge | `listener`, `auth` | Admitted Basic checks not yet completed |
-| `masque_auth_running` | gauge | `listener`, `auth` | Argon2 jobs currently executing |
-| `masque_packets_dropped_total` | counter | `listener`, `auth`, `reason` | Drops at bounded shard, datagram, or TUN queues |
+| `masque_listener_shards` | gauge | `listener`, `transport`, `auth` | Event-loop workers assigned to the listener |
+| `masque_shard_heartbeat_age_seconds` | gauge | `listener`, `transport`, `auth`, `shard` | Time since the worker last made event-loop progress |
+| `masque_event_loop_lag_seconds` | gauge | `listener`, `transport`, `auth`, `shard` | Latest one-second heartbeat scheduling delay |
+| `masque_event_loop_lag_max_seconds` | gauge | `listener`, `transport`, `auth`, `shard` | Largest heartbeat delay since startup |
+| `masque_connections_active` | gauge | `listener`, `transport`, `auth` | Live HTTP transport connections |
+| `masque_connections_accepted_total` | counter | `listener`, `transport`, `auth` | Accepted connection objects |
+| `masque_connections_rejected_total` | counter | `listener`, `transport`, `auth`, `reason` | Connections rejected at a resource limit |
+| `masque_quic_receive_batches_total` | counter | `listener`, `transport`, `auth` | Non-empty HTTP/3 network receive batches |
+| `masque_quic_receive_packets_total` | counter | `listener`, `transport`, `auth` | Received HTTP/3 QUIC UDP datagrams |
+| `masque_quic_receive_bytes_total` | counter | `listener`, `transport`, `auth` | Received HTTP/3 QUIC UDP bytes |
+| `masque_quic_send_batches_total` | counter | `listener`, `transport`, `auth` | Successful HTTP/3 network send batches |
+| `masque_quic_send_packets_total` | counter | `listener`, `transport`, `auth` | Sent HTTP/3 QUIC UDP datagrams |
+| `masque_quic_send_bytes_total` | counter | `listener`, `transport`, `auth` | Sent HTTP/3 QUIC UDP bytes |
+| `masque_quic_udp_gso_enabled` | gauge | `listener`, `transport`, `auth` | Bound HTTP/3 socket is using UDP GSO |
+| `masque_quic_udp_gro_enabled` | gauge | `listener`, `transport`, `auth` | Bound HTTP/3 socket is using UDP GRO |
+| `masque_tcp_relay_batches_total` | counter | `listener`, `transport`, `auth` | HTTP/3 event-loop rounds consuming target TCP events |
+| `masque_tcp_relay_events_total` | counter | `listener`, `transport`, `auth` | Target TCP events consumed by HTTP/3 shards |
+| `masque_tcp_relay_bytes_total` | counter | `listener`, `transport`, `auth` | Target TCP response bytes handed to HTTP/3 shards |
+| `masque_tunnels_active` | gauge | `listener`, `transport`, `auth`, `protocol` | Live `tcp`, `udp`, or `ip` tunnels |
+| `masque_auth_attempts_total` | counter | `listener`, `transport`, `auth`, `result` | Successful, failed, or load-shed verification |
+| `masque_auth_pending` | gauge | `listener`, `transport`, `auth` | Admitted Basic checks not yet completed |
+| `masque_auth_running` | gauge | `listener`, `transport`, `auth` | Argon2 jobs currently executing |
+| `masque_packets_dropped_total` | counter | `listener`, `transport`, `auth`, `reason` | Drops at bounded shard, datagram, or TUN queues |
 | `masque_roster_reloads_total` | counter | `result` | Successful and rejected SIGHUP roster reloads |
 | `masque_forced_shutdowns_total` | counter | — | Process shutdowns that reached the drain deadline |
 
 Labels deliberately describe only configured listeners, authentication modes,
-protocols, and fixed result classes. Usernames, client identities, target
+transports, protocols, and fixed result classes. Usernames, client identities, target
 addresses, stream IDs, and connection IDs are never labels, which avoids both
 sensitive-data exposure and unbounded Prometheus cardinality.
 
-Receive, send, and TCP relay counters are updated once per batch rather than
+QUIC and HTTP/3 TCP-relay counters remain zero for HTTP/2 listeners. Receive,
+send, and TCP relay counters are updated once per batch rather than
 once per packet or relay event. Dividing relay events by relay batches shows
 the effective event-loop coalescing factor. Connection counts use object
 lifetime, while tunnel gauges are published once after a connection's
@@ -147,6 +148,6 @@ service, add `--log-format json` to an `ExecStart` override when desired.
 
 The supplied unit uses `Type=notify` and `WatchdogSec=30s`. The process sends
 `READY=1` only after all proxy sockets and the optional operational socket are
-bound, sends watchdog pings only while every shard heartbeat is current, and
+bound, sends watchdog pings only while every worker heartbeat is current, and
 sends `STOPPING=1` when graceful draining begins. Manual foreground runs need
 no special environment; notification is a no-op when `NOTIFY_SOCKET` is absent.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -16,6 +16,21 @@ Payload bit rate excludes QUIC, UDP, IP, Ethernet, TLS, and proxy framing. A
 1200-byte payload can show fewer packets per second than a 64-byte payload yet
 carry much more useful bandwidth. Always report both pps and Gbit/s.
 
+## HTTP/2 compatibility path
+
+HTTP/2 standard CONNECT uses H2 DATA frames with explicit flow-control
+backpressure in both directions. CONNECT-UDP and CONNECT-IP place each HTTP
+Datagram payload inside a DATAGRAM capsule carried by DATA frames. That makes
+loss recoverable and ordered by the outer TCP connection; it also introduces
+head-of-line blocking and nested loss recovery that HTTP/3 DATAGRAM avoids.
+Treat HTTP/2 as a reachability fallback, not as a replacement for HTTP/3 in
+performance comparisons.
+
+The current network benchmark drives HTTP/3. HTTP/2 is covered by real TLS/H2
+relay integration tests, but no HTTP/2 throughput number should be compared to
+the network benchmark until the same harness can drive both transports with
+the same targets, payloads, windows, and CPU placement.
+
 ## Linux fast paths
 
 ### QUIC socket
@@ -77,6 +92,11 @@ Important settings:
 | Setting | Effect |
 | --- | --- |
 | `listeners[].shards` | Aggregate multi-connection CPU parallelism for that listener |
+| `http2.initial_*_window` | HTTP/2 initial bandwidth-delay credit |
+| `http2.max_concurrent_streams` | HTTP/2 per-connection stream concurrency |
+| `http2.max_send_buffer_size` | HTTP/2 buffered response bound per stream |
+| `http2.data_frame_budget` | Small DATA-frame burst tolerance versus per-connection memory-abuse bound |
+| `http2.max_datagram_size` | HTTP/2 CONNECT-UDP payload / CONNECT-IP packet ceiling |
 | `quic.enable_udp_gso` | QUIC send syscall and per-packet overhead |
 | `quic.enable_udp_gro` | QUIC receive syscall overhead |
 | `udp_proxy.enable_udp_gso` | Client-to-target UDP kernel overhead |

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -5,14 +5,17 @@
 | Standard | Use |
 | --- | --- |
 | [RFC 9000](https://www.rfc-editor.org/rfc/rfc9000) | QUIC transport and variable-length integers |
+| [RFC 9113](https://www.rfc-editor.org/rfc/rfc9113) | HTTP/2 streams and flow control |
 | [RFC 9114](https://www.rfc-editor.org/rfc/rfc9114) | HTTP/3 request streams |
+| [RFC 8441](https://www.rfc-editor.org/rfc/rfc8441) | HTTP/2 Extended CONNECT |
 | [RFC 9297](https://www.rfc-editor.org/rfc/rfc9297) | HTTP Datagrams and Capsule Protocol |
 | [RFC 9298](https://www.rfc-editor.org/rfc/rfc9298) | CONNECT-UDP |
 | [RFC 9484](https://www.rfc-editor.org/rfc/rfc9484) | CONNECT-IP |
 | [RFC 7617](https://www.rfc-editor.org/rfc/rfc7617) | Basic authentication syntax |
 
-The TLS ALPN is HTTP/3 as provided by quiche. QUIC DATAGRAM support and HTTP/3
-Extended CONNECT are advertised during connection setup.
+An HTTP/3 listener negotiates an HTTP/3 ALPN through quiche and advertises QUIC
+DATAGRAM plus Extended CONNECT. An HTTP/2 listener negotiates only the `h2`
+ALPN over TCP/TLS and advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`.
 
 ## Authentication
 
@@ -35,7 +38,7 @@ Authentication is per request, so one authenticated tunnel does not authorize
 later streams that omit the header.
 
 With a listener's `auth.mode = "client_cert"` there is no per-request step: the client is
-identified once, from its TLS client certificate, during the QUIC handshake. An
+identified once, from its TLS client certificate, during the TLS handshake. An
 unregistered key never reaches the request path — it is refused with a TLS
 `access_denied` alert. See
 [Cloudflare-compatible clients](#cloudflare-compatible-clients).
@@ -46,9 +49,9 @@ The request uses `:method = CONNECT` and places the TCP destination in
 `:authority` as `host:port`. It does not use `:protocol`.
 
 After authentication, resolution, and policy checks, the server connects to
-the target and returns `200`. HTTP/3 request-body bytes flow to the target and
-target bytes flow in the response body. Either side's end-of-stream is relayed
-as a half-close when possible.
+the target and returns `200`. Request-body bytes flow to the target and target
+bytes flow in the response body. Either side's end-of-stream is relayed as a
+half-close when possible. This behavior is the same over HTTP/2 and HTTP/3.
 
 ## CONNECT-UDP
 
@@ -65,13 +68,18 @@ The URI template is configurable but must expose both target variables. After
 authentication, resolution, and UDP policy, a connected target socket is
 created and the server returns `200` with `Capsule-Protocol: ?1`.
 
-Each HTTP Datagram starts with the request stream's Quarter Stream ID followed
-by Context ID `0` and the UDP payload. Unexpected Context IDs are rejected.
-Datagrams are not retransmitted by QUIC.
+On HTTP/3, each HTTP Datagram starts with the request stream's Quarter Stream
+ID followed by Context ID `0` and the UDP payload. QUIC does not retransmit a
+lost datagram.
 
-If a client uses Capsule Protocol fallback, DATAGRAM capsules are incrementally
-decoded from the request stream. Unknown capsule types are ignored as required
-by the Capsule Protocol unless they affect tunnel state.
+HTTP/2 has no native HTTP Datagram frame. The client must negotiate Capsule
+Protocol with `Capsule-Protocol: ?1`; each request and response DATA stream then
+carries RFC 9297 DATAGRAM capsules whose value is Context ID `0` followed by
+the UDP payload. Those capsules inherit HTTP/2's reliable, ordered TCP delivery,
+so this mode is for compatibility rather than maximum datagram performance.
+Capsules are decoded incrementally and oversized declarations are rejected
+before their values are buffered. Unknown capsule types are ignored. The same
+stream fallback carries CONNECT-IP packets over HTTP/2.
 
 ## CONNECT-IP
 
@@ -90,12 +98,16 @@ connection carrying the same enrolled key; the newest tunnel atomically takes
 over the return route, while reference-counted leases keep later cleanup from
 freeing an address that is still live.
 
-IP packets use HTTP Datagrams with Context ID `0`. Before writing a client
-packet to TUN, the server checks the source address against the tunnel's
-assignment. Return packets are routed only to the owning tunnel.
+IP packets use HTTP Datagrams with Context ID `0`. HTTP/3 sends them as QUIC
+DATAGRAM frames; HTTP/2 sends the same payload inside DATAGRAM capsules on the
+request/response DATA stream. Before writing a client packet to TUN, the server
+checks the source address against the tunnel's assignment. Return packets are
+routed only to the owning tunnel through transport-specific bounded queues.
 
-CONNECT-IP depends on host routing and firewall configuration; the HTTP
-protocol does not configure NAT or upstream routes for the host.
+CONNECT-IP depends on Linux TUN, host routing, and firewall configuration; the
+HTTP transport does not configure NAT or upstream routes for the host. HTTP/2
+improves reachability where UDP is blocked, but its ordered TCP stream can
+head-of-line block unrelated IP packets after loss.
 
 ## Response status
 
@@ -110,11 +122,15 @@ protocol does not configure NAT or upstream routes for the host.
 | `502` | DNS, target socket, or upstream TCP setup failed |
 
 Once a tunnel is established, relay errors normally reset that stream rather
-than close every tunnel on the QUIC connection.
+than close every tunnel on the HTTP connection.
 
 ## Interoperability
 
-Clients must support HTTP/3 proxy CONNECT and the relevant MASQUE extension.
+Clients must support proxy CONNECT on the selected transport and the relevant
+MASQUE extension. Standards-based HTTP/2 CONNECT-UDP and CONNECT-IP require
+Extended CONNECT and Capsule Protocol support; an ordinary HTTP proxy client
+is sufficient only for standard CONNECT. The additional Cloudflare-compatible
+CONNECT-IP shape below is deliberately supported for deployed clients.
 Configuration syntaxes in products such as Surge are client-specific and are
 not part of the RFCs. Test authentication, target policy, TCP, UDP, and DNS
 separately when qualifying a client.
@@ -127,15 +143,15 @@ VPN-style MASQUE clients modelled on Cloudflare WARP — for example
 RFC 9484 in ways the server accommodates. Everything below is on by default
 except the authentication mode.
 
-**`:protocol` is `cf-connect-ip`.** Cloudflare's endpoint uses that instead of
-the registered `connect-ip`, and these clients send only it. Both are in
+**HTTP/3 `:protocol` is `cf-connect-ip`.** Cloudflare's endpoint uses that
+instead of the registered `connect-ip`, and these clients send only it. Both are in
 `ip_proxy.connect_protocols` by default. This is not optional: usque and mihomo
 are independent implementations, and both were observed sending byte-identical
 requests — `:protocol: cf-connect-ip`, `:authority: cloudflareaccess.com`,
 `:path: /` — so a server accepting only `connect-ip` answers `404` to every
 client in this family.
 
-**`:authority` and `:path` are fixed.** The request arrives as
+**HTTP/3 `:authority` and `:path` are fixed.** The request arrives as
 `:authority: cloudflareaccess.com` and `:path: /`, with no URI Template
 variables. The CONNECT-IP path ignores both, so `ip_proxy.uri_template` does not
 apply to these clients.
@@ -148,14 +164,22 @@ standards-compliant clients at the same time, give each mode its own
 [listener](configuration.md#listeners) — the mode fixes the TLS
 context, so the two cannot share a socket, but they can share a process.
 
-**Extended CONNECT is not required of the server.** Cloudflare does not
-advertise `SETTINGS_ENABLE_CONNECT_PROTOCOL`, and these clients tolerate its
-absence. This server advertises it anyway, which is compatible.
+**The HTTP/2 fallback uses a separate deployed wire shape.** usque's `--http2`
+mode sends an ordinary CONNECT with `cf-connect-proto: cf-connect-ip`, not an
+Extended CONNECT `:protocol`. Its DATAGRAM capsule value contains the raw IP
+packet and omits the otherwise mandatory Context ID zero. The server detects
+that exact header and mirrors the framing on responses. Standards-based H2
+CONNECT-IP remains available at the same time; it uses Extended CONNECT,
+`Capsule-Protocol: ?1`, and retains Context ID zero.
+
+Cloudflare's HTTP/3 service does not require clients to observe
+`SETTINGS_ENABLE_CONNECT_PROTOCOL`; this server advertises the setting on both
+HTTP transports where applicable.
 
 **Addresses come from the client's own configuration, not from
-`ADDRESS_ASSIGN`.** Cloudflare sends no capsules at all; the client learns its
-tunnel addresses from its config file and configures its interface from those.
-Two consequences:
+`ADDRESS_ASSIGN`.** These clients send no address-control capsules; the client
+learns its tunnel addresses from its config file and configures its interface
+from those. Two consequences:
 
 - The address must be pinned per client with `[[clients]].ipv4` / `.ipv6`, and
   the client's configuration must carry the same values. A pool-allocated
@@ -172,6 +196,8 @@ reliable way to keep them consistent.
 **Keepalive interacts with the idle timeout.** These clients default to a 30s
 keepalive period. Keep `server.idle_timeout_secs` above it; the default is 60.
 
-**HTTP/2 fallback is not supported.** Some of these clients can carry
-CONNECT-IP over TCP and HTTP/2 instead of QUIC. This server is HTTP/3 only, so
-those clients must use their default QUIC transport.
+**HTTP/2 fallback is available when the client supports it.** These clients may
+carry CONNECT-IP over TCP/H2 instead of QUIC. Point that mode at a listener with
+`transport = "http2"`; address assignment, certificate identity, source checks,
+and TUN routing are shared with HTTP/3. Prefer QUIC when it is reachable because
+TCP loss makes all capsules on the H2 connection wait for retransmission.

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,7 +2,8 @@
 
 ## Threat model
 
-The listener is expected to receive arbitrary UDP, QUIC, HTTP/3, CONNECT,
+The listeners are expected to receive arbitrary TCP, UDP, TLS, QUIC, HTTP/2,
+HTTP/3, CONNECT,
 credential, and target data from the internet. A successful client can ask the
 server to originate TCP/UDP traffic, and CONNECT-IP clients can exchange raw IP
 packets through the host. The principal risks are:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,6 +13,7 @@
 | Network benchmark | `scripts/network-bench.sh` | Local direct-vs-MASQUE throughput and RTT |
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
 | Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth, CONNECT-IP setup, and both authentication modes served from one process |
+| HTTP/2 interop | `cargo test --test http2_connect` | Real TLS/H2 CONNECT, CONNECT-UDP, RFC CONNECT-IP, usque-style CONNECT-IP, Basic auth, and client-certificate auth |
 | Observability assets | `cargo test --test monitoring_assets` | Prometheus metric references and importable Grafana JSON |
 | Service shutdown | `tests/systemd-shutdown.sh` | Real SIGTERM/SIGINT handling and every-shard drain; Linux exercises two shards |
 | Config preflight | `cargo test --test check_config` | `check-config` accepts what a server accepts, including multi-listener files |
@@ -28,9 +29,10 @@ cargo +1.88.0 check --workspace --locked
 cargo test --workspace --locked
 ```
 
-macOS covers portable CONNECT, CONNECT-UDP, authentication, protocol codecs,
-and scheduling. It does not validate Linux `recvmmsg`/`sendmmsg`, GSO/GRO,
-`SO_REUSEPORT`, TUN offload, capabilities, or systemd.
+macOS covers HTTP/2 CONNECT-IP setup plus portable HTTP/2 and HTTP/3 CONNECT,
+CONNECT-UDP, authentication, protocol codecs, and scheduling. It does not
+validate Linux `recvmmsg`/`sendmmsg`, GSO/GRO, `SO_REUSEPORT`, actual TUN
+forwarding/offload, capabilities, or systemd.
 
 ## Docker E2E
 
@@ -202,6 +204,10 @@ flag — enrollment prints the exact argument:
 sudo ./usque nativetun --config config.json --connect-port 4433
 ```
 
+Add `--http2` to that command when testing a listener with
+`transport = "http2"`; enrollment already fills the JSON's `endpoint_h2_v4` or
+`endpoint_h2_v6` field.
+
 **6. Verify.** The most decisive target is the server's own TUN address, because
 it exercises the tunnel end to end without depending on the host's egress path
 at all. Serve a large file there and pull it through the tunnel, comparing
@@ -267,7 +273,7 @@ that, and all three were hit while qualifying this feature:
 | In-tunnel traffic works, egress does not | The host's forwarding path, not the server. See [Egress testing needs an uncontended host](#egress-testing-needs-an-uncontended-host). |
 | Egress ICMP works but TCP hangs | Almost always a transparent proxy on the server host that exempts ICMP from its policy routing. Check `ip rule show`. |
 | Server logs `spoofed source address, dropping` | The client's interface address disagrees with its pinned address. Re-enroll so both sides match. |
-| Small packets work, bulk transfers stall | The framed MTU exceeds the datagram budget. Raise `quic.max_datagram_size` or lower the client's MTU; keep the client at 1280 unless both ends were changed together. |
+| Small packets work, bulk transfers stall | The framed MTU exceeds the selected transport's datagram budget. Raise `quic.max_datagram_size` for HTTP/3 or `http2.max_datagram_size` for HTTP/2, or lower the client's MTU; keep the client at 1280 unless both ends were changed together. |
 | Tunnel drops roughly every 30s | `server.idle_timeout_secs` is at or below the client's keepalive period. |
 
 ## Release checklist

--- a/src/capsule/decoder.rs
+++ b/src/capsule/decoder.rs
@@ -13,6 +13,8 @@ pub enum DecodeError {
     Incomplete,
     /// The capsule value could not be parsed.
     Malformed(String),
+    /// The declared capsule value exceeds the configured memory bound.
+    TooLarge { length: u64, max: usize },
 }
 
 impl std::fmt::Display for DecodeError {
@@ -20,6 +22,9 @@ impl std::fmt::Display for DecodeError {
         match self {
             DecodeError::Incomplete => write!(f, "incomplete capsule data"),
             DecodeError::Malformed(msg) => write!(f, "malformed capsule: {msg}"),
+            DecodeError::TooLarge { length, max } => {
+                write!(f, "capsule value is {length} bytes, limit is {max}")
+            }
         }
     }
 }
@@ -31,17 +36,26 @@ pub struct CapsuleDecoder {
     buf: Vec<u8>,
     /// Bytes at the front of `buf` that have already been decoded.
     consumed: usize,
+    max_capsule_size: usize,
 }
 
 /// Compact `buf` once the decoded prefix grows past this many bytes, so a long
 /// stream neither memmoves after every capsule nor grows without bound.
 const COMPACT_THRESHOLD: usize = 16 * 1024;
+const DEFAULT_MAX_CAPSULE_SIZE: usize = 1024 * 1024;
 
 impl CapsuleDecoder {
     pub fn new() -> Self {
+        Self::with_max_capsule_size(DEFAULT_MAX_CAPSULE_SIZE)
+    }
+
+    /// Build a decoder that rejects a capsule before buffering a value larger
+    /// than `max_capsule_size`.
+    pub fn with_max_capsule_size(max_capsule_size: usize) -> Self {
         Self {
             buf: Vec::new(),
             consumed: 0,
+            max_capsule_size,
         }
     }
 
@@ -63,7 +77,7 @@ impl CapsuleDecoder {
         let mut frames = Vec::new();
 
         loop {
-            match try_decode_one(&self.buf[self.consumed..]) {
+            match try_decode_one(&self.buf[self.consumed..], self.max_capsule_size) {
                 Ok((frame, consumed)) => {
                     frames.push(frame);
                     self.consumed += consumed;
@@ -89,15 +103,27 @@ impl Default for CapsuleDecoder {
 }
 
 /// Try to decode one capsule from `buf`. Returns `(frame, bytes_consumed)`.
-fn try_decode_one(buf: &[u8]) -> Result<(CapsuleFrame, usize), DecodeError> {
+fn try_decode_one(
+    buf: &[u8],
+    max_capsule_size: usize,
+) -> Result<(CapsuleFrame, usize), DecodeError> {
     // Parse Type varint
     let (capsule_type, tlen) = varint::decode(buf).map_err(|_| DecodeError::Incomplete)?;
 
     // Parse Length varint
     let (length, llen) = varint::decode(&buf[tlen..]).map_err(|_| DecodeError::Incomplete)?;
 
+    if length > max_capsule_size as u64 {
+        return Err(DecodeError::TooLarge {
+            length,
+            max: max_capsule_size,
+        });
+    }
+
     let header_len = tlen + llen;
-    let total_len = header_len + length as usize;
+    let total_len = header_len
+        .checked_add(length as usize)
+        .ok_or_else(|| DecodeError::Malformed("capsule length overflows usize".into()))?;
 
     if buf.len() < total_len {
         return Err(DecodeError::Incomplete);
@@ -518,5 +544,22 @@ mod tests {
         let mut dec = CapsuleDecoder::new();
         let result = dec.decode(&wire);
         assert!(matches!(result, Err(DecodeError::Malformed(_))));
+    }
+
+    #[test]
+    fn declared_value_over_the_limit_is_rejected_from_its_header() {
+        let mut wire = Vec::new();
+        crate::varint::encode_to_vec(CAPSULE_DATAGRAM, &mut wire).unwrap();
+        crate::varint::encode_to_vec(65_000, &mut wire).unwrap();
+
+        let mut decoder = CapsuleDecoder::with_max_capsule_size(1_200);
+        assert_eq!(
+            decoder.decode(&wire),
+            Err(DecodeError::TooLarge {
+                length: 65_000,
+                max: 1_200,
+            })
+        );
+        assert_eq!(decoder.buffered(), wire.len());
     }
 }

--- a/src/capsule/encoder.rs
+++ b/src/capsule/encoder.rs
@@ -30,6 +30,22 @@ pub fn encode(frame: &CapsuleFrame, buf: &mut Vec<u8>) {
     }
 }
 
+/// Encode a DATAGRAM capsule directly from its HTTP Datagram payload.
+///
+/// This avoids constructing an owned [`CapsuleFrame`] on relay paths that
+/// already have the payload in a reusable receive buffer.
+pub fn encode_datagram(payload: &[u8], buf: &mut Vec<u8>) {
+    encode_raw(CAPSULE_DATAGRAM, payload, buf);
+}
+
+/// Encode a DATAGRAM capsule whose HTTP Datagram payload uses Context ID zero.
+pub fn encode_datagram_context_zero(payload: &[u8], buf: &mut Vec<u8>) {
+    varint::encode_to_vec(CAPSULE_DATAGRAM, buf).expect("capsule type fits varint");
+    varint::encode_to_vec((payload.len() + 1) as u64, buf).expect("capsule length fits varint");
+    buf.push(0); // Context ID zero.
+    buf.extend_from_slice(payload);
+}
+
 /// Encode a raw capsule: Type(varint) + Length(varint) + Value.
 fn encode_raw(capsule_type: u64, value: &[u8], buf: &mut Vec<u8>) {
     varint::encode_to_vec(capsule_type, buf).expect("capsule type fits varint");

--- a/src/client_identity.rs
+++ b/src/client_identity.rs
@@ -21,7 +21,9 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
 use boring::nid::Nid;
 use boring::pkey::{PKey, Public};
+use boring::ssl::{SslAlert, SslContextBuilder, SslVerifyError, SslVerifyMode};
 use boring::x509::X509;
+use tracing::{debug, warn};
 
 use crate::config::ClientEntry;
 
@@ -242,6 +244,50 @@ impl SharedRoster {
     pub fn generation(&self) -> u64 {
         self.generation.load(Ordering::Acquire)
     }
+}
+
+/// Configure a TLS server context to require a client certificate and admit
+/// only public keys present in `roster`.
+///
+/// MASQUE clients in this family present short-lived self-signed certificates,
+/// so normal CA-chain verification is intentionally replaced by a canonical
+/// public-key lookup. Keeping the callback here lets QUIC and TCP/TLS listeners
+/// enforce exactly the same identity rule.
+pub(crate) fn configure_client_cert_verification(
+    builder: &mut SslContextBuilder,
+    roster: Arc<SharedRoster>,
+) {
+    let mode = SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT;
+    builder.set_custom_verify_callback(mode, move |ssl| {
+        let denied = Err(SslVerifyError::Invalid(SslAlert::ACCESS_DENIED));
+
+        let Some(cert) = ssl.peer_certificate() else {
+            warn!("rejecting client that presented no certificate");
+            return denied;
+        };
+        let Ok(der) = cert.to_der() else {
+            warn!("rejecting client certificate that could not be re-encoded");
+            return denied;
+        };
+
+        match roster.load().identify(&der) {
+            Ok(identity) => {
+                debug!(client = %identity.name, "client certificate accepted");
+                Ok(())
+            }
+            Err(IdentityError::UnknownKey(key)) => {
+                warn!(
+                    public_key = %key,
+                    "rejecting client: public key is not in the [[clients]] roster"
+                );
+                denied
+            }
+            Err(e) => {
+                warn!(%e, "rejecting client certificate");
+                denied
+            }
+        }
+    });
 }
 
 /// Why a presented client certificate was not accepted.

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct ServerConfig {
     #[serde(default)]
     pub quic: QuicSection,
     #[serde(default)]
+    pub http2: Http2Section,
+    #[serde(default)]
     pub tcp_proxy: TcpProxySection,
     #[serde(default)]
     pub udp_proxy: UdpProxySection,
@@ -63,11 +65,32 @@ pub enum AuthMode {
     #[default]
     Basic,
     /// A TLS client certificate, matched against the `[[clients]]` roster by
-    /// public key during the QUIC handshake.
+    /// public key during the TLS handshake.
     ///
     /// This is what Cloudflare's WARP MASQUE endpoint does, and what clients
     /// built against it (usque) expect: they never send `Proxy-Authorization`.
     ClientCert,
+}
+
+/// HTTP transport carried by one listener.
+///
+/// HTTP/3 listens on UDP and remains the default. HTTP/2 listens on TCP/TLS
+/// and carries HTTP Datagrams through reliable DATAGRAM capsules.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ListenerTransport {
+    #[default]
+    Http3,
+    Http2,
+}
+
+impl ListenerTransport {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Http3 => "http3",
+            Self::Http2 => "http2",
+        }
+    }
 }
 
 #[derive(Clone, Deserialize, PartialEq)]
@@ -119,6 +142,10 @@ impl AuthSection {
 #[serde(deny_unknown_fields)]
 pub struct ListenerSection {
     pub listen_addr: SocketAddr,
+    /// `http3` binds UDP; `http2` binds TCP/TLS. The default preserves
+    /// configurations written before HTTP/2 support was added.
+    #[serde(default)]
+    pub transport: ListenerTransport,
     /// Independent event loops for this listener. Each shard owns a
     /// `SO_REUSEPORT` socket and a disjoint share of the connections. `0` means
     /// one per available core and is accepted only for a single listener.
@@ -137,6 +164,7 @@ fn default_listener_shards() -> usize {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedListener {
     pub listen_addr: SocketAddr,
+    pub transport: ListenerTransport,
     pub shards: usize,
     pub auth: AuthSection,
 }
@@ -209,6 +237,31 @@ pub struct QuicSection {
     pub discover_pmtu: bool,
 }
 
+/// HTTP/2 flow-control and resource limits.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct Http2Section {
+    /// Receive credit advertised for each request stream.
+    pub initial_stream_window: u32,
+    /// Receive credit advertised for the whole connection.
+    pub initial_connection_window: u32,
+    /// Maximum simultaneous streams accepted on one connection.
+    pub max_concurrent_streams: u32,
+    /// Maximum uncompressed request header list size.
+    pub max_header_list_size: u32,
+    /// Per-stream response bytes the h2 implementation may buffer.
+    pub max_send_buffer_size: usize,
+    /// Connection-level allowance for queued small DATA-frame overhead.
+    ///
+    /// CONNECT-IP clients commonly put one small inner TCP ACK in each DATA
+    /// frame. The generic h2 default is intentionally tiny and can mistake a
+    /// legitimate packet burst for abusive framing before the tunnel task gets
+    /// scheduled to consume it.
+    pub data_frame_budget: usize,
+    /// Largest UDP payload accepted in a CONNECT-UDP DATAGRAM capsule.
+    pub max_datagram_size: usize,
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct UdpProxySection {
@@ -274,6 +327,7 @@ impl Default for ServerConfig {
             server: ServerSection::default(),
             tls: TlsSection::default(),
             quic: QuicSection::default(),
+            http2: Http2Section::default(),
             tcp_proxy: TcpProxySection::default(),
             udp_proxy: UdpProxySection::default(),
             ip_proxy: IpProxySection::default(),
@@ -281,6 +335,7 @@ impl Default for ServerConfig {
             clients: Vec::new(),
             listeners: vec![ListenerSection {
                 listen_addr: "0.0.0.0:443".parse().unwrap(),
+                transport: ListenerTransport::Http3,
                 shards: default_listener_shards(),
                 auth: AuthSection::default(),
             }],
@@ -353,6 +408,23 @@ impl Default for QuicSection {
             dgram_recv_queue_len: 2048,
             dgram_send_queue_len: 2048,
             discover_pmtu: false,
+        }
+    }
+}
+
+impl Default for Http2Section {
+    fn default() -> Self {
+        Self {
+            initial_stream_window: 1024 * 1024,
+            initial_connection_window: 16 * 1024 * 1024,
+            max_concurrent_streams: 128,
+            max_header_list_size: 8 * 1024,
+            max_send_buffer_size: 256 * 1024,
+            // Enough for a TLS read containing thousands of packet-sized DATA
+            // frames, while retaining h2's connection-level abuse bound.
+            data_frame_budget: 256 * 1024,
+            // RFC 9298 caps a context-zero UDP payload at 65,527 bytes.
+            max_datagram_size: 65_527,
         }
     }
 }
@@ -432,6 +504,7 @@ enabled = false
         assert!(cfg.clients.is_empty());
         assert_eq!(cfg.listeners.len(), 1);
         assert_eq!(cfg.listeners[0].listen_addr.port(), 443);
+        assert_eq!(cfg.listeners[0].transport, ListenerTransport::Http3);
         assert_eq!(cfg.listeners[0].shards, 1);
         assert!(cfg.listeners[0].auth.basic_enabled());
         assert!(!cfg.listeners[0].auth.client_cert_enabled());
@@ -444,6 +517,7 @@ enabled = false
         assert!(cfg.quic.initial_max_stream_data <= cfg.quic.max_stream_window);
         assert!(cfg.quic.initial_max_data <= cfg.quic.max_connection_window);
         assert!(!cfg.quic.discover_pmtu);
+        assert_eq!(cfg.http2.data_frame_budget, 256 * 1024);
         assert!(cfg.tcp_proxy.enabled);
         assert_eq!(cfg.tcp_proxy.connect_timeout_secs, 10);
         assert!(cfg.udp_proxy.enabled);
@@ -617,6 +691,40 @@ mode = "client_cert"
         assert_eq!(cfg.listeners[1].shards, 2);
         assert!(cfg.listeners[1].auth.client_cert_enabled());
         assert!(!cfg.listeners[1].auth.basic_enabled());
+    }
+
+    #[test]
+    fn parses_http2_listener_and_tuning() {
+        let cfg = parse_toml(
+            r#"
+[http2]
+initial_stream_window = 2097152
+initial_connection_window = 33554432
+max_concurrent_streams = 64
+max_header_list_size = 4096
+max_send_buffer_size = 131072
+data_frame_budget = 524288
+max_datagram_size = 4096
+
+[[listeners]]
+listen_addr = "127.0.0.1:8443"
+transport = "http2"
+
+[listeners.auth]
+enabled = false
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.listeners[0].transport, ListenerTransport::Http2);
+        assert_eq!(cfg.listeners[0].shards, 1);
+        assert_eq!(cfg.http2.initial_stream_window, 2 * 1024 * 1024);
+        assert_eq!(cfg.http2.initial_connection_window, 32 * 1024 * 1024);
+        assert_eq!(cfg.http2.max_concurrent_streams, 64);
+        assert_eq!(cfg.http2.max_header_list_size, 4096);
+        assert_eq!(cfg.http2.max_send_buffer_size, 128 * 1024);
+        assert_eq!(cfg.http2.data_frame_budget, 512 * 1024);
+        assert_eq!(cfg.http2.max_datagram_size, 4096);
     }
 
     #[test]

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -37,7 +37,9 @@ use anyhow::{Context, bail, ensure};
 use zeroize::Zeroizing;
 
 use crate::auth;
-use crate::config::{self, AuthMode, AuthSection, ListenerSection, ServerConfig};
+use crate::config::{
+    self, AuthMode, AuthSection, ListenerSection, ListenerTransport, ServerConfig,
+};
 use crate::enroll::toml_string;
 use crate::server::validate_config;
 
@@ -57,6 +59,7 @@ const SUGGESTED_PORT: u16 = 4443;
 #[derive(Debug, Default)]
 pub struct AddListener {
     pub listen_addr: Option<SocketAddr>,
+    pub transport: Option<ListenerTransport>,
     pub mode: Option<AuthMode>,
     pub shards: Option<usize>,
     pub username: Option<String>,
@@ -106,9 +109,15 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
     // prompt on and every other value has to come from a flag.
     let interactive = std::io::stdin().is_terminal() && !request.password_stdin;
 
+    let transport = match request.transport {
+        Some(transport) => transport,
+        None if interactive => prompt_transport(&config)?,
+        None => ListenerTransport::Http3,
+    };
+
     let listen_addr = match request.listen_addr {
         Some(addr) => addr,
-        None if interactive => prompt_listen_addr(&config)?,
+        None if interactive => prompt_listen_addr(&config, transport)?,
         None => bail!("--listen-addr is required when standard input is not a terminal"),
     };
 
@@ -131,10 +140,14 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         );
     }
 
-    let shards = match request.shards {
-        Some(shards) => shards,
-        None if interactive => prompt_shards()?,
-        None => 1,
+    let shards = match (transport, request.shards) {
+        (ListenerTransport::Http2, Some(1) | None) => 1,
+        (ListenerTransport::Http2, Some(shards)) => {
+            bail!("HTTP/2 listeners must use --shards 1, not {shards}")
+        }
+        (ListenerTransport::Http3, Some(shards)) => shards,
+        (ListenerTransport::Http3, None) if interactive => prompt_shards()?,
+        (ListenerTransport::Http3, None) => 1,
     };
 
     let mut generated_password: Option<Zeroizing<String>> = None;
@@ -176,6 +189,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
 
     let listener = ListenerSection {
         listen_addr,
+        transport,
         shards,
         auth,
     };
@@ -197,7 +211,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
     })?;
 
     if !request.no_bind_check {
-        probe_listen_addr(listen_addr).with_context(|| {
+        probe_listen_addr(listen_addr, transport).with_context(|| {
             format!(
                 "the new listener would not bind, and a listener that cannot bind stops \
                  the whole server — including the sockets that work today; {} is unchanged \
@@ -234,7 +248,8 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
     write_in_place(config_path, &text, &merged)?;
 
     println!(
-        "added listener {listen_addr} auth={} shards={shards} to {}",
+        "added listener {listen_addr} transport={} auth={} shards={shards} to {}",
+        transport.as_str(),
         auth_label(&listener.auth),
         config_path.display()
     );
@@ -247,7 +262,11 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
     );
     if listen_addr.port() != 0 {
         println!(
-            "the firewall has to allow UDP {} as well",
+            "the firewall has to allow {} {} as well",
+            match transport {
+                ListenerTransport::Http3 => "UDP",
+                ListenerTransport::Http2 => "TCP",
+            },
             listen_addr.port()
         );
     }
@@ -283,7 +302,7 @@ fn print_generated_password(username: &str, password: &str) -> anyhow::Result<()
 ///
 /// This is a probe, not a reservation. The port is free at this instant; a
 /// service started in between can still take it.
-fn probe_listen_addr(addr: SocketAddr) -> anyhow::Result<()> {
+fn probe_listen_addr(addr: SocketAddr, transport: ListenerTransport) -> anyhow::Result<()> {
     // Port 0 asks the kernel for whichever port is free at startup, so there is
     // nothing to probe and no address to be in use.
     if addr.port() == 0 {
@@ -293,11 +312,12 @@ fn probe_listen_addr(addr: SocketAddr) -> anyhow::Result<()> {
     // Deliberately without SO_REUSEPORT: a listener that binds with it would
     // join an existing group and silently take a share of another socket's
     // traffic, which is exactly what has to be reported rather than allowed.
-    match std::net::UdpSocket::bind(addr) {
-        Ok(socket) => {
-            drop(socket);
-            Ok(())
-        }
+    let result = match transport {
+        ListenerTransport::Http3 => std::net::UdpSocket::bind(addr).map(drop),
+        ListenerTransport::Http2 => std::net::TcpListener::bind(addr).map(drop),
+    };
+    match result {
+        Ok(()) => Ok(()),
         // A privileged port without the privilege to bind it says nothing about
         // the server, which holds CAP_NET_BIND_SERVICE. Report and continue.
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -333,6 +353,10 @@ pub fn listener_toml_block(listener: &ListenerSection) -> String {
     block.push_str(&format!(
         "listen_addr = {}\n",
         toml_string(&listener.listen_addr.to_string())
+    ));
+    block.push_str(&format!(
+        "transport = {}\n",
+        toml_string(listener.transport.as_str())
     ));
     block.push_str(&format!("shards = {}\n", listener.shards));
     block.push_str("\n[listeners.auth]\n");
@@ -477,8 +501,11 @@ fn trim_newline(value: &str) -> &str {
 // Prompts and their echoes go to standard error, so `--dry-run | tee` and the
 // final summary on standard output stay usable in a pipeline.
 
-fn prompt_listen_addr(config: &ServerConfig) -> anyhow::Result<SocketAddr> {
-    let suggestion = suggest_listen_addr(config);
+fn prompt_listen_addr(
+    config: &ServerConfig,
+    transport: ListenerTransport,
+) -> anyhow::Result<SocketAddr> {
+    let suggestion = suggest_listen_addr(config, transport);
     prompt_until_valid(
         "Listen address (ip:port)",
         &suggestion.to_string(),
@@ -496,7 +523,7 @@ fn prompt_listen_addr(config: &ServerConfig) -> anyhow::Result<SocketAddr> {
 /// already decided to expose, and the first free port at or above the
 /// suggestion. Overlap is refused later anyway; this only keeps the default
 /// from being one that would be.
-fn suggest_listen_addr(config: &ServerConfig) -> SocketAddr {
+fn suggest_listen_addr(config: &ServerConfig, transport: ListenerTransport) -> SocketAddr {
     let mut addr = config
         .listeners
         .first()
@@ -507,7 +534,7 @@ fn suggest_listen_addr(config: &ServerConfig) -> SocketAddr {
         config
             .listeners
             .iter()
-            .any(|listener| listener.listen_addr.port() == port)
+            .any(|listener| listener.transport == transport && listener.listen_addr.port() == port)
     };
 
     let mut port = SUGGESTED_PORT;
@@ -516,6 +543,23 @@ fn suggest_listen_addr(config: &ServerConfig) -> SocketAddr {
     }
     addr.set_port(port);
     addr
+}
+
+fn prompt_transport(config: &ServerConfig) -> anyhow::Result<ListenerTransport> {
+    let suggestion = if config
+        .listeners
+        .iter()
+        .any(|listener| listener.transport == ListenerTransport::Http2)
+    {
+        "http3"
+    } else {
+        "http2"
+    };
+    prompt_until_valid("Transport (http3 | http2)", suggestion, |line| match line {
+        "http3" | "h3" => Ok(ListenerTransport::Http3),
+        "http2" | "h2" => Ok(ListenerTransport::Http2),
+        other => bail!("unknown transport {other:?}; write http3 or http2"),
+    })
 }
 
 fn prompt_mode(config: &ServerConfig) -> anyhow::Result<AuthMode> {
@@ -922,6 +966,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
     fn client_cert_listener(port: u16) -> ListenerSection {
         ListenerSection {
             listen_addr: format!("0.0.0.0:{port}").parse().unwrap(),
+            transport: config::ListenerTransport::Http3,
             shards: 1,
             auth: AuthSection {
                 enabled: true,
@@ -940,6 +985,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
         let parsed = config::parse_toml(&merged).unwrap();
         assert_eq!(parsed.listeners.len(), 2);
         assert_eq!(parsed.listeners[1], listener);
+        assert!(listener_toml_block(&listener).contains("transport = \"http3\""));
     }
 
     /// The edit is textual, so the comments an operator relies on must survive
@@ -958,6 +1004,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
     fn a_basic_listener_carries_its_own_credentials() {
         let listener = ListenerSection {
             listen_addr: "127.0.0.1:8443".parse().unwrap(),
+            transport: config::ListenerTransport::Http3,
             shards: 2,
             auth: AuthSection {
                 enabled: true,
@@ -985,6 +1032,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
     fn a_disabled_listener_states_only_that_it_is_disabled() {
         let listener = ListenerSection {
             listen_addr: "127.0.0.1:8443".parse().unwrap(),
+            transport: config::ListenerTransport::Http3,
             shards: 1,
             auth: AuthSection {
                 enabled: false,
@@ -1044,9 +1092,12 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
     fn the_suggested_port_skips_the_ports_already_in_use() {
         let mut config = config::parse_toml(BASIC_CONFIG).unwrap();
         config.listeners.push(client_cert_listener(SUGGESTED_PORT));
-        assert_eq!(suggest_listen_addr(&config).port(), SUGGESTED_PORT + 1);
         assert_eq!(
-            suggest_listen_addr(&config).ip(),
+            suggest_listen_addr(&config, ListenerTransport::Http3).port(),
+            SUGGESTED_PORT + 1
+        );
+        assert_eq!(
+            suggest_listen_addr(&config, ListenerTransport::Http3).ip(),
             config.listeners[0].listen_addr.ip()
         );
     }
@@ -1144,16 +1195,26 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
     fn the_bind_probe_reports_an_address_already_in_use() {
         let occupied = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
         let addr = occupied.local_addr().unwrap();
-        assert!(probe_listen_addr(addr).is_err());
+        assert!(probe_listen_addr(addr, ListenerTransport::Http3).is_err());
 
         drop(occupied);
-        probe_listen_addr(addr).expect("a free address passes");
+        probe_listen_addr(addr, ListenerTransport::Http3).expect("a free address passes");
+    }
+
+    #[test]
+    fn the_http2_bind_probe_checks_tcp() {
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = occupied.local_addr().unwrap();
+        assert!(probe_listen_addr(addr, ListenerTransport::Http2).is_err());
+
+        drop(occupied);
+        probe_listen_addr(addr, ListenerTransport::Http2).expect("a free TCP address passes");
     }
 
     /// Port 0 has nothing to probe: the kernel picks a free port when the
     /// server binds, which is a different port every time.
     #[test]
     fn the_bind_probe_accepts_an_ephemeral_port() {
-        probe_listen_addr("127.0.0.1:0".parse().unwrap()).unwrap();
+        probe_listen_addr("127.0.0.1:0".parse().unwrap(), ListenerTransport::Http3).unwrap();
     }
 }

--- a/src/enroll.rs
+++ b/src/enroll.rs
@@ -195,9 +195,10 @@ pub fn write_client_config(path: &Path, contents: &str) -> anyhow::Result<()> {
 
 /// The client-side JSON configuration.
 ///
-/// `endpoint_v4` / `endpoint_v6` are bare addresses, not `host:port`: the port
-/// is a separate client-side flag. The `id` and `access_token` fields belong to
-/// the vendor API and are emitted empty so a client that reads them finds
+/// The UDP/HTTP3 and TCP/HTTP2 endpoint fields are bare addresses, not
+/// `host:port`: the port is a separate client-side flag. Both transports point
+/// at the enrolled server by default. The `id` and `access_token` fields belong
+/// to the vendor API and are emitted empty so a client that reads them finds
 /// something well formed rather than a missing key.
 pub fn client_config_json(
     private_key_b64: &str,
@@ -213,8 +214,10 @@ pub fn client_config_json(
 
     let fields = [
         ("private_key", private_key_b64.to_string()),
-        ("endpoint_v4", endpoint_v4),
-        ("endpoint_v6", endpoint_v6),
+        ("endpoint_v4", endpoint_v4.clone()),
+        ("endpoint_v6", endpoint_v6.clone()),
+        ("endpoint_h2_v4", endpoint_v4),
+        ("endpoint_h2_v6", endpoint_v6),
         ("endpoint_pub_key", server_public_key_pem.to_string()),
         ("id", String::new()),
         ("access_token", String::new()),
@@ -383,6 +386,8 @@ mod tests {
         assert!(json.contains("\\n"));
         assert!(!json.contains("KEY-----\n-"));
         assert!(json.contains("\"endpoint_v4\": \"203.0.113.9\""));
+        assert!(json.contains("\"endpoint_h2_v4\": \"203.0.113.9\""));
+        assert!(json.contains("\"endpoint_h2_v6\": \"\""));
         // The port travels as a client flag, so it must not leak into the field.
         assert!(!json.contains("203.0.113.9:443"));
         assert!(json.contains("\"ipv4\": \"10.89.0.2\""));
@@ -456,6 +461,8 @@ mod tests {
         );
         assert!(json.contains("\"endpoint_v6\": \"2001:db8::1\""));
         assert!(json.contains("\"endpoint_v4\": \"\""));
+        assert!(json.contains("\"endpoint_h2_v6\": \"2001:db8::1\""));
+        assert!(json.contains("\"endpoint_h2_v4\": \"\""));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,8 @@ use masque::config_edit;
 use masque::enroll;
 use masque::server::{Server, validate_config};
 
-/// MASQUE proxy server (CONNECT / CONNECT-UDP / CONNECT-IP over HTTP/3).
+/// MASQUE proxy server (CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 or
+/// HTTP/3).
 #[derive(Parser)]
 #[command(name = "masque-server", version)]
 struct Cli {
@@ -104,6 +105,10 @@ enum Command {
         #[arg(long)]
         listen_addr: Option<SocketAddr>,
 
+        /// HTTP transport for this socket. Defaults to http3 for scripted use.
+        #[arg(long, value_enum)]
+        transport: Option<TransportArg>,
+
         /// Authentication this socket demands. One mode per listener: the mode
         /// decides which TLS context is built before clients connect.
         #[arg(long, value_enum)]
@@ -170,6 +175,21 @@ enum AuthModeArg {
     ClientCert,
 }
 
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum TransportArg {
+    Http3,
+    Http2,
+}
+
+impl From<TransportArg> for config::ListenerTransport {
+    fn from(transport: TransportArg) -> Self {
+        match transport {
+            TransportArg::Http3 => Self::Http3,
+            TransportArg::Http2 => Self::Http2,
+        }
+    }
+}
+
 impl From<AuthModeArg> for config::AuthMode {
     fn from(mode: AuthModeArg) -> Self {
         match mode {
@@ -196,7 +216,9 @@ fn auth_label(auth: &config::AuthSection) -> &'static str {
 }
 
 fn usque_port_instruction(port: u16) -> String {
-    format!("# Start usque with --connect-port {port} (short form: -P {port}).")
+    format!(
+        "# Start usque with --connect-port {port} (short form: -P {port}); add --http2 for an HTTP/2 listener."
+    )
 }
 
 /// Generate and print one client enrollment.
@@ -331,6 +353,7 @@ async fn main() -> anyhow::Result<()> {
     // with this invocation's --cert/--key overrides applied.
     if let Some(Command::AddListener {
         listen_addr,
+        transport,
         mode,
         shards,
         username,
@@ -346,6 +369,7 @@ async fn main() -> anyhow::Result<()> {
             &cli.config,
             config_edit::AddListener {
                 listen_addr,
+                transport: transport.map(Into::into),
                 mode: mode.map(Into::into),
                 shards,
                 username,
@@ -416,8 +440,9 @@ async fn main() -> anyhow::Result<()> {
         // a large value is capped, neither of which the file shows.
         for listener in listeners {
             println!(
-                "listener {} auth={} shards={}",
+                "listener {} transport={} auth={} shards={}",
                 listener.listen_addr,
+                listener.transport.as_str(),
                 auth_label(&listener.auth),
                 listener.shards
             );
@@ -457,6 +482,7 @@ mod tests {
         let instruction = usque_port_instruction(8449);
         assert!(instruction.contains("--connect-port 8449"));
         assert!(instruction.contains("-P 8449"));
+        assert!(instruction.contains("--http2"));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -53,14 +53,20 @@ impl Metrics {
     pub(crate) fn register_listener(
         &self,
         addr: SocketAddr,
+        transport: &'static str,
         auth: &'static str,
         shards: usize,
         udp_gso: bool,
         udp_gro: bool,
     ) -> Vec<Arc<ShardMetrics>> {
+        let label = format!(
+            "listener=\"{}\",transport=\"{}\",auth=\"{}\"",
+            escape_label(&addr.to_string()),
+            escape_label(transport),
+            escape_label(auth)
+        );
         let listener = ListenerMetrics::new(
-            addr,
-            auth,
+            label,
             shards,
             udp_gso,
             udp_gro,
@@ -229,8 +235,7 @@ struct ListenerMetrics {
 
 impl ListenerMetrics {
     fn new(
-        addr: SocketAddr,
-        auth: &'static str,
+        label: String,
         shards: usize,
         udp_gso: bool,
         udp_gro: bool,
@@ -238,11 +243,7 @@ impl ListenerMetrics {
         now_millis: u64,
     ) -> Self {
         Self {
-            label: format!(
-                "listener=\"{}\",auth=\"{}\"",
-                escape_label(&addr.to_string()),
-                escape_label(auth)
-            ),
+            label,
             shards: (0..shards)
                 .map(|_| Arc::new(ShardMetrics::new(enabled, now_millis, udp_gso, udp_gro)))
                 .collect(),
@@ -580,6 +581,20 @@ impl ShardMetrics {
         }
     }
 
+    /// Record one independently managed tunnel, used by transports whose
+    /// streams run as Tokio tasks rather than inside a shard-owned map.
+    pub(crate) fn tunnel_opened(&self, protocol_index: usize) {
+        if self.enabled {
+            self.tunnels_active[protocol_index].fetch_add(1, RELAXED);
+        }
+    }
+
+    pub(crate) fn tunnel_closed(&self, protocol_index: usize) {
+        if self.enabled {
+            subtract(&self.tunnels_active[protocol_index], 1);
+        }
+    }
+
     pub(crate) fn record_auth_success(&self) {
         if !self.enabled {
             return;
@@ -728,17 +743,17 @@ fn render_listener_headers(out: &mut String) {
         ),
         (
             "masque_connections_active",
-            "Currently active QUIC connections.",
+            "Currently active HTTP transport connections.",
             "gauge",
         ),
         (
             "masque_connections_accepted_total",
-            "Accepted QUIC connections.",
+            "Accepted HTTP transport connections.",
             "counter",
         ),
         (
             "masque_connections_rejected_total",
-            "Rejected QUIC connection attempts.",
+            "Rejected HTTP transport connection attempts.",
             "counter",
         ),
         (
@@ -836,8 +851,14 @@ mod tests {
     #[test]
     fn renders_prometheus_metrics_with_stable_low_cardinality_labels() {
         let metrics = Metrics::new(true);
-        let shards =
-            metrics.register_listener("127.0.0.1:8449".parse().unwrap(), "basic", 2, true, true);
+        let shards = metrics.register_listener(
+            "127.0.0.1:8449".parse().unwrap(),
+            "http3",
+            "basic",
+            2,
+            true,
+            true,
+        );
         let listener = &shards[0];
         metrics.set_ready(true);
         listener.connection_opened();
@@ -853,28 +874,28 @@ mod tests {
         assert!(rendered.contains("masque_server_ready 1\n"));
         assert!(
             rendered.contains(
-                "masque_connections_active{listener=\"127.0.0.1:8449\",auth=\"basic\"} 2"
+                "masque_connections_active{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 2"
             )
         );
         assert!(rendered.contains(
-            "masque_quic_receive_bytes_total{listener=\"127.0.0.1:8449\",auth=\"basic\"} 4800"
+            "masque_quic_receive_bytes_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 4800"
         ));
         assert!(
             rendered.contains(
-                "masque_quic_udp_gso_enabled{listener=\"127.0.0.1:8449\",auth=\"basic\"} 1"
+                "masque_quic_udp_gso_enabled{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 1"
             )
         );
         assert!(rendered.contains(
-            "masque_tcp_relay_events_total{listener=\"127.0.0.1:8449\",auth=\"basic\"} 4"
+            "masque_tcp_relay_events_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 4"
         ));
         assert!(rendered.contains(
-            "masque_tcp_relay_bytes_total{listener=\"127.0.0.1:8449\",auth=\"basic\"} 262144"
+            "masque_tcp_relay_bytes_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 262144"
         ));
         assert!(rendered.contains(
-            "masque_tunnels_active{listener=\"127.0.0.1:8449\",auth=\"basic\",protocol=\"udp\"} 2"
+            "masque_tunnels_active{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",protocol=\"udp\"} 2"
         ));
         assert!(rendered.contains(
-            "masque_event_loop_lag_seconds{listener=\"127.0.0.1:8449\",auth=\"basic\",shard=\"0\"} 0.025000"
+            "masque_event_loop_lag_seconds{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",shard=\"0\"} 0.025000"
         ));
         assert!(!rendered.contains("username="));
         assert!(!rendered.contains("target="));
@@ -883,7 +904,7 @@ mod tests {
         let after_fallback = metrics.render();
         assert!(
             after_fallback.contains(
-                "masque_quic_udp_gso_enabled{listener=\"127.0.0.1:8449\",auth=\"basic\"} 0"
+                "masque_quic_udp_gso_enabled{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 0"
             )
         );
     }
@@ -891,8 +912,14 @@ mod tests {
     #[test]
     fn gauge_guards_are_balanced_when_dropped() {
         let metrics = Metrics::new(true);
-        let shards =
-            metrics.register_listener("[::1]:9090".parse().unwrap(), "basic", 1, false, true);
+        let shards = metrics.register_listener(
+            "[::1]:9090".parse().unwrap(),
+            "http3",
+            "basic",
+            1,
+            false,
+            true,
+        );
         let listener = &shards[0];
         {
             let _pending = listener.auth_pending_guard();
@@ -907,8 +934,14 @@ mod tests {
     #[test]
     fn disabled_collection_does_not_touch_counters() {
         let metrics = Metrics::new(false);
-        let shards =
-            metrics.register_listener("127.0.0.1:8449".parse().unwrap(), "basic", 1, false, false);
+        let shards = metrics.register_listener(
+            "127.0.0.1:8449".parse().unwrap(),
+            "http3",
+            "basic",
+            1,
+            false,
+            false,
+        );
         let shard = &shards[0];
         shard.connection_opened();
         shard.record_receive_batch(8, 9600);
@@ -930,8 +963,14 @@ mod tests {
     #[test]
     fn readiness_fails_closed_when_any_shard_heartbeat_is_stale() {
         let metrics = Metrics::new(false);
-        let shards =
-            metrics.register_listener("127.0.0.1:8449".parse().unwrap(), "basic", 1, false, false);
+        let shards = metrics.register_listener(
+            "127.0.0.1:8449".parse().unwrap(),
+            "http3",
+            "basic",
+            1,
+            false,
+            false,
+        );
         let registered_at = shards[0].last_heartbeat_millis.load(RELAXED);
         let stale_after = SHARD_STALE_AFTER.as_millis() as u64;
         metrics.set_ready(true);

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -278,8 +278,14 @@ mod tests {
     #[tokio::test]
     async fn exposes_health_readiness_and_metrics() {
         let metrics = Arc::new(Metrics::new(true));
-        let _ =
-            metrics.register_listener("127.0.0.1:8449".parse().unwrap(), "basic", 1, false, true);
+        let _ = metrics.register_listener(
+            "127.0.0.1:8449".parse().unwrap(),
+            "http3",
+            "basic",
+            1,
+            false,
+            true,
+        );
         let server =
             ObservabilityServer::bind("127.0.0.1:0".parse().unwrap(), Arc::clone(&metrics))
                 .await

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -10,15 +10,15 @@ use crate::fxhash::FxHashMap;
 /// Identifies a specific tunnel within a connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TunnelOwner {
-    /// Opaque identifier for the QUIC connection (index into a connection table).
+    /// Process-unique identifier for the HTTP connection.
     pub conn_id: u64,
-    /// The HTTP/3 stream ID that owns this tunnel.
+    /// The HTTP/2 or HTTP/3 stream ID that owns this tunnel.
     pub stream_id: u64,
 }
 
 /// Maps client-assigned IP addresses to tunnel owners.
 ///
-/// Used by the TUN reader to route inbound packets to the correct QUIC
+/// Used by the TUN reader to route inbound packets to the correct HTTP
 /// connection and stream.
 pub struct RoutingTable {
     entries: FxHashMap<IpAddr, TunnelOwner>,

--- a/src/server/http2.rs
+++ b/src/server/http2.rs
@@ -1,0 +1,1387 @@
+//! MASQUE over HTTP/2.
+//!
+//! HTTP/2 is a compatibility transport for networks where UDP/QUIC is
+//! unavailable. Standard CONNECT streams carry bytes directly in DATA frames;
+//! CONNECT-UDP and CONNECT-IP streams carry DATAGRAM capsules. Both RFC 9484
+//! Extended CONNECT and Cloudflare's deployed H2 CONNECT-IP dialect are
+//! accepted. HTTP/3 remains the preferred transport because HTTP/2 makes
+//! datagrams reliable and ordered.
+
+use std::future::{pending, poll_fn};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Context as _;
+use boring::ssl::{AlpnError, SslAcceptor, SslFiletype, SslMethod, select_next_proto};
+use bytes::{Buf as _, Bytes};
+use h2::Reason;
+use h2::SendStream;
+use h2::server::SendResponse;
+use http::header::{HeaderName, HeaderValue, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION};
+use http::{Request, Response, StatusCode};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, watch};
+use tokio::task::JoinSet;
+use tracing::{debug, info, warn};
+use zeroize::Zeroizing;
+
+use super::request::{ConnectRequest, classify_connect_request};
+use super::{
+    Http2TunRoute, MAX_EPHEMERAL_BIND_ATTEMPTS, MAX_PENDING_AUTH_PER_CONNECTION, Shared,
+    allocate_pool_addresses, claim_static_addresses, encode_ip_setup_capsules,
+    listen_address_conflict,
+};
+use crate::auth::{AuthPrecheck, BasicAuthenticator};
+use crate::capsule::decoder::CapsuleDecoder;
+use crate::capsule::{CapsuleFrame, encoder};
+use crate::client_identity::{ClientIdentity, SharedRoster, configure_client_cert_verification};
+use crate::config::{ResolvedListener, ServerConfig};
+use crate::ip_packet;
+use crate::metrics::{Metrics, ShardMetrics};
+use crate::policy::TargetPolicy;
+use crate::routing::TunnelOwner;
+use crate::tun::TunSendBatch;
+use crate::tunnel::tcp::{TcpSetupFailure, resolve_and_connect};
+use crate::uri::{self, TcpTarget, UdpTarget};
+use crate::varint;
+
+const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+const TCP_READ_CHUNK_SIZE: usize = 64 * 1024;
+const MAX_UDP_PAYLOAD: usize = 65_527;
+const MAX_HTTP2_TUN_QUEUE_PACKETS: usize = 256;
+const IP_RESPONSE_BATCH_SIZE: usize = 64 * 1024;
+const MAX_IP_CONTROL_CAPSULE_SIZE: usize = 64 * 1024;
+const CAPSULE_PROTOCOL: HeaderName = HeaderName::from_static("capsule-protocol");
+const CF_CONNECT_PROTO: HeaderName = HeaderName::from_static("cf-connect-proto");
+
+/// A bound TCP/TLS listener and the immutable state shared by its connections.
+pub(super) struct Http2Listener {
+    listener: TcpListener,
+    listen_addr: SocketAddr,
+    acceptor: Arc<SslAcceptor>,
+    config: Arc<ServerConfig>,
+    shared: Arc<Shared>,
+    auth: Option<Arc<BasicAuthenticator>>,
+    client_certs: Option<Arc<SharedRoster>>,
+    tcp_policy: TargetPolicy,
+    udp_policy: TargetPolicy,
+    metrics: Arc<ShardMetrics>,
+    connection_slots: Arc<Semaphore>,
+}
+
+impl Http2Listener {
+    /// Bind one TCP listener, retrying a colliding ephemeral assignment before
+    /// the rest of the configured listeners are opened.
+    pub(super) async fn bind(
+        config: Arc<ServerConfig>,
+        shared: Arc<Shared>,
+        listener: ResolvedListener,
+        process_metrics: Arc<Metrics>,
+        auth_label: &'static str,
+        unavailable: &[SocketAddr],
+    ) -> anyhow::Result<Self> {
+        let acceptor = Arc::new(build_acceptor(
+            &config,
+            listener
+                .auth
+                .client_cert_enabled()
+                .then(|| Arc::clone(&shared.clients)),
+        )?);
+
+        let (socket, listen_addr) = bind_tcp_listener(listener.listen_addr, unavailable).await?;
+        let metrics = process_metrics
+            .register_listener(listen_addr, "http2", auth_label, 1, false, false)
+            .into_iter()
+            .next()
+            .expect("one metrics owner was requested for the HTTP/2 listener");
+        let auth = listener
+            .auth
+            .basic_enabled()
+            .then(|| {
+                BasicAuthenticator::new(&listener.auth.username, &listener.auth.password_hash)
+                    .map(Arc::new)
+            })
+            .transpose()?;
+        let client_certs = listener
+            .auth
+            .client_cert_enabled()
+            .then(|| Arc::clone(&shared.clients));
+
+        info!(addr = %listen_addr, transport = "http2", "listening");
+        Ok(Self {
+            listener: socket,
+            listen_addr,
+            acceptor,
+            tcp_policy: TargetPolicy::new(
+                &config.tcp_proxy.allow_targets,
+                &config.tcp_proxy.deny_targets,
+            ),
+            udp_policy: TargetPolicy::new(
+                &config.udp_proxy.allow_targets,
+                &config.udp_proxy.deny_targets,
+            ),
+            connection_slots: Arc::new(Semaphore::new(config.server.max_connections)),
+            config,
+            shared,
+            auth,
+            client_certs,
+            metrics,
+        })
+    }
+
+    pub(super) fn local_addr(&self) -> SocketAddr {
+        self.listen_addr
+    }
+
+    /// Accept TCP connections until shutdown, then give established H2
+    /// connections a bounded interval to finish their streams.
+    pub(super) async fn run(self, mut shutdown: watch::Receiver<bool>) -> anyhow::Result<()> {
+        let mut connections = JoinSet::new();
+        let connection_shutdown = shutdown.clone();
+        let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = shutdown.wait_for(|requested| *requested) => break,
+                _ = heartbeat.tick() => {
+                    self.metrics.record_heartbeat(
+                        self.shared.metrics.elapsed_millis(),
+                        Duration::ZERO,
+                    );
+                }
+                joined = connections.join_next(), if !connections.is_empty() => {
+                    if let Some(Err(error)) = joined {
+                        warn!(%error, "HTTP/2 connection task panicked");
+                    }
+                }
+                accepted = self.listener.accept() => {
+                    let (stream, peer) = accepted
+                        .with_context(|| format!("HTTP/2 listener {} accept failed", self.listen_addr))?;
+                    let connection_slot = match Arc::clone(&self.connection_slots).try_acquire_owned() {
+                        Ok(slot) => slot,
+                        Err(_) => {
+                            self.metrics.connection_rejected_limit();
+                            warn!(%peer, "HTTP/2 connection limit reached");
+                            continue;
+                        }
+                    };
+
+                    let context = ConnectionContext {
+                        acceptor: Arc::clone(&self.acceptor),
+                        config: Arc::clone(&self.config),
+                        shared: Arc::clone(&self.shared),
+                        auth: self.auth.as_ref().map(Arc::clone),
+                        client_certs: self.client_certs.as_ref().map(Arc::clone),
+                        tcp_policy: self.tcp_policy.clone(),
+                        udp_policy: self.udp_policy.clone(),
+                        metrics: Arc::clone(&self.metrics),
+                    };
+                    connections.spawn(serve_connection(
+                        stream,
+                        peer,
+                        context,
+                        connection_shutdown.clone(),
+                        connection_slot,
+                    ));
+                }
+            }
+        }
+
+        info!(addr = %self.listen_addr, connections = connections.len(), "HTTP/2 listener draining");
+        let drain = async {
+            while let Some(joined) = connections.join_next().await {
+                if let Err(error) = joined {
+                    warn!(%error, "HTTP/2 connection task panicked during drain");
+                }
+            }
+        };
+        if tokio::time::timeout(DRAIN_TIMEOUT, drain).await.is_err() {
+            connections.abort_all();
+            self.shared.metrics.record_forced_shutdown();
+            while connections.join_next().await.is_some() {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct ConnectionContext {
+    acceptor: Arc<SslAcceptor>,
+    config: Arc<ServerConfig>,
+    shared: Arc<Shared>,
+    auth: Option<Arc<BasicAuthenticator>>,
+    client_certs: Option<Arc<SharedRoster>>,
+    tcp_policy: TargetPolicy,
+    udp_policy: TargetPolicy,
+    metrics: Arc<ShardMetrics>,
+}
+
+/// Validate and build the TLS context used by an H2 listener.
+pub(super) fn build_acceptor(
+    config: &ServerConfig,
+    client_certs: Option<Arc<SharedRoster>>,
+) -> anyhow::Result<SslAcceptor> {
+    let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())
+        .context("failed to create HTTP/2 TLS context")?;
+    builder
+        .set_certificate_chain_file(&config.tls.cert_path)
+        .with_context(|| {
+            format!(
+                "failed to load tls.cert_path {}",
+                config.tls.cert_path.display()
+            )
+        })?;
+    builder
+        .set_private_key_file(&config.tls.key_path, SslFiletype::PEM)
+        .with_context(|| {
+            format!(
+                "failed to load tls.key_path {}",
+                config.tls.key_path.display()
+            )
+        })?;
+    builder.check_private_key().with_context(|| {
+        format!(
+            "tls.key_path {} does not match tls.cert_path {}",
+            config.tls.key_path.display(),
+            config.tls.cert_path.display()
+        )
+    })?;
+    builder.set_alpn_select_callback(|_, client| {
+        select_next_proto(b"\x02h2", client).ok_or(AlpnError::NOACK)
+    });
+    if let Some(roster) = client_certs {
+        configure_client_cert_verification(&mut builder, roster);
+    }
+    Ok(builder.build())
+}
+
+async fn bind_tcp_listener(
+    requested: SocketAddr,
+    unavailable: &[SocketAddr],
+) -> anyhow::Result<(TcpListener, SocketAddr)> {
+    for attempt in 1..=MAX_EPHEMERAL_BIND_ATTEMPTS {
+        let listener = TcpListener::bind(requested)
+            .await
+            .with_context(|| format!("failed to bind HTTP/2 listener {requested}"))?;
+        let bound = listener.local_addr()?;
+        if requested.port() != 0 {
+            return Ok((listener, bound));
+        }
+
+        if let Some(existing) = unavailable
+            .iter()
+            .copied()
+            .find(|existing| listen_address_conflict(bound, *existing).is_some())
+        {
+            if attempt == MAX_EPHEMERAL_BIND_ATTEMPTS {
+                anyhow::bail!(
+                    "HTTP/2 listener {requested} repeatedly received an ephemeral address that \
+                     overlaps listener {existing}"
+                );
+            }
+            debug!(%requested, assigned = %bound, %existing, attempt, "retrying HTTP/2 ephemeral bind");
+            continue;
+        }
+        return Ok((listener, bound));
+    }
+    unreachable!("bounded ephemeral bind loop returns or reports its last collision")
+}
+
+async fn serve_connection(
+    stream: TcpStream,
+    peer: SocketAddr,
+    context: ConnectionContext,
+    mut shutdown: watch::Receiver<bool>,
+    _connection_slot: OwnedSemaphorePermit,
+) {
+    let _connection_metrics = ConnectionMetricsGuard::new(Arc::clone(&context.metrics));
+    let tls = match tokio::time::timeout(
+        TLS_HANDSHAKE_TIMEOUT,
+        tokio_boring::accept(&context.acceptor, stream),
+    )
+    .await
+    {
+        Ok(Ok(tls)) => tls,
+        Ok(Err(error)) => {
+            debug!(%peer, %error, "HTTP/2 TLS handshake failed");
+            return;
+        }
+        Err(_) => {
+            debug!(%peer, "HTTP/2 TLS handshake timed out");
+            return;
+        }
+    };
+
+    if tls.ssl().selected_alpn_protocol() != Some(b"h2") {
+        warn!(%peer, "HTTP/2 TLS connection negotiated no h2 ALPN");
+        return;
+    }
+
+    let (authenticated_identity, mut applied_roster_generation) =
+        if let Some(roster) = &context.client_certs {
+            let identity = tls
+                .ssl()
+                .peer_certificate()
+                .and_then(|cert| cert.to_der().ok())
+                .and_then(|der| identify_current_client(roster, &der));
+            let Some((identity, generation)) = identity else {
+                context.metrics.record_auth_failure();
+                warn!(%peer, "closing HTTP/2 connection with no current client identity");
+                return;
+            };
+            context.metrics.record_auth_success();
+            info!(%peer, client = %identity.name, "HTTP/2 client authenticated by certificate");
+            (Some(identity), generation)
+        } else {
+            (None, 0)
+        };
+
+    let h2 = &context.config.http2;
+    let mut builder = h2::server::Builder::new();
+    builder
+        .enable_connect_protocol()
+        .initial_window_size(h2.initial_stream_window)
+        .initial_connection_window_size(h2.initial_connection_window)
+        .max_concurrent_streams(h2.max_concurrent_streams)
+        .max_header_list_size(h2.max_header_list_size)
+        .max_send_buffer_size(h2.max_send_buffer_size)
+        .data_frame_budget(h2.data_frame_budget);
+
+    let mut connection = match builder.handshake(tls).await {
+        Ok(connection) => connection,
+        Err(error) => {
+            debug!(%peer, %error, "HTTP/2 handshake failed");
+            return;
+        }
+    };
+    info!(%peer, "HTTP/2 connection established");
+    let connection_index = context
+        .shared
+        .next_conn_index
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    let tunnel_slots = Arc::new(Semaphore::new(
+        context.config.server.max_tunnels_per_connection,
+    ));
+    let auth_slots = Arc::new(Semaphore::new(MAX_PENDING_AUTH_PER_CONNECTION));
+    let mut requests = JoinSet::new();
+    let mut draining = false;
+    let mut drain_deadline = None;
+    let mut roster_sweep = tokio::time::interval_at(
+        tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+        HEARTBEAT_INTERVAL,
+    );
+    roster_sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = shutdown.wait_for(|requested| *requested), if !draining => {
+                draining = true;
+                drain_deadline = Some(tokio::time::Instant::now() + DRAIN_TIMEOUT);
+                connection.graceful_shutdown();
+            }
+            _ = roster_sweep.tick(), if authenticated_identity.is_some() => {
+                let roster = context
+                    .client_certs
+                    .as_ref()
+                    .expect("an authenticated identity has a roster");
+                let generation = roster.generation();
+                if generation != applied_roster_generation {
+                    applied_roster_generation = generation;
+                    let identity = authenticated_identity
+                        .as_deref()
+                        .expect("guarded by authenticated_identity.is_some()");
+                    if !roster.load().still_authorizes(identity) {
+                        info!(%peer, client = %identity.name, "disconnecting HTTP/2 client removed from the roster");
+                        connection.abrupt_shutdown(Reason::NO_ERROR);
+                        requests.abort_all();
+                        break;
+                    }
+                }
+            }
+            _ = async {
+                match drain_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => pending::<()>().await,
+                }
+            } => {
+                connection.abrupt_shutdown(Reason::NO_ERROR);
+                requests.abort_all();
+                break;
+            }
+            joined = requests.join_next(), if !requests.is_empty() => {
+                if let Some(Err(error)) = joined {
+                    warn!(%peer, %error, "HTTP/2 request task panicked");
+                }
+            }
+            accepted = connection.accept() => {
+                match accepted {
+                    Some(Ok((request, respond))) if !draining => {
+                        requests.spawn(handle_request(
+                            request,
+                            respond,
+                            context.clone(),
+                            connection_index,
+                            authenticated_identity.as_ref().map(Arc::clone),
+                            Arc::clone(&tunnel_slots),
+                            Arc::clone(&auth_slots),
+                        ));
+                    }
+                    Some(Ok((_request, mut respond))) => {
+                        let _ = send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE);
+                    }
+                    Some(Err(error)) => {
+                        debug!(%peer, %error, "HTTP/2 connection error");
+                        break;
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+
+    requests.abort_all();
+    while requests.join_next().await.is_some() {}
+    debug!(%peer, "HTTP/2 connection closed");
+}
+
+/// Resolve a certificate against one stable roster generation.
+///
+/// A SIGHUP can replace the roster between any two reads. Retrying when its
+/// generation changes prevents a connection from retaining an identity from
+/// the old roster while recording the new generation as already enforced.
+fn identify_current_client(
+    roster: &SharedRoster,
+    cert_der: &[u8],
+) -> Option<(Arc<ClientIdentity>, u64)> {
+    loop {
+        let before = roster.generation();
+        let identity = roster.load().identify(cert_der);
+        let after = roster.generation();
+        if before == after {
+            return identity.ok().map(|identity| (identity, after));
+        }
+    }
+}
+
+enum RequestKind {
+    Tcp(TcpTarget),
+    Udp(UdpTarget),
+    Ip(IpCapsuleMode),
+}
+
+/// CONNECT-IP has two HTTP/2 wire shapes in active use.
+///
+/// RFC 9484 uses Extended CONNECT and keeps Context ID zero in each DATAGRAM
+/// capsule. Cloudflare's TCP fallback predates that shape: it uses a regular
+/// CONNECT plus `cf-connect-proto`, and removes the zero byte from capsule
+/// values. usque intentionally mirrors the latter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IpCapsuleMode {
+    Standard,
+    Cloudflare,
+}
+
+impl IpCapsuleMode {
+    fn decode_packet(self, payload: &[u8]) -> anyhow::Result<Option<&[u8]>> {
+        match self {
+            Self::Cloudflare => Ok(Some(payload)),
+            Self::Standard => {
+                let (context_id, context_len) = varint::decode(payload)
+                    .map_err(|_| anyhow::anyhow!("DATAGRAM capsule has no Context ID"))?;
+                if context_id == 0 {
+                    Ok(Some(&payload[context_len..]))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    fn encode_packet(self, packet: &[u8], output: &mut Vec<u8>) {
+        match self {
+            Self::Standard => encoder::encode_datagram_context_zero(packet, output),
+            Self::Cloudflare => encoder::encode_datagram(packet, output),
+        }
+    }
+}
+
+async fn handle_request(
+    request: Request<h2::RecvStream>,
+    mut respond: SendResponse<Bytes>,
+    context: ConnectionContext,
+    connection_index: u64,
+    authenticated_identity: Option<Arc<ClientIdentity>>,
+    tunnel_slots: Arc<Semaphore>,
+    auth_slots: Arc<Semaphore>,
+) {
+    let stream_id = respond.stream_id().as_u32();
+    let protocol = request
+        .extensions()
+        .get::<h2::ext::Protocol>()
+        .map(|protocol| protocol.as_str().to_owned());
+    let mut cloudflare_protocols = request.headers().get_all(&CF_CONNECT_PROTO).iter();
+    let cloudflare_protocol = cloudflare_protocols.next().map(HeaderValue::as_bytes);
+    let duplicate_cloudflare_protocol = cloudflare_protocols.next().is_some();
+    let cloudflare_capsules = protocol.is_none() && cloudflare_protocol == Some(b"cf-connect-ip");
+    let effective_protocol = if cloudflare_capsules {
+        "cf-connect-ip"
+    } else {
+        protocol.as_deref().unwrap_or("")
+    };
+
+    let authority = request
+        .uri()
+        .authority()
+        .map_or("", |authority| authority.as_str());
+    let Some(connect) = classify_connect_request(
+        request.method().as_str().as_bytes(),
+        effective_protocol.as_bytes(),
+        authority.as_bytes(),
+        request.uri().path().as_bytes(),
+        &context.config,
+    ) else {
+        let _ = send_error(&mut respond, StatusCode::NOT_FOUND);
+        return;
+    };
+
+    if let Some(auth) = &context.auth {
+        let mut values = request.headers().get_all(PROXY_AUTHORIZATION).iter();
+        let first = values.next().map(HeaderValue::as_bytes);
+        if values.next().is_some() {
+            let _ = send_proxy_auth_required(&mut respond);
+            return;
+        }
+        let password = match auth.precheck(first) {
+            AuthPrecheck::Rejected => {
+                let _ = send_proxy_auth_required(&mut respond);
+                return;
+            }
+            AuthPrecheck::NeedsVerify(password) => password,
+        };
+        let auth_slot = match auth_slots.try_acquire_owned() {
+            Ok(slot) => slot,
+            Err(_) => {
+                context.metrics.record_auth_overloaded();
+                let _ = send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE);
+                return;
+            }
+        };
+        let verification = verify_password(
+            Arc::clone(auth),
+            password,
+            Arc::clone(&context.shared.auth_queue_slots),
+            Arc::clone(&context.shared.auth_permits),
+            Arc::clone(&context.metrics),
+            auth_slot,
+        );
+        tokio::pin!(verification);
+        let authorized = tokio::select! {
+            result = &mut verification => result,
+            _ = poll_fn(|cx| respond.poll_reset(cx)) => return,
+        };
+        match authorized {
+            AuthResult::Authorized => {}
+            AuthResult::Rejected => {
+                let _ = send_proxy_auth_required(&mut respond);
+                return;
+            }
+            AuthResult::Overloaded => {
+                let _ = send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE);
+                return;
+            }
+        }
+    }
+
+    // Match HTTP/3's ordering: a recognized proxy request authenticates before
+    // target parsing or transport-specific validation. This keeps malformed
+    // requests from using status differences to bypass the 407 boundary.
+    let kind = match prepare_request(
+        &request,
+        connect,
+        &context.config,
+        cloudflare_capsules,
+        duplicate_cloudflare_protocol,
+    ) {
+        Ok(kind) => kind,
+        Err(status) => {
+            let _ = send_error(&mut respond, status);
+            return;
+        }
+    };
+
+    let tunnel_slot = match tunnel_slots.try_acquire_owned() {
+        Ok(slot) => slot,
+        Err(_) => {
+            let _ = send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE);
+            return;
+        }
+    };
+    let (_parts, body) = request.into_parts();
+
+    let result = match kind {
+        RequestKind::Tcp(target) => {
+            serve_tcp_tunnel(stream_id, target, body, respond, context, tunnel_slot).await
+        }
+        RequestKind::Udp(target) => {
+            serve_udp_tunnel(stream_id, target, body, respond, context, tunnel_slot).await
+        }
+        RequestKind::Ip(capsule_mode) => {
+            serve_ip_tunnel(
+                connection_index,
+                stream_id,
+                body,
+                respond,
+                context,
+                authenticated_identity,
+                capsule_mode,
+                tunnel_slot,
+            )
+            .await
+        }
+    };
+    if let Err(error) = result {
+        debug!(stream_id, %error, "HTTP/2 tunnel closed with an error");
+    }
+}
+
+fn prepare_request(
+    request: &Request<h2::RecvStream>,
+    connect: ConnectRequest,
+    config: &ServerConfig,
+    cloudflare_capsules: bool,
+    duplicate_cloudflare_protocol: bool,
+) -> Result<RequestKind, StatusCode> {
+    match connect {
+        ConnectRequest::Tcp { authority } => uri::parse_connect_authority(&authority)
+            .map(RequestKind::Tcp)
+            .map_err(|_| StatusCode::BAD_REQUEST),
+        ConnectRequest::Udp { path } => {
+            if !uses_capsule_protocol(request) {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+            uri::parse_udp_path(&path, &config.udp_proxy.uri_template)
+                .map(RequestKind::Udp)
+                .map_err(|_| StatusCode::BAD_REQUEST)
+        }
+        ConnectRequest::Ip => {
+            if cloudflare_capsules {
+                if duplicate_cloudflare_protocol {
+                    return Err(StatusCode::BAD_REQUEST);
+                }
+                return Ok(RequestKind::Ip(IpCapsuleMode::Cloudflare));
+            }
+            if !uses_capsule_protocol(request) {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+            Ok(RequestKind::Ip(IpCapsuleMode::Standard))
+        }
+    }
+}
+
+/// HTTP/2 Extended CONNECT has no native datagram frame, so both datagram
+/// protocols require the Capsule Protocol on a fully formed absolute URI.
+fn uses_capsule_protocol(request: &Request<h2::RecvStream>) -> bool {
+    request.uri().scheme().is_some()
+        && request.uri().authority().is_some()
+        && !request.uri().path().is_empty()
+        && request.headers().get_all(&CAPSULE_PROTOCOL).iter().count() == 1
+        && request.headers().get(&CAPSULE_PROTOCOL) == Some(&HeaderValue::from_static("?1"))
+}
+
+enum AuthResult {
+    Authorized,
+    Rejected,
+    Overloaded,
+}
+
+async fn verify_password(
+    auth: Arc<BasicAuthenticator>,
+    password: Zeroizing<Vec<u8>>,
+    queue_slots: Arc<Semaphore>,
+    permits: Arc<Semaphore>,
+    metrics: Arc<ShardMetrics>,
+    _connection_slot: OwnedSemaphorePermit,
+) -> AuthResult {
+    let queue_slot = match queue_slots.try_acquire_owned() {
+        Ok(slot) => slot,
+        Err(_) => {
+            metrics.record_auth_overloaded();
+            return AuthResult::Overloaded;
+        }
+    };
+    let pending = metrics.auth_pending_guard();
+    let permit = match permits.acquire_owned().await {
+        Ok(permit) => permit,
+        Err(_) => return AuthResult::Rejected,
+    };
+    drop(pending);
+    let running = metrics.auth_running_guard();
+    let completion_metrics = Arc::clone(&metrics);
+    match tokio::task::spawn_blocking(move || {
+        let _queue_slot = queue_slot;
+        let _permit = permit;
+        let _running = running;
+        let authorized = auth.verify(&password);
+        if authorized {
+            completion_metrics.record_auth_success();
+        } else {
+            completion_metrics.record_auth_failure();
+        }
+        authorized
+    })
+    .await
+    {
+        Ok(true) => AuthResult::Authorized,
+        Ok(false) | Err(_) => AuthResult::Rejected,
+    }
+}
+
+async fn serve_tcp_tunnel(
+    stream_id: u32,
+    target: TcpTarget,
+    mut body: h2::RecvStream,
+    mut respond: SendResponse<Bytes>,
+    context: ConnectionContext,
+    _tunnel_slot: OwnedSemaphorePermit,
+) -> anyhow::Result<()> {
+    let (stream, target_addr) = match resolve_and_connect(
+        target,
+        &context.tcp_policy,
+        Duration::from_secs(context.config.tcp_proxy.connect_timeout_secs),
+    )
+    .await
+    {
+        Ok(connected) => connected,
+        Err(TcpSetupFailure { status, reason }) => {
+            warn!(stream_id, %reason, "HTTP/2 TCP target setup failed");
+            let status = StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY);
+            send_error(&mut respond, status)?;
+            return Ok(());
+        }
+    };
+
+    let response = Response::builder().status(StatusCode::OK).body(())?;
+    let mut send = respond.send_response(response, false)?;
+    info!(stream_id, %target_addr, transport = "http2", "TCP tunnel established");
+    let _metrics = TunnelMetricsGuard::new(Arc::clone(&context.metrics), 0);
+    let activity = Arc::new(Activity::new());
+    let (mut target_read, mut target_write) = stream.into_split();
+
+    let client_to_target = async {
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            target_write.write_all(&chunk).await?;
+            body.flow_control().release_capacity(chunk.len())?;
+            activity.touch();
+        }
+        target_write.shutdown().await?;
+        Ok::<_, anyhow::Error>(())
+    };
+    let target_to_client = async {
+        let mut buf = vec![0_u8; TCP_READ_CHUNK_SIZE];
+        loop {
+            let read = target_read.read(&mut buf).await?;
+            if read == 0 {
+                send_h2_data(&mut send, Bytes::new(), true).await?;
+                return Ok::<_, anyhow::Error>(());
+            }
+            activity.touch();
+            send_h2_data(&mut send, Bytes::copy_from_slice(&buf[..read]), false).await?;
+        }
+    };
+
+    let relay = async { tokio::try_join!(client_to_target, target_to_client).map(|_| ()) };
+    tokio::select! {
+        result = relay => result?,
+        _ = wait_until_idle(Arc::clone(&activity), Duration::from_secs(context.config.server.idle_timeout_secs)) => {
+            send.send_reset(Reason::CANCEL);
+        }
+    }
+    Ok(())
+}
+
+async fn serve_udp_tunnel(
+    stream_id: u32,
+    target: UdpTarget,
+    mut body: h2::RecvStream,
+    mut respond: SendResponse<Bytes>,
+    context: ConnectionContext,
+    _tunnel_slot: OwnedSemaphorePermit,
+) -> anyhow::Result<()> {
+    let addrs: Vec<SocketAddr> =
+        match tokio::net::lookup_host((target.host.as_str(), target.port)).await {
+            Ok(addrs) => addrs.collect(),
+            Err(error) => {
+                warn!(stream_id, %error, "HTTP/2 UDP target DNS resolution failed");
+                send_error(&mut respond, StatusCode::BAD_GATEWAY)?;
+                return Ok(());
+            }
+        };
+    if addrs.is_empty() {
+        send_error(&mut respond, StatusCode::BAD_GATEWAY)?;
+        return Ok(());
+    }
+    if !context
+        .udp_policy
+        .all_allowed(&addrs.iter().map(|addr| addr.ip()).collect::<Vec<_>>())
+    {
+        send_error(&mut respond, StatusCode::FORBIDDEN)?;
+        return Ok(());
+    }
+    let target_addr = addrs[0];
+    let socket = match UdpSocket::bind(if target_addr.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    })
+    .await
+    {
+        Ok(socket) => socket,
+        Err(error) => {
+            warn!(stream_id, %error, "HTTP/2 UDP socket bind failed");
+            send_error(&mut respond, StatusCode::BAD_GATEWAY)?;
+            return Ok(());
+        }
+    };
+    if let Err(error) = socket.connect(target_addr).await {
+        warn!(stream_id, %error, "HTTP/2 UDP target connect failed");
+        send_error(&mut respond, StatusCode::BAD_GATEWAY)?;
+        return Ok(());
+    }
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CAPSULE_PROTOCOL, "?1")
+        .body(())?;
+    let mut send = respond.send_response(response, false)?;
+    info!(stream_id, %target_addr, transport = "http2", "UDP tunnel established");
+    let _metrics = TunnelMetricsGuard::new(Arc::clone(&context.metrics), 1);
+    let activity = Arc::new(Activity::new());
+    let max_payload = context.config.http2.max_datagram_size.min(MAX_UDP_PAYLOAD);
+    // One extra byte admits the context ID zero before the UDP payload.
+    let mut decoder = CapsuleDecoder::with_max_capsule_size(max_payload + 1);
+
+    let client_to_target = async {
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            let frames = decoder.decode(&chunk)?;
+            body.flow_control().release_capacity(chunk.len())?;
+            for frame in frames {
+                let CapsuleFrame::Datagram(payload) = frame else {
+                    continue;
+                };
+                let (context_id, context_len) = varint::decode(&payload)
+                    .map_err(|_| anyhow::anyhow!("DATAGRAM capsule has no Context ID"))?;
+                if context_id != 0 {
+                    continue;
+                }
+                let udp_payload = &payload[context_len..];
+                if udp_payload.len() > max_payload {
+                    anyhow::bail!("UDP payload exceeds configured HTTP/2 datagram limit");
+                }
+                let written = socket.send(udp_payload).await?;
+                if written != udp_payload.len() {
+                    anyhow::bail!("target UDP socket accepted a partial datagram");
+                }
+                activity.touch();
+            }
+        }
+        if decoder.buffered() != 0 {
+            anyhow::bail!("request ended with a truncated DATAGRAM capsule");
+        }
+        Ok::<_, anyhow::Error>(())
+    };
+
+    let target_to_client = async {
+        // One extra byte detects a datagram larger than the configured limit;
+        // never forward a silently truncated prefix.
+        let mut recv = vec![0_u8; max_payload + 1];
+        let mut capsule = Vec::with_capacity(max_payload + 16);
+        loop {
+            let read = socket.recv(&mut recv).await?;
+            if read > max_payload {
+                debug!(
+                    stream_id,
+                    read, max_payload, "dropping oversized HTTP/2 target datagram"
+                );
+                continue;
+            }
+            activity.touch();
+            // The HTTP Datagram payload begins with Context ID zero.
+            capsule.clear();
+            encoder::encode_datagram_context_zero(&recv[..read], &mut capsule);
+            send_h2_data(&mut send, Bytes::copy_from_slice(&capsule), false).await?;
+        }
+    };
+
+    // RFC 9298 recommends not expiring UDP mappings in less than two minutes.
+    let idle_timeout =
+        Duration::from_secs(context.config.server.idle_timeout_secs).max(Duration::from_secs(120));
+    enum Completion {
+        Client(anyhow::Result<()>),
+        Target(anyhow::Result<()>),
+        Idle,
+    }
+    let completion = tokio::select! {
+        result = client_to_target => Completion::Client(result),
+        result = target_to_client => Completion::Target(result),
+        _ = wait_until_idle(Arc::clone(&activity), idle_timeout) => Completion::Idle,
+    };
+    match completion {
+        Completion::Client(Ok(())) => {
+            send_h2_data(&mut send, Bytes::new(), true).await?;
+        }
+        Completion::Client(Err(error)) | Completion::Target(Err(error)) => {
+            send.send_reset(Reason::PROTOCOL_ERROR);
+            return Err(error);
+        }
+        Completion::Target(Ok(())) => unreachable!("target receive loop never completes cleanly"),
+        Completion::Idle => send.send_reset(Reason::CANCEL),
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_ip_tunnel(
+    connection_index: u64,
+    stream_id: u32,
+    mut body: h2::RecvStream,
+    mut respond: SendResponse<Bytes>,
+    context: ConnectionContext,
+    authenticated_identity: Option<Arc<ClientIdentity>>,
+    capsule_mode: IpCapsuleMode,
+    _tunnel_slot: OwnedSemaphorePermit,
+) -> anyhow::Result<()> {
+    let stream_id = u64::from(stream_id);
+    let pinned = authenticated_identity
+        .as_deref()
+        .filter(|identity| identity.has_static_addresses());
+    let addresses = match pinned {
+        Some(identity) => match claim_static_addresses(&context.shared, identity) {
+            Ok(addresses) => addresses,
+            Err(error) => {
+                warn!(
+                    stream_id,
+                    client = %identity.name,
+                    %error,
+                    "cannot attach HTTP/2 IP tunnel to fixed addresses"
+                );
+                send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE)?;
+                return Ok(());
+            }
+        },
+        None => allocate_pool_addresses(&context.shared),
+    };
+    if addresses.is_empty() {
+        warn!(stream_id, "address pool exhausted for HTTP/2 IP tunnel");
+        send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE)?;
+        return Ok(());
+    }
+
+    let owner = TunnelOwner {
+        conn_id: connection_index,
+        stream_id,
+    };
+    let max_ip_packet = context
+        .config
+        .ip_proxy
+        .tun_mtu
+        .min(context.config.http2.max_datagram_size);
+    // Bound queued TUN data by the H2 stream's configured send-buffer budget,
+    // not by a fixed packet count that could become tens of megabytes at a
+    // jumbo MTU. One slot is retained even when one packet exceeds the budget.
+    let return_queue_capacity = (context.config.http2.max_send_buffer_size / max_ip_packet.max(1))
+        .clamp(1, MAX_HTTP2_TUN_QUEUE_PACKETS);
+    let (return_sender, mut return_packets) = mpsc::channel(return_queue_capacity);
+    context
+        .shared
+        .http2_tun_routes
+        .write()
+        .expect("HTTP/2 TUN routes poisoned")
+        .insert(
+            owner,
+            Http2TunRoute {
+                sender: return_sender,
+                metrics: Arc::clone(&context.metrics),
+            },
+        );
+    {
+        let mut routes = context
+            .shared
+            .routing_table
+            .write()
+            .expect("routing table poisoned");
+        for address in &addresses {
+            routes.insert(*address, owner);
+            info!(
+                stream_id,
+                addr = %address,
+                pinned = pinned.is_some(),
+                transport = "http2",
+                "assigned address to IP tunnel"
+            );
+        }
+    }
+    let _lease = Http2IpLease {
+        shared: Arc::clone(&context.shared),
+        owner,
+        addresses: addresses.clone(),
+    };
+
+    let mut response = Response::builder().status(StatusCode::OK);
+    if capsule_mode == IpCapsuleMode::Standard {
+        response = response.header(CAPSULE_PROTOCOL, "?1");
+    }
+    let response = response.body(())?;
+    let mut send = respond.send_response(response, false)?;
+    send_h2_data(
+        &mut send,
+        Bytes::from(encode_ip_setup_capsules(&addresses)),
+        false,
+    )
+    .await?;
+
+    info!(
+        stream_id,
+        transport = "http2",
+        capsule_mode = ?capsule_mode,
+        "CONNECT-IP tunnel established"
+    );
+    let _metrics = TunnelMetricsGuard::new(Arc::clone(&context.metrics), 2);
+    let activity = Arc::new(Activity::new());
+    let idle = wait_until_idle(
+        Arc::clone(&activity),
+        Duration::from_secs(context.config.server.idle_timeout_secs),
+    );
+    tokio::pin!(idle);
+
+    let context_bytes = usize::from(capsule_mode == IpCapsuleMode::Standard);
+    let mut decoder = CapsuleDecoder::with_max_capsule_size(
+        MAX_IP_CONTROL_CAPSULE_SIZE.max(max_ip_packet.saturating_add(context_bytes)),
+    );
+    let mut tun_send = TunSendBatch::new();
+    let mut response_capsules = Vec::with_capacity(IP_RESPONSE_BATCH_SIZE);
+
+    enum Completion {
+        ClientClosed,
+        Idle,
+    }
+
+    // Keep the two directions independent. In particular, waiting for response
+    // flow-control credit must not stop us from consuming request DATA frames:
+    // Cloudflare-style clients put each inner TCP ACK in a small DATA frame,
+    // and h2 deliberately closes a connection when too many unconsumed small
+    // frames accumulate. A single select loop whose return-path arm awaited
+    // `send_h2_data` could therefore reset an otherwise healthy bulk transfer.
+    let client_to_tun = async {
+        loop {
+            let Some(chunk) = body.data().await else {
+                if decoder.buffered() != 0 {
+                    anyhow::bail!("request ended with a truncated CONNECT-IP capsule");
+                }
+                return Ok::<_, anyhow::Error>(());
+            };
+            let chunk = chunk?;
+            let frames = decoder.decode(&chunk)?;
+            body.flow_control().release_capacity(chunk.len())?;
+
+            for frame in frames {
+                let CapsuleFrame::Datagram(payload) = frame else {
+                    // ADDRESS_* and ROUTE_ADVERTISEMENT are valid on this
+                    // stream but do not alter the server's local lease or
+                    // source-spoofing boundary.
+                    continue;
+                };
+                let Some(packet) = capsule_mode.decode_packet(&payload)? else {
+                    continue;
+                };
+                if packet.len() > max_ip_packet {
+                    debug!(
+                        stream_id,
+                        packet_len = packet.len(),
+                        max_ip_packet,
+                        "dropping oversized HTTP/2 IP packet"
+                    );
+                    continue;
+                }
+                let source = match ip_packet::src_addr(packet) {
+                    Ok(source) => source,
+                    Err(error) => {
+                        debug!(stream_id, %error, "invalid IP header in HTTP/2 client packet");
+                        continue;
+                    }
+                };
+                if !addresses.contains(&source) {
+                    debug!(stream_id, %source, "spoofed HTTP/2 source address, dropping");
+                    continue;
+                }
+
+                activity.touch();
+                if let Some(tun) = &context.shared.tun {
+                    if tun_send.is_full() {
+                        tun.send_batch(&mut tun_send).await?;
+                    }
+                    tun_send.push(packet);
+                }
+            }
+            if let Some(tun) = &context.shared.tun
+                && !tun_send.is_empty()
+            {
+                tun.send_batch(&mut tun_send).await?;
+            }
+        }
+    };
+
+    let tun_to_client = async {
+        loop {
+            let Some(packet) = return_packets.recv().await else {
+                anyhow::bail!("HTTP/2 TUN return path closed");
+            };
+            response_capsules.clear();
+            if packet.len() <= max_ip_packet {
+                capsule_mode.encode_packet(&packet, &mut response_capsules);
+            }
+            while response_capsules.len() < IP_RESPONSE_BATCH_SIZE {
+                let packet = match return_packets.try_recv() {
+                    Ok(packet) => packet,
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        anyhow::bail!("HTTP/2 TUN return path closed");
+                    }
+                };
+                if packet.len() <= max_ip_packet {
+                    capsule_mode.encode_packet(&packet, &mut response_capsules);
+                }
+            }
+            if response_capsules.is_empty() {
+                continue;
+            }
+            activity.touch();
+            send_h2_data(&mut send, Bytes::copy_from_slice(&response_capsules), false).await?;
+        }
+        #[allow(unreachable_code)]
+        Ok::<_, anyhow::Error>(())
+    };
+
+    let relay = {
+        tokio::pin!(client_to_tun);
+        tokio::pin!(tun_to_client);
+        tokio::select! {
+            result = &mut client_to_tun => result.map(|()| Completion::ClientClosed),
+            result = &mut tun_to_client => result.map(|()| Completion::ClientClosed),
+            _ = &mut idle => Ok(Completion::Idle),
+        }
+    };
+
+    match relay {
+        Ok(Completion::ClientClosed) => send_h2_data(&mut send, Bytes::new(), true).await?,
+        Ok(Completion::Idle) => send.send_reset(Reason::CANCEL),
+        Err(error) => {
+            send.send_reset(Reason::PROTOCOL_ERROR);
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+/// Synchronous cleanup makes task cancellation safe: aborting an H2 stream
+/// immediately removes its return route and releases every address lease.
+struct Http2IpLease {
+    shared: Arc<Shared>,
+    owner: TunnelOwner,
+    addresses: Vec<IpAddr>,
+}
+
+impl Drop for Http2IpLease {
+    fn drop(&mut self) {
+        self.shared
+            .http2_tun_routes
+            .write()
+            .expect("HTTP/2 TUN routes poisoned")
+            .remove(&self.owner);
+        self.shared
+            .routing_table
+            .write()
+            .expect("routing table poisoned")
+            .remove_owned(&self.addresses, &self.owner);
+        self.shared
+            .address_pool
+            .lock()
+            .expect("address pool poisoned")
+            .release_all(&self.addresses);
+        info!(
+            stream_id = self.owner.stream_id,
+            transport = "http2",
+            "CONNECT-IP tunnel closed"
+        );
+    }
+}
+
+async fn send_h2_data(
+    send: &mut SendStream<Bytes>,
+    mut data: Bytes,
+    end_stream: bool,
+) -> Result<(), h2::Error> {
+    if data.is_empty() {
+        return send.send_data(data, end_stream);
+    }
+
+    while data.has_remaining() {
+        send.reserve_capacity(data.remaining());
+        let capacity = poll_fn(|cx| send.poll_capacity(cx))
+            .await
+            .ok_or_else(|| h2::Error::from(Reason::STREAM_CLOSED))??;
+        let take = capacity.min(data.remaining());
+        let chunk = data.split_to(take);
+        let finished = end_stream && data.is_empty();
+        send.send_data(chunk, finished)?;
+    }
+    Ok(())
+}
+
+fn send_error(respond: &mut SendResponse<Bytes>, status: StatusCode) -> Result<(), h2::Error> {
+    let response = Response::builder()
+        .status(status)
+        .body(())
+        .expect("status-only response is valid");
+    respond.send_response(response, true).map(|_| ())
+}
+
+fn send_proxy_auth_required(respond: &mut SendResponse<Bytes>) -> Result<(), h2::Error> {
+    let response = Response::builder()
+        .status(StatusCode::PROXY_AUTHENTICATION_REQUIRED)
+        .header(
+            PROXY_AUTHENTICATE,
+            "Basic realm=\"masque\", charset=\"UTF-8\"",
+        )
+        .body(())
+        .expect("static proxy-authenticate response is valid");
+    respond.send_response(response, true).map(|_| ())
+}
+
+struct Activity {
+    started: Instant,
+    last_millis: std::sync::atomic::AtomicU64,
+}
+
+impl Activity {
+    fn new() -> Self {
+        Self {
+            started: Instant::now(),
+            last_millis: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn touch(&self) {
+        use std::sync::atomic::Ordering;
+        let elapsed = self.started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        self.last_millis.store(elapsed, Ordering::Relaxed);
+    }
+
+    fn idle_for(&self) -> Duration {
+        use std::sync::atomic::Ordering;
+        let last = self.last_millis.load(Ordering::Relaxed);
+        let now = self.started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        Duration::from_millis(now.saturating_sub(last))
+    }
+}
+
+async fn wait_until_idle(activity: Arc<Activity>, timeout: Duration) {
+    let check_interval = timeout.min(Duration::from_secs(1));
+    loop {
+        tokio::time::sleep(check_interval).await;
+        if activity.idle_for() >= timeout {
+            return;
+        }
+    }
+}
+
+struct ConnectionMetricsGuard {
+    metrics: Arc<ShardMetrics>,
+}
+
+impl ConnectionMetricsGuard {
+    fn new(metrics: Arc<ShardMetrics>) -> Self {
+        metrics.connection_opened();
+        Self { metrics }
+    }
+}
+
+impl Drop for ConnectionMetricsGuard {
+    fn drop(&mut self) {
+        self.metrics.connection_closed();
+    }
+}
+
+struct TunnelMetricsGuard {
+    metrics: Arc<ShardMetrics>,
+    protocol_index: usize,
+}
+
+impl TunnelMetricsGuard {
+    fn new(metrics: Arc<ShardMetrics>, protocol_index: usize) -> Self {
+        metrics.tunnel_opened(protocol_index);
+        Self {
+            metrics,
+            protocol_index,
+        }
+    }
+}
+
+impl Drop for TunnelMetricsGuard {
+    fn drop(&mut self) {
+        self.metrics.tunnel_closed(self.protocol_index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IpCapsuleMode;
+    use crate::capsule::CapsuleFrame;
+    use crate::capsule::decoder::CapsuleDecoder;
+
+    #[test]
+    fn standard_ip_capsule_keeps_context_id_zero() {
+        let mut encoded = Vec::new();
+        IpCapsuleMode::Standard.encode_packet(b"packet", &mut encoded);
+
+        let frames = CapsuleDecoder::new().decode(&encoded).unwrap();
+        assert_eq!(
+            frames,
+            vec![CapsuleFrame::Datagram(
+                [vec![0], b"packet".to_vec()].concat()
+            )]
+        );
+        assert_eq!(
+            IpCapsuleMode::Standard.decode_packet(&[0, b'p']).unwrap(),
+            Some(&b"p"[..])
+        );
+    }
+
+    #[test]
+    fn cloudflare_ip_capsule_omits_context_id_zero() {
+        let mut encoded = Vec::new();
+        IpCapsuleMode::Cloudflare.encode_packet(b"packet", &mut encoded);
+
+        let frames = CapsuleDecoder::new().decode(&encoded).unwrap();
+        assert_eq!(frames, vec![CapsuleFrame::Datagram(b"packet".to_vec())]);
+        assert_eq!(
+            IpCapsuleMode::Cloudflare.decode_packet(b"packet").unwrap(),
+            Some(&b"packet"[..])
+        );
+    }
+
+    #[test]
+    fn standard_ip_capsule_ignores_unknown_context() {
+        assert_eq!(
+            IpCapsuleMode::Standard.decode_packet(&[1, 42]).unwrap(),
+            None
+        );
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,7 @@
 // QUIC listener and connection accept loop.
 
 mod authentication;
+mod http2;
 mod request;
 
 use std::net::{IpAddr, SocketAddr};
@@ -23,8 +24,10 @@ use crate::address_pool::{AddressPool, PoolError};
 use crate::auth::BasicAuthenticator;
 use crate::capsule;
 use crate::capsule::{AssignedAddress, CapsuleFrame, IpAddress, IpAddressRange};
-use crate::client_identity::{ClientIdentity, ClientRegistry, IdentityError, SharedRoster};
-use crate::config::{ResolvedListener, ServerConfig};
+use crate::client_identity::{
+    ClientIdentity, ClientRegistry, SharedRoster, configure_client_cert_verification,
+};
+use crate::config::{ListenerTransport, ResolvedListener, ServerConfig};
 use crate::connection::{AwaitingAuth, ClientConnection};
 use crate::datagram::{self, DatagramHeader};
 use crate::fxhash::FxHashMap;
@@ -150,6 +153,17 @@ struct UdpResponse {
     datagrams: Vec<Vec<u8>>,
 }
 
+/// Return path for one CONNECT-IP stream carried by HTTP/2.
+///
+/// HTTP/3 connections live inside shards and can be addressed through
+/// `index_shard`. HTTP/2 streams are independent Tokio tasks, so the shared
+/// TUN reader hands their packets to a bounded channel instead.
+#[derive(Clone)]
+struct Http2TunRoute {
+    sender: mpsc::Sender<Vec<u8>>,
+    metrics: Arc<ShardMetrics>,
+}
+
 /// Top-level MASQUE server.
 ///
 /// Runs one event loop per shard. A listener's shards each bind its address
@@ -167,6 +181,11 @@ struct UdpResponse {
 /// stays single and needs no knowledge of which listener a shard serves.
 pub struct Server {
     shards: Vec<Shard>,
+    http2_listeners: Vec<http2::Http2Listener>,
+    /// Bound worker addresses in configuration order. HTTP/3 repeats an
+    /// address once per shard, preserving the public method's original shape.
+    listen_addrs: Vec<SocketAddr>,
+    shared: Arc<Shared>,
     metrics: Arc<Metrics>,
     observability: Option<ObservabilityServer>,
 }
@@ -349,6 +368,9 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
         // rather than left to fail at bind time with an EADDRINUSE that says
         // nothing about which two listeners disagreed.
         let conflict = plans.iter().find_map(|plan| {
+            if plan.listener.transport != listener.transport {
+                return None;
+            }
             let existing = plan.listener.listen_addr;
             listen_address_conflict(existing, listener.listen_addr)
                 .map(|conflict| (existing, conflict))
@@ -374,7 +396,18 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
         // "One per core" has no single answer once the cores are shared between
         // listeners, and quietly giving every listener a full set would
         // oversubscribe the machine by the number of listeners.
-        if listener.shards == 0 && config.listeners.len() > 1 {
+        if listener.transport == ListenerTransport::Http2 && listener.shards != 1 {
+            anyhow::bail!(
+                "HTTP/2 listener {} must use shards = 1; one Tokio accept loop already \
+                 dispatches its TCP connections across the runtime",
+                listener.listen_addr
+            );
+        }
+
+        if listener.transport == ListenerTransport::Http3
+            && listener.shards == 0
+            && config.listeners.len() > 1
+        {
             anyhow::bail!(
                 "listener {} uses shards = 0 (one per core), which has no meaning \
                  alongside other listeners; give each listener an explicit count",
@@ -382,10 +415,17 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
             );
         }
 
-        let shards = resolve_shard_count(listener.shards);
+        let shards = if listener.transport == ListenerTransport::Http3 {
+            resolve_shard_count(listener.shards)
+        } else {
+            1
+        };
         // Sharing one address needs SO_REUSEPORT, which only Linux provides in
         // the load-balancing form this depends on.
-        if shards > 1 && !cfg!(target_os = "linux") {
+        if listener.transport == ListenerTransport::Http3
+            && shards > 1
+            && !cfg!(target_os = "linux")
+        {
             anyhow::bail!(
                 "listener {} asks for {shards} shards, which needs SO_REUSEPORT; \
                  that is Linux only, so set shards = 1",
@@ -393,10 +433,13 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
             );
         }
 
-        total_shards += shards;
+        if listener.transport == ListenerTransport::Http3 {
+            total_shards += shards;
+        }
         plans.push(ListenerPlan {
             listener: ResolvedListener {
                 listen_addr: listener.listen_addr,
+                transport: listener.transport,
                 shards,
                 auth: listener.auth.clone(),
             },
@@ -531,6 +574,49 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
         );
     }
 
+    const MAX_HTTP2_WINDOW: u32 = (1_u32 << 31) - 1;
+    if !(1..=MAX_HTTP2_WINDOW).contains(&config.http2.initial_stream_window) {
+        anyhow::bail!(
+            "http2.initial_stream_window ({}) must be between 1 and {MAX_HTTP2_WINDOW}",
+            config.http2.initial_stream_window
+        );
+    }
+    if !(1..=MAX_HTTP2_WINDOW).contains(&config.http2.initial_connection_window) {
+        anyhow::bail!(
+            "http2.initial_connection_window ({}) must be between 1 and {MAX_HTTP2_WINDOW}",
+            config.http2.initial_connection_window
+        );
+    }
+    if config.http2.max_concurrent_streams == 0 {
+        anyhow::bail!("http2.max_concurrent_streams must be at least 1");
+    }
+    if config.http2.max_header_list_size == 0 {
+        anyhow::bail!("http2.max_header_list_size must be at least 1");
+    }
+    if config.http2.max_send_buffer_size == 0
+        || config.http2.max_send_buffer_size > u32::MAX as usize
+    {
+        anyhow::bail!(
+            "http2.max_send_buffer_size ({}) must be between 1 and {}",
+            config.http2.max_send_buffer_size,
+            u32::MAX
+        );
+    }
+    const MAX_HTTP2_DATA_FRAME_BUDGET: usize = 16 * 1024 * 1024;
+    if !(1..=MAX_HTTP2_DATA_FRAME_BUDGET).contains(&config.http2.data_frame_budget) {
+        anyhow::bail!(
+            "http2.data_frame_budget ({}) must be between 1 and \
+             {MAX_HTTP2_DATA_FRAME_BUDGET}",
+            config.http2.data_frame_budget
+        );
+    }
+    if !(1..=65_527).contains(&config.http2.max_datagram_size) {
+        anyhow::bail!(
+            "http2.max_datagram_size ({}) must be between 1 and 65527 bytes",
+            config.http2.max_datagram_size
+        );
+    }
+
     if config.ip_proxy.enabled && !(1..=u16::MAX as usize).contains(&config.ip_proxy.tun_mtu) {
         anyhow::bail!(
             "ip_proxy.tun_mtu ({}) must be between 1 and {}",
@@ -569,12 +655,29 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
             .auth
             .client_cert_enabled()
             .then(|| Arc::new(SharedRoster::new(clients.clone())));
-        build_quic_config(config, client_certs)
-            .with_context(|| format!("listener {}", plan.listener.listen_addr))?;
+        match plan.listener.transport {
+            ListenerTransport::Http3 => {
+                build_quic_config(config, client_certs)
+                    .with_context(|| format!("listener {}", plan.listener.listen_addr))?;
+            }
+            ListenerTransport::Http2 => {
+                http2::build_acceptor(config, client_certs)
+                    .with_context(|| format!("listener {}", plan.listener.listen_addr))?;
+            }
+        }
     }
-    build_h3_config()?;
+    if listeners
+        .iter()
+        .any(|plan| plan.listener.transport == ListenerTransport::Http3)
+    {
+        build_h3_config()?;
+    }
 
-    let total_shards = listeners.iter().map(|plan| plan.listener.shards).sum();
+    let total_shards = listeners
+        .iter()
+        .filter(|plan| plan.listener.transport == ListenerTransport::Http3)
+        .map(|plan| plan.listener.shards)
+        .sum();
     Ok(ValidatedServerConfig {
         clients,
         listeners,
@@ -721,6 +824,7 @@ impl Server {
             routing_table: RwLock::new(RoutingTable::new()),
             cid_shard: RwLock::new(FxHashMap::default()),
             index_shard: RwLock::new(FxHashMap::default()),
+            http2_tun_routes: RwLock::new(FxHashMap::default()),
             next_conn_index: AtomicU64::new(0),
             conn_id_key: ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &key_bytes),
             tun,
@@ -735,18 +839,43 @@ impl Server {
         });
 
         let mut shards = Vec::with_capacity(total_shards);
+        let mut http2_listeners = Vec::new();
+        let mut listen_addrs = Vec::with_capacity(total_shards + listeners.len());
         let mut inboxes = forward_rx.into_iter().zip(tun_rx);
         // Ephemeral listeners must avoid not only sockets that are already up,
         // but fixed listeners that have not been reached yet. Otherwise an
         // early `:0` listener can take a later port and, under SO_REUSEPORT,
         // silently join the other authentication mode's group.
-        let mut unavailable_listener_addrs: Vec<SocketAddr> = listeners
+        let mut unavailable_http3_addrs: Vec<SocketAddr> = listeners
             .iter()
+            .filter(|plan| plan.listener.transport == ListenerTransport::Http3)
+            .map(|plan| plan.listener.listen_addr)
+            .filter(|addr| addr.port() != 0)
+            .collect();
+        let mut unavailable_http2_addrs: Vec<SocketAddr> = listeners
+            .iter()
+            .filter(|plan| plan.listener.transport == ListenerTransport::Http2)
             .map(|plan| plan.listener.listen_addr)
             .filter(|addr| addr.port() != 0)
             .collect();
 
         for mut plan in listeners {
+            if plan.listener.transport == ListenerTransport::Http2 {
+                let listener = http2::Http2Listener::bind(
+                    Arc::clone(&config),
+                    Arc::clone(&shared),
+                    plan.listener.clone(),
+                    Arc::clone(&metrics),
+                    listener_auth_label(&plan.listener),
+                    &unavailable_http2_addrs,
+                )
+                .await?;
+                unavailable_http2_addrs.push(listener.local_addr());
+                listen_addrs.push(listener.local_addr());
+                http2_listeners.push(listener);
+                continue;
+            }
+
             // SO_REUSEPORT is what lets one listener's shards share an address.
             // A single-shard listener must not set it, or a later listener that
             // was misconfigured onto the same address could join its group.
@@ -759,13 +888,15 @@ impl Server {
                 &config,
                 plan.listener.listen_addr,
                 reuseport,
-                &unavailable_listener_addrs,
+                &unavailable_http3_addrs,
             )
             .await?;
             plan.listener.listen_addr = bound_addr;
-            unavailable_listener_addrs.push(bound_addr);
+            unavailable_http3_addrs.push(bound_addr);
+            listen_addrs.extend(std::iter::repeat_n(bound_addr, plan.listener.shards));
             let listener_metrics = metrics.register_listener(
                 bound_addr,
+                plan.listener.transport.as_str(),
                 listener_auth_label(&plan.listener),
                 plan.listener.shards,
                 first_socket.udp_gso_enabled(),
@@ -816,9 +947,16 @@ impl Server {
             None => None,
         };
 
-        info!(shards = total_shards, "server ready");
+        info!(
+            http3_shards = total_shards,
+            http2_listeners = http2_listeners.len(),
+            "server ready"
+        );
         Ok(Self {
             shards,
+            http2_listeners,
+            listen_addrs,
+            shared,
             metrics,
             observability,
         })
@@ -830,10 +968,7 @@ impl Server {
     /// free. This is the programmatic way to learn it; the live `listening` log
     /// reports it too. Shards of one listener share an address and repeat here.
     pub fn listen_addrs(&self) -> Vec<SocketAddr> {
-        self.shards
-            .iter()
-            .map(|shard| shard.socket.local_addr().unwrap_or(shard.listen_addr))
-            .collect()
+        self.listen_addrs.clone()
     }
 
     /// Bound observability address, including a kernel-selected test port.
@@ -888,9 +1023,7 @@ impl Server {
     pub async fn run(&mut self) -> anyhow::Result<()> {
         let watchdog_timeout =
             systemd::watchdog_timeout().context("invalid systemd watchdog environment")?;
-        if let Some(shard) = self.shards.first() {
-            Self::spawn_roster_reloader(Arc::clone(&shard.shared));
-        }
+        Self::spawn_roster_reloader(Arc::clone(&self.shared));
 
         // Install one process-wide signal listener before any shard starts.
         // Every shard receives the same latched watch value, so one SIGINT or
@@ -934,9 +1067,11 @@ impl Server {
             }
         });
 
-        // A single shard keeps the current behaviour of running on the caller's
-        // task, which keeps the common case free of a spawn and a join.
-        if self.shards.len() == 1 {
+        // Preserve the hot-path shape used by the common one-listener,
+        // one-shard HTTP/3 deployment. Running that shard on the caller avoids
+        // an otherwise unnecessary Tokio task boundary and keeps HTTP/2 support
+        // from perturbing existing throughput.
+        if self.http2_listeners.is_empty() && self.shards.len() == 1 {
             let outcome = self.shards[0].run(shutdown_rx).await;
             if self.metrics.begin_shutdown()
                 && let Err(error) = systemd::notify("STOPPING=1\nSTATUS=Stopping")
@@ -956,39 +1091,52 @@ impl Server {
         }
 
         let mut tasks = tokio::task::JoinSet::new();
+        if self.shards.is_empty() && self.shared.tun.is_some() {
+            let shared = Arc::clone(&self.shared);
+            let shutdown_rx = shutdown_rx.clone();
+            tasks.spawn(async move {
+                let result = run_http2_tun_dispatcher(shared, shutdown_rx).await;
+                ("HTTP/2 TUN dispatcher".to_string(), result)
+            });
+        }
         for mut shard in self.shards.drain(..) {
             let shutdown_rx = shutdown_rx.clone();
             tasks.spawn(async move {
                 let index = shard.index;
                 let result = shard.run(shutdown_rx).await;
-                (index, result)
+                (format!("HTTP/3 shard {index}"), result)
+            });
+        }
+        for listener in self.http2_listeners.drain(..) {
+            let shutdown_rx = shutdown_rx.clone();
+            let addr = listener.local_addr();
+            tasks.spawn(async move {
+                let result = listener.run(shutdown_rx).await;
+                (format!("HTTP/2 listener {addr}"), result)
             });
         }
 
         let mut outcome = Ok(());
         while let Some(joined) = tasks.join_next().await {
             match joined {
-                Ok((index, Err(error))) => {
-                    error!(shard = index, %error, "shard exited with an error");
+                Ok((worker, Err(error))) => {
+                    error!(%worker, %error, "proxy worker exited with an error");
                     if outcome.is_ok() {
                         outcome = Err(error);
                     }
                     if !*shutdown_tx.borrow() {
-                        warn!(
-                            shard = index,
-                            "draining remaining shards after an unexpected exit"
-                        );
+                        warn!(%worker, "draining remaining workers after an unexpected exit");
                         let _ = shutdown_tx.send(true);
                     }
                 }
                 Ok((_, Ok(()))) => {}
                 Err(error) => {
-                    error!(%error, "shard task panicked");
+                    error!(%error, "proxy worker task panicked");
                     if outcome.is_ok() {
-                        outcome = Err(anyhow::anyhow!("shard task panicked: {error}"));
+                        outcome = Err(anyhow::anyhow!("proxy worker task panicked: {error}"));
                     }
                     if !*shutdown_tx.borrow() {
-                        warn!("draining remaining shards after an unexpected exit");
+                        warn!("draining remaining workers after an unexpected exit");
                         let _ = shutdown_tx.send(true);
                     }
                 }
@@ -1012,7 +1160,7 @@ impl Server {
     }
 }
 
-/// Ping systemd only while every proxy shard is making progress. If one shard
+/// Ping systemd only while every proxy worker is making progress. If one worker
 /// stops completing its once-per-second heartbeat, readiness fails and pings
 /// are withheld so `WatchdogSec` can restart the process.
 fn spawn_systemd_watchdog(
@@ -1238,6 +1386,47 @@ fn allocate_pool_addresses(shared: &Shared) -> Vec<IpAddr> {
     addresses
 }
 
+/// Encode the address and default-route capsules shared by HTTP/2 and HTTP/3
+/// CONNECT-IP setup.
+fn encode_ip_setup_capsules(addresses: &[IpAddr]) -> Vec<u8> {
+    let assigned = addresses
+        .iter()
+        .map(|ip| match *ip {
+            IpAddr::V4(ip) => AssignedAddress {
+                request_id: 0,
+                ip: IpAddress::V4(ip),
+                prefix_len: 32,
+            },
+            IpAddr::V6(ip) => AssignedAddress {
+                request_id: 0,
+                ip: IpAddress::V6(ip),
+                prefix_len: 128,
+            },
+        })
+        .collect();
+
+    let mut capsules = Vec::new();
+    capsule::encoder::encode(&CapsuleFrame::AddressAssign(assigned), &mut capsules);
+    capsule::encoder::encode(
+        &CapsuleFrame::RouteAdvertisement(vec![
+            IpAddressRange {
+                start: IpAddress::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                end: IpAddress::V4(std::net::Ipv4Addr::BROADCAST),
+                ip_protocol: 0,
+            },
+            IpAddressRange {
+                start: IpAddress::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                end: IpAddress::V6(std::net::Ipv6Addr::new(
+                    0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+                )),
+                ip_protocol: 0,
+            },
+        ]),
+        &mut capsules,
+    );
+    capsules
+}
+
 /// Build a QUIC config that demands a client certificate and admits only keys
 /// on the roster.
 ///
@@ -1283,54 +1472,7 @@ fn build_client_cert_quic_config(
         )
     })?;
 
-    // PEER asks for the certificate; FAIL_IF_NO_PEER_CERT makes it mandatory.
-    // Without the second flag a client that simply omits its certificate would
-    // complete the handshake and reach the request path with no identity.
-    //
-    // This is the *custom* verify hook, not the legacy `SSL_CTX_set_verify`
-    // callback: the legacy one runs as a step inside BoringSSL's X.509 chain
-    // verification, which never happens here because no CA store is configured,
-    // so it is simply never consulted. `SSL_CTX_set_custom_verify` replaces
-    // chain verification outright and is always called.
-    let mode = boring::ssl::SslVerifyMode::PEER | boring::ssl::SslVerifyMode::FAIL_IF_NO_PEER_CERT;
-    builder.set_custom_verify_callback(mode, move |ssl| {
-        // ACCESS_DENIED rather than a certificate-specific alert: the
-        // certificate is structurally fine, it is the identity behind it that
-        // is not authorized. Clients in this family surface that alert as a
-        // login failure, which is the right thing to tell the operator.
-        let denied = Err(boring::ssl::SslVerifyError::Invalid(
-            boring::ssl::SslAlert::ACCESS_DENIED,
-        ));
-
-        let Some(cert) = ssl.peer_certificate() else {
-            warn!("rejecting client that presented no certificate");
-            return denied;
-        };
-        let Ok(der) = cert.to_der() else {
-            warn!("rejecting client certificate that could not be re-encoded");
-            return denied;
-        };
-
-        match roster.load().identify(&der) {
-            Ok(identity) => {
-                debug!(client = %identity.name, "client certificate accepted");
-                Ok(())
-            }
-            Err(IdentityError::UnknownKey(key)) => {
-                // Logged in full so an operator can enroll the client by
-                // pasting this straight into a `[[clients]]` entry.
-                warn!(
-                    public_key = %key,
-                    "rejecting client: public key is not in the [[clients]] roster"
-                );
-                denied
-            }
-            Err(e) => {
-                warn!(%e, "rejecting client certificate");
-                denied
-            }
-        }
-    });
+    configure_client_cert_verification(&mut builder, roster);
 
     quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, builder)
         .map_err(|e| anyhow::anyhow!("failed to build QUIC config: {e}"))
@@ -1518,6 +1660,60 @@ fn build_tun(config: &ServerConfig) -> anyhow::Result<Option<TunManager>> {
     }
 }
 
+/// Own the shared TUN read side when a process has HTTP/2 listeners but no
+/// HTTP/3 shard. In a mixed deployment HTTP/3 shard zero already performs this
+/// job and dispatches HTTP/2-owned packets through `relay_http2_tun_packet`.
+async fn run_http2_tun_dispatcher(
+    shared: Arc<Shared>,
+    mut shutdown: watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    let tun = shared
+        .tun
+        .as_ref()
+        .expect("HTTP/2 TUN dispatcher requires a configured device");
+    let device = tun.device();
+    let mut batch = TunRecvBatch::new(tun.mtu());
+
+    loop {
+        let received = tokio::select! {
+            result = shutdown.wait_for(|requested| *requested) => {
+                let _ = result;
+                return Ok(());
+            }
+            result = tun::recv_batch(&device, &mut batch) => result,
+        };
+
+        let segments = match received {
+            Ok(segments) => segments,
+            Err(error) => {
+                error!(%error, "HTTP/2 TUN receive failed");
+                continue;
+            }
+        };
+        for index in 0..segments.min(MAX_TUN_RECV_BATCH) {
+            let Some(packet) = batch.packet(index) else {
+                break;
+            };
+            let destination = match ip_packet::dst_addr(packet) {
+                Ok(destination) => destination,
+                Err(error) => {
+                    debug!(%error, "invalid IP header from TUN");
+                    continue;
+                }
+            };
+            let owner = shared
+                .routing_table
+                .read()
+                .expect("routing table poisoned")
+                .lookup(&destination)
+                .copied();
+            if let Some(owner) = owner {
+                shared.relay_http2_tun_packet(owner, packet);
+            }
+        }
+    }
+}
+
 /// Wait for the target socket to be readable, then drain a batch of datagrams.
 async fn recv_target_batch(
     socket: &UdpSocket,
@@ -1575,6 +1771,12 @@ struct Shared {
     cid_shard: RwLock<FxHashMap<quiche::ConnectionId<'static>, usize>>,
     /// Which shard owns each connection index, for routing TUN packets.
     index_shard: RwLock<FxHashMap<u64, usize>>,
+    /// Bounded return path for CONNECT-IP streams owned by HTTP/2 tasks.
+    ///
+    /// An owner is present in exactly one of `index_shard` or this map. That
+    /// keeps the common HTTP/3 lookup unchanged while allowing the one shared
+    /// TUN reader to dispatch packets across transports.
+    http2_tun_routes: RwLock<FxHashMap<TunnelOwner, Http2TunRoute>>,
     /// Monotonically increasing connection index used as the conn_id in
     /// TunnelOwner (since quiche ConnectionId is not easily hashable).
     ///
@@ -1642,6 +1844,34 @@ impl Shared {
             metrics.record_tun_queue_drop();
         }
     }
+
+    /// Hand one TUN packet to an HTTP/2 CONNECT-IP task without waiting for
+    /// stream flow control. Returns false when `owner` belongs to HTTP/3 (or
+    /// has already disappeared), so the shard can continue its normal path.
+    fn relay_http2_tun_packet(&self, owner: TunnelOwner, packet: &[u8]) -> bool {
+        let route = self
+            .http2_tun_routes
+            .read()
+            .expect("HTTP/2 TUN routes poisoned")
+            .get(&owner)
+            .cloned();
+        let Some(route) = route else {
+            return false;
+        };
+
+        match route.sender.try_reserve() {
+            Ok(permit) => permit.send(packet.to_vec()),
+            Err(_) => {
+                route.metrics.record_tun_queue_drop();
+                debug!(
+                    conn_id = owner.conn_id,
+                    stream_id = owner.stream_id,
+                    "HTTP/2 TUN queue full, dropping packet"
+                );
+            }
+        }
+        true
+    }
 }
 
 /// One shard: an independent event loop over its own share of connections.
@@ -1664,8 +1894,6 @@ struct Shard {
     tcp_policy: TargetPolicy,
     udp_policy: TargetPolicy,
     config: Arc<ServerConfig>,
-    /// Configured address after an ephemeral port, if any, has been resolved.
-    listen_addr: SocketAddr,
     /// Reverse index for routing TUN packets without scanning every connection.
     conn_by_index: FxHashMap<u64, quiche::ConnectionId<'static>>,
     udp_response_tx: mpsc::Sender<UdpResponse>,
@@ -1772,7 +2000,6 @@ impl Shard {
             tcp_policy,
             udp_policy,
             config,
-            listen_addr: listener.listen_addr,
             conn_by_index: FxHashMap::default(),
             udp_response_tx,
             udp_response_rx,
@@ -2733,21 +2960,8 @@ impl Shard {
             return;
         }
 
-        let mut assigned = Vec::with_capacity(addresses.len());
         for ip in &addresses {
             tunnel.assigned_addrs.push(*ip);
-            assigned.push(match *ip {
-                IpAddr::V4(v4) => AssignedAddress {
-                    request_id: 0,
-                    ip: IpAddress::V4(v4),
-                    prefix_len: 32,
-                },
-                IpAddr::V6(v6) => AssignedAddress {
-                    request_id: 0,
-                    ip: IpAddress::V6(v6),
-                    prefix_len: 128,
-                },
-            });
         }
 
         // Do not acknowledge the CONNECT until every address has been leased.
@@ -2801,25 +3015,7 @@ impl Shard {
         // Send ADDRESS_ASSIGN and ROUTE_ADVERTISEMENT back to back: one buffer,
         // one send_body call. The route advertisement is a default route, so
         // the client knows it can send all traffic through this tunnel.
-        let mut capsules = Vec::new();
-        capsule::encoder::encode(&CapsuleFrame::AddressAssign(assigned), &mut capsules);
-        capsule::encoder::encode(
-            &CapsuleFrame::RouteAdvertisement(vec![
-                IpAddressRange {
-                    start: IpAddress::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
-                    end: IpAddress::V4(std::net::Ipv4Addr::new(255, 255, 255, 255)),
-                    ip_protocol: 0, // all protocols
-                },
-                IpAddressRange {
-                    start: IpAddress::V6(std::net::Ipv6Addr::UNSPECIFIED),
-                    end: IpAddress::V6(std::net::Ipv6Addr::new(
-                        0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
-                    )),
-                    ip_protocol: 0,
-                },
-            ]),
-            &mut capsules,
-        );
+        let capsules = encode_ip_setup_capsules(&addresses);
 
         if let Err(e) = h3.send_body(&mut client.quic, stream_id, &capsules, false) {
             warn!(stream_id, %e, "failed to send CONNECT-IP capsules");
@@ -3367,6 +3563,9 @@ impl Shard {
             .expect("index ownership poisoned")
             .get(&owner.conn_id)
             .copied();
+        if owner_shard.is_none() && self.shared.relay_http2_tun_packet(owner, pkt) {
+            return true;
+        }
         if let Some(shard) = owner_shard
             && shard != self.index
         {
@@ -3710,7 +3909,9 @@ impl Shard {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{AuthMode, AuthSection, ClientEntry, ListenerSection, ServerConfig};
+    use crate::config::{
+        AuthMode, AuthSection, ClientEntry, ListenerSection, ListenerTransport, ServerConfig,
+    };
 
     fn invalid_roster_entry() -> ClientEntry {
         ClientEntry {
@@ -3733,6 +3934,7 @@ mod tests {
     fn listener(addr: &str, mode: AuthMode) -> ListenerSection {
         ListenerSection {
             listen_addr: addr.parse().unwrap(),
+            transport: ListenerTransport::Http3,
             shards: 1,
             auth: AuthSection {
                 enabled: true,
@@ -3887,6 +4089,31 @@ mod tests {
             listener("0.0.0.0:443", AuthMode::ClientCert),
         ]);
         assert!(super::plan_listeners(&config).is_err());
+    }
+
+    #[test]
+    fn http2_and_http3_may_share_a_numeric_address() {
+        let mut http3 = listener("127.0.0.1:8443", AuthMode::Basic);
+        http3.transport = ListenerTransport::Http3;
+        let mut http2 = listener("127.0.0.1:8443", AuthMode::Basic);
+        http2.transport = ListenerTransport::Http2;
+        let config = config_with(vec![http3, http2]);
+
+        assert!(super::plan_listeners(&config).is_ok());
+    }
+
+    #[test]
+    fn http2_listener_rejects_quic_sharding() {
+        let mut http2 = listener("127.0.0.1:8443", AuthMode::Basic);
+        http2.transport = ListenerTransport::Http2;
+        http2.shards = 2;
+        let config = config_with(vec![http2]);
+
+        let error = match super::plan_listeners(&config) {
+            Ok(_) => panic!("HTTP/2 sharding should be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("HTTP/2 listener"));
     }
 
     /// A wildcard claims every address of its family on its port, so an

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -57,6 +57,38 @@ fn accepts_connect_ip(configured: &[String], protocol: &[u8]) -> bool {
             .any(|accepted| accepted.as_bytes() == protocol)
 }
 
+/// Classify the transport-neutral semantics of one header block.
+///
+/// HTTP/2 and HTTP/3 encode their pseudo-headers differently in memory, but
+/// the supported CONNECT methods and feature gates must stay identical.
+pub(super) fn classify_connect_request(
+    method: &[u8],
+    protocol: &[u8],
+    authority: &[u8],
+    path: &[u8],
+    config: &ServerConfig,
+) -> Option<ConnectRequest> {
+    if method != b"CONNECT" {
+        return None;
+    }
+
+    if protocol.is_empty() && config.tcp_proxy.enabled {
+        Some(ConnectRequest::Tcp {
+            authority: String::from_utf8_lossy(authority).into_owned(),
+        })
+    } else if protocol == b"connect-udp" && config.udp_proxy.enabled {
+        Some(ConnectRequest::Udp {
+            path: String::from_utf8_lossy(path).into_owned(),
+        })
+    } else if config.ip_proxy.enabled
+        && accepts_connect_ip(&config.ip_proxy.connect_protocols, protocol)
+    {
+        Some(ConnectRequest::Ip)
+    } else {
+        None
+    }
+}
+
 /// Shared request dependencies passed together to keep dispatch APIs focused.
 pub(super) struct RequestContext<'a> {
     pub(super) config: &'a ServerConfig,
@@ -109,50 +141,34 @@ impl Shard {
         // Authenticate supported proxy requests before parsing their target
         // or allocating any tunnel resources. Duplicate credentials are
         // rejected rather than choosing one ambiguously.
-        if method == b"CONNECT" {
-            let request = if protocol.is_empty() && context.config.tcp_proxy.enabled {
-                Some(ConnectRequest::Tcp {
-                    authority: String::from_utf8_lossy(authority).into_owned(),
-                })
-            } else if protocol == b"connect-udp" && context.config.udp_proxy.enabled {
-                Some(ConnectRequest::Udp {
-                    path: String::from_utf8_lossy(path).into_owned(),
-                })
-            } else if context.config.ip_proxy.enabled
-                && accepts_connect_ip(&context.config.ip_proxy.connect_protocols, protocol)
-            {
-                Some(ConnectRequest::Ip)
-            } else {
-                None
+        if let Some(request) =
+            classify_connect_request(method, protocol, authority, path, context.config)
+        {
+            let Some(auth) = context.auth else {
+                Self::dispatch_connect(h3, quic, stream_id, &request, context, pending);
+                return None;
             };
 
-            if let Some(request) = request {
-                let Some(auth) = context.auth else {
-                    Self::dispatch_connect(h3, quic, stream_id, &request, context, pending);
-                    return None;
-                };
-
-                // The cheap half runs here; only a well-formed request for the
-                // configured user reaches the password hash, and that is
-                // deliberately slow enough that it must not run on this thread.
-                if duplicate_proxy_authorization {
-                    warn!(stream_id, "duplicate proxy credentials");
+            // The cheap half runs here; only a well-formed request for the
+            // configured user reaches the password hash, and that is
+            // deliberately slow enough that it must not run on this thread.
+            if duplicate_proxy_authorization {
+                warn!(stream_id, "duplicate proxy credentials");
+                Self::send_proxy_auth_required(h3, quic, stream_id);
+                return None;
+            }
+            match auth.precheck(proxy_authorization) {
+                AuthPrecheck::Rejected => {
+                    warn!(stream_id, "proxy authentication failed");
                     Self::send_proxy_auth_required(h3, quic, stream_id);
                     return None;
                 }
-                match auth.precheck(proxy_authorization) {
-                    AuthPrecheck::Rejected => {
-                        warn!(stream_id, "proxy authentication failed");
-                        Self::send_proxy_auth_required(h3, quic, stream_id);
-                        return None;
-                    }
-                    AuthPrecheck::NeedsVerify(password) => {
-                        return Some(PendingAuth {
-                            stream_id,
-                            password,
-                            request,
-                        });
-                    }
+                AuthPrecheck::NeedsVerify(password) => {
+                    return Some(PendingAuth {
+                        stream_id,
+                        password,
+                        request,
+                    });
                 }
             }
         }

--- a/src/tunnel/tcp.rs
+++ b/src/tunnel/tcp.rs
@@ -406,7 +406,7 @@ pub fn spawn_tcp_connect(
     })
 }
 
-async fn resolve_and_connect(
+pub(crate) async fn resolve_and_connect(
     target: TcpTarget,
     policy: &TargetPolicy,
     timeout: Duration,

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -201,7 +201,7 @@ fn adds_a_certificate_listener_beside_a_basic_one() {
         .unwrap();
     let stdout = String::from_utf8_lossy(&check.stdout);
     assert!(check.status.success(), "check-config rejected the edit");
-    assert!(stdout.contains("listener 127.0.0.1:8450 auth=client_cert shards=1"));
+    assert!(stdout.contains("listener 127.0.0.1:8450 transport=http3 auth=client_cert shards=1"));
 }
 
 #[test]
@@ -330,6 +330,37 @@ fn refuses_an_address_that_overlaps_the_existing_listener() {
         String::from_utf8_lossy(&output.stderr)
     );
     fixture.assert_unchanged();
+}
+
+#[test]
+fn adds_http2_on_the_same_numeric_port_as_http3() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--transport",
+        "http2",
+        "--listen-addr",
+        "127.0.0.1:8449",
+        "--mode",
+        "client-cert",
+        "--no-bind-check",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let config = fixture.config();
+    assert_eq!(
+        config.listeners[1].transport,
+        masque::config::ListenerTransport::Http2
+    );
+    assert_eq!(
+        config.listeners[1].listen_addr,
+        config.listeners[0].listen_addr
+    );
+    assert_eq!(config.listeners[1].shards, 1);
+    assert!(fixture.text().contains("transport = \"http2\""));
 }
 
 /// A certificate listener with an empty roster is refused at startup, so
@@ -478,7 +509,7 @@ fn writes_a_listener_that_demands_nothing_when_asked() {
     assert!(check.status.success());
     assert!(
         String::from_utf8_lossy(&check.stdout)
-            .contains("listener 127.0.0.1:8459 auth=disabled shards=1")
+            .contains("listener 127.0.0.1:8459 transport=http3 auth=disabled shards=1")
     );
 }
 

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -233,7 +233,7 @@ fn check_config_keeps_an_ephemeral_port_unresolved() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        stdout.contains("listener 127.0.0.1:0 auth=disabled shards=1"),
+        stdout.contains("listener 127.0.0.1:0 transport=http3 auth=disabled shards=1"),
         "check-config must not invent a runtime port: {stdout}"
     );
 }
@@ -492,7 +492,7 @@ enabled = false
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        stdout.contains("listener 127.0.0.1:8449 auth=disabled shards="),
+        stdout.contains("listener 127.0.0.1:8449 transport=http3 auth=disabled shards="),
         "unexpected listener line: {stdout}"
     );
     assert!(

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -28,7 +28,9 @@ use quiche::h3::NameValue as _;
 
 use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
 use masque::capsule::{CapsuleFrame, IpAddress};
-use masque::config::{AuthMode, AuthSection, ClientEntry, ListenerSection, ServerConfig};
+use masque::config::{
+    AuthMode, AuthSection, ClientEntry, ListenerSection, ListenerTransport, ServerConfig,
+};
 use masque::datagram::DatagramHeader;
 use masque::server::Server;
 
@@ -561,6 +563,7 @@ fn dual_fixture(tag: &str) -> DualFixture {
     config.listeners = vec![
         ListenerSection {
             listen_addr: ephemeral_addr(),
+            transport: ListenerTransport::Http3,
             shards: 1,
             auth: AuthSection {
                 enabled: true,
@@ -571,6 +574,7 @@ fn dual_fixture(tag: &str) -> DualFixture {
         },
         ListenerSection {
             listen_addr: ephemeral_addr(),
+            transport: ListenerTransport::Http3,
             shards: 1,
             auth: AuthSection {
                 enabled: true,
@@ -696,6 +700,7 @@ fn ephemeral_multi_shard_listeners_share_only_their_own_port() {
     config.listeners = vec![
         ListenerSection {
             listen_addr: ephemeral_addr(),
+            transport: ListenerTransport::Http3,
             shards: 2,
             auth: AuthSection {
                 enabled: false,
@@ -704,6 +709,7 @@ fn ephemeral_multi_shard_listeners_share_only_their_own_port() {
         },
         ListenerSection {
             listen_addr: ephemeral_addr(),
+            transport: ListenerTransport::Http3,
             shards: 2,
             auth: AuthSection {
                 enabled: false,

--- a/tests/http2_connect.rs
+++ b/tests/http2_connect.rs
@@ -1,0 +1,564 @@
+//! End-to-end coverage for the HTTP/2 compatibility transport.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::asn1::Asn1Time;
+use boring::bn::BigNum;
+use boring::ec::{EcGroup, EcKey};
+use boring::hash::MessageDigest;
+use boring::nid::Nid;
+use boring::pkey::{PKey, Private};
+use boring::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
+use boring::x509::{X509Builder, X509NameBuilder};
+use bytes::Bytes;
+use http::{Method, Request, StatusCode};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream, UdpSocket};
+
+use masque::capsule::decoder::CapsuleDecoder;
+use masque::capsule::{CapsuleFrame, IpAddress, encoder};
+use masque::config::{AuthMode, ClientEntry, ListenerTransport, ServerConfig};
+use masque::server::Server;
+
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+struct TestFiles {
+    directory: PathBuf,
+    cert: PathBuf,
+    key: PathBuf,
+}
+
+impl TestFiles {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "masque-http2-test-{}-{nonce}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+
+        let key = p256_key();
+        let cert = self_signed(&key);
+        let cert_path = directory.join("server.crt");
+        let key_path = directory.join("server.key");
+        std::fs::write(&cert_path, cert.to_pem().unwrap()).unwrap();
+        std::fs::write(&key_path, key.private_key_to_pem_pkcs8().unwrap()).unwrap();
+        Self {
+            directory,
+            cert: cert_path,
+            key: key_path,
+        }
+    }
+}
+
+impl Drop for TestFiles {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+fn p256_key() -> PKey<Private> {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+}
+
+fn self_signed(key: &PKey<Private>) -> boring::x509::X509 {
+    let mut name = X509NameBuilder::new().unwrap();
+    name.append_entry_by_text("CN", "localhost").unwrap();
+    let name = name.build();
+
+    let mut cert = X509Builder::new().unwrap();
+    cert.set_version(2).unwrap();
+    cert.set_serial_number(&BigNum::from_u32(1).unwrap().to_asn1_integer().unwrap())
+        .unwrap();
+    cert.set_subject_name(&name).unwrap();
+    cert.set_issuer_name(&name).unwrap();
+    cert.set_pubkey(key).unwrap();
+    cert.set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .unwrap();
+    cert.set_not_after(&Asn1Time::days_from_now(1).unwrap())
+        .unwrap();
+    cert.sign(key, MessageDigest::sha256()).unwrap();
+    cert.build()
+}
+
+fn http2_config(files: &TestFiles) -> ServerConfig {
+    let mut config = ServerConfig::default();
+    config.tls.cert_path = files.cert.clone();
+    config.tls.key_path = files.key.clone();
+    config.listeners[0].listen_addr = "127.0.0.1:0".parse().unwrap();
+    config.listeners[0].transport = ListenerTransport::Http2;
+    config.listeners[0].auth.enabled = false;
+    config.ip_proxy.enabled = false;
+    config.tcp_proxy.allow_targets = vec!["127.0.0.0/8".into()];
+    config.tcp_proxy.deny_targets.clear();
+    config.udp_proxy.allow_targets = vec!["127.0.0.0/8".into()];
+    config.udp_proxy.deny_targets.clear();
+    config
+}
+
+async fn spawn_http2_server(
+    files: &TestFiles,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    spawn_http2_config(http2_config(files)).await
+}
+
+async fn spawn_http2_config(
+    config: ServerConfig,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let mut server = Server::bind(config).await.unwrap();
+    let addr = server.listen_addrs()[0];
+    let task = tokio::spawn(async move {
+        server.run().await.unwrap();
+    });
+    (addr, task)
+}
+
+async fn connect_h2(
+    addr: std::net::SocketAddr,
+) -> (
+    h2::client::SendRequest<Bytes>,
+    tokio::task::JoinHandle<Result<(), h2::Error>>,
+) {
+    connect_h2_with_identity(addr, None).await
+}
+
+async fn connect_h2_with_identity(
+    addr: std::net::SocketAddr,
+    identity: Option<(&Path, &Path)>,
+) -> (
+    h2::client::SendRequest<Bytes>,
+    tokio::task::JoinHandle<Result<(), h2::Error>>,
+) {
+    let mut connector = SslConnector::builder(SslMethod::tls_client()).unwrap();
+    connector.set_verify(SslVerifyMode::NONE);
+    connector.set_alpn_protos(b"\x02h2").unwrap();
+    if let Some((cert, key)) = identity {
+        connector
+            .set_certificate_chain_file(cert)
+            .expect("client certificate is valid PEM");
+        connector
+            .set_private_key_file(key, SslFiletype::PEM)
+            .expect("client private key is valid PEM");
+        connector.check_private_key().unwrap();
+    }
+    let tls = tokio_boring::connect(
+        connector.build().configure().unwrap(),
+        "localhost",
+        TcpStream::connect(addr).await.unwrap(),
+    )
+    .await
+    .unwrap();
+    let (client, connection) = h2::client::handshake(tls).await.unwrap();
+    let driver = tokio::spawn(connection);
+    (client.ready().await.unwrap(), driver)
+}
+
+fn connect_request(target: std::net::SocketAddr) -> Request<()> {
+    let uri = http::Uri::builder()
+        .authority(target.to_string())
+        .build()
+        .unwrap();
+    Request::builder()
+        .method(Method::CONNECT)
+        .uri(uri)
+        .body(())
+        .unwrap()
+}
+
+fn connect_ip_request(protocol: &'static str) -> Request<()> {
+    let mut request = Request::builder()
+        .method(Method::CONNECT)
+        .uri("https://localhost/.well-known/masque/ip/*/*/")
+        .header("capsule-protocol", "?1")
+        .body(())
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(h2::ext::Protocol::from_static(protocol));
+    request
+}
+
+fn cloudflare_h2_connect_ip_request() -> Request<()> {
+    let uri = http::Uri::builder()
+        .authority("cloudflareaccess.com:443")
+        .build()
+        .unwrap();
+    Request::builder()
+        .method(Method::CONNECT)
+        .uri(uri)
+        .header("cf-connect-proto", "cf-connect-ip")
+        .header("pq-enabled", "false")
+        .body(())
+        .unwrap()
+}
+
+async fn read_connect_ip_setup(
+    response: http::Response<h2::RecvStream>,
+) -> (Vec<CapsuleFrame>, h2::RecvStream) {
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut response_body = response.into_body();
+    let mut decoder = CapsuleDecoder::new();
+    let mut frames = Vec::new();
+    while frames.len() < 2 {
+        let data = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        response_body
+            .flow_control()
+            .release_capacity(data.len())
+            .unwrap();
+        frames.extend(decoder.decode(&data).unwrap());
+    }
+    (frames, response_body)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn standard_connect_relays_bytes_over_http2() {
+    let files = TestFiles::new();
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_task = tokio::spawn(async move {
+        let (mut stream, _) = target.accept().await.unwrap();
+        let mut buf = [0_u8; 64];
+        let read = stream.read(&mut buf).await.unwrap();
+        stream.write_all(&buf[..read]).await.unwrap();
+    });
+
+    let (server_addr, server_task) = spawn_http2_server(&files).await;
+    let (mut client, driver) = connect_h2(server_addr).await;
+    let request = connect_request(target_addr);
+    let (response, mut request_body) = client.send_request(request, false).unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    request_body
+        .send_data(Bytes::from_static(b"hello over h2"), true)
+        .unwrap();
+    let mut response_body = response.into_body();
+    let echoed = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(&echoed[..], b"hello over h2");
+    response_body
+        .flow_control()
+        .release_capacity(echoed.len())
+        .unwrap();
+
+    target_task.await.unwrap();
+    server_task.abort();
+    driver.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn basic_auth_challenges_missing_credentials_and_accepts_valid_credentials() {
+    let files = TestFiles::new();
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_task = tokio::spawn(async move {
+        let (mut stream, _) = target.accept().await.unwrap();
+        let mut byte = [0_u8; 1];
+        stream.read_exact(&mut byte).await.unwrap();
+        stream.write_all(&byte).await.unwrap();
+    });
+
+    let mut config = http2_config(&files);
+    config.listeners[0].auth.enabled = true;
+    config.listeners[0].auth.mode = AuthMode::Basic;
+    config.listeners[0].auth.username = "alice".into();
+    config.listeners[0].auth.password_hash = masque::auth::hash_password(b"secret").unwrap();
+    let (server_addr, server_task) = spawn_http2_config(config).await;
+    let (mut client, driver) = connect_h2(server_addr).await;
+
+    let (response, _) = client
+        .send_request(connect_request(target_addr), true)
+        .unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::PROXY_AUTHENTICATION_REQUIRED);
+    assert_eq!(
+        response.headers()["proxy-authenticate"],
+        "Basic realm=\"masque\", charset=\"UTF-8\""
+    );
+
+    client = client.ready().await.unwrap();
+    let mut request = connect_request(target_addr);
+    request.headers_mut().insert(
+        "proxy-authorization",
+        "Basic YWxpY2U6c2VjcmV0".parse().unwrap(),
+    );
+    let (response, mut request_body) = client.send_request(request, false).unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    request_body
+        .send_data(Bytes::from_static(b"x"), true)
+        .unwrap();
+    let mut response_body = response.into_body();
+    let echoed = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(&echoed[..], b"x");
+    response_body
+        .flow_control()
+        .release_capacity(echoed.len())
+        .unwrap();
+
+    target_task.await.unwrap();
+    server_task.abort();
+    driver.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_certificate_authenticates_http2_connection() {
+    let files = TestFiles::new();
+    let client_key = p256_key();
+    let client_cert = self_signed(&client_key);
+    let client_cert_path = files.directory.join("client.crt");
+    let client_key_path = files.directory.join("client.key");
+    std::fs::write(&client_cert_path, client_cert.to_pem().unwrap()).unwrap();
+    std::fs::write(
+        &client_key_path,
+        client_key.private_key_to_pem_pkcs8().unwrap(),
+    )
+    .unwrap();
+
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_task = tokio::spawn(async move {
+        let (mut stream, _) = target.accept().await.unwrap();
+        let mut byte = [0_u8; 1];
+        stream.read_exact(&mut byte).await.unwrap();
+        stream.write_all(&byte).await.unwrap();
+    });
+
+    let mut config = http2_config(&files);
+    config.listeners[0].auth.enabled = true;
+    config.listeners[0].auth.mode = AuthMode::ClientCert;
+    config.clients = vec![ClientEntry {
+        name: "h2-client".into(),
+        public_key: STANDARD.encode(client_key.public_key_to_der().unwrap()),
+        ipv4: None,
+        ipv6: None,
+    }];
+    let (server_addr, server_task) = spawn_http2_config(config).await;
+    let (mut client, driver) =
+        connect_h2_with_identity(server_addr, Some((&client_cert_path, &client_key_path))).await;
+
+    let (response, mut request_body) = client
+        .send_request(connect_request(target_addr), false)
+        .unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    request_body
+        .send_data(Bytes::from_static(b"c"), true)
+        .unwrap();
+    let mut response_body = response.into_body();
+    let echoed = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(&echoed[..], b"c");
+    response_body
+        .flow_control()
+        .release_capacity(echoed.len())
+        .unwrap();
+
+    target_task.await.unwrap();
+    server_task.abort();
+    driver.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connect_udp_relays_datagram_capsules_over_http2() {
+    let files = TestFiles::new();
+    let target = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_task = tokio::spawn(async move {
+        let mut buf = [0_u8; 256];
+        let (read, peer) = target.recv_from(&mut buf).await.unwrap();
+        target.send_to(&buf[..read], peer).await.unwrap();
+    });
+
+    let (server_addr, server_task) = spawn_http2_server(&files).await;
+    let (mut client, driver) = connect_h2(server_addr).await;
+    let uri = format!(
+        "https://localhost/.well-known/masque/udp/{}/{}/",
+        target_addr.ip(),
+        target_addr.port()
+    );
+    let mut request = Request::builder()
+        .method(Method::CONNECT)
+        .uri(uri)
+        .header("capsule-protocol", "?1")
+        .body(())
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(h2::ext::Protocol::from_static("connect-udp"));
+    let (response, mut request_body) = client.send_request(request, false).unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["capsule-protocol"], "?1");
+
+    let mut capsule = Vec::new();
+    encoder::encode_datagram_context_zero(b"udp over h2", &mut capsule);
+    request_body.send_data(Bytes::from(capsule), false).unwrap();
+
+    let mut response_body = response.into_body();
+    let data = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    response_body
+        .flow_control()
+        .release_capacity(data.len())
+        .unwrap();
+    let frames = CapsuleDecoder::new().decode(&data).unwrap();
+    assert_eq!(
+        frames,
+        vec![CapsuleFrame::Datagram(
+            [vec![0], b"udp over h2".to_vec()].concat()
+        )]
+    );
+
+    request_body.send_data(Bytes::new(), true).unwrap();
+    target_task.await.unwrap();
+    server_task.abort();
+    driver.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connect_ip_assigns_addresses_and_routes_over_http2_capsules() {
+    let files = TestFiles::new();
+    let mut config = http2_config(&files);
+    config.ip_proxy.enabled = true;
+    let (server_addr, server_task) = spawn_http2_config(config).await;
+    let (mut client, driver) = connect_h2(server_addr).await;
+
+    // Exercise the identifier used by Cloudflare-compatible clients; the
+    // registered `connect-ip` identifier is covered by request unit tests.
+    let request = connect_ip_request("cf-connect-ip");
+    let (response, mut request_body) = client.send_request(request, false).unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.headers()["capsule-protocol"], "?1");
+    let (frames, _response_body) = read_connect_ip_setup(response).await;
+
+    let CapsuleFrame::AddressAssign(addresses) = &frames[0] else {
+        panic!("first setup capsule was not ADDRESS_ASSIGN");
+    };
+    assert!(
+        addresses
+            .iter()
+            .any(|address| matches!(address.ip, IpAddress::V4(_)))
+    );
+    assert!(
+        addresses
+            .iter()
+            .any(|address| matches!(address.ip, IpAddress::V6(_)))
+    );
+    let CapsuleFrame::RouteAdvertisement(routes) = &frames[1] else {
+        panic!("second setup capsule was not ROUTE_ADVERTISEMENT");
+    };
+    assert_eq!(routes.len(), 2);
+
+    request_body.send_data(Bytes::new(), true).unwrap();
+    server_task.abort();
+    driver.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_certificate_pins_http2_connect_ip_addresses() {
+    let files = TestFiles::new();
+    let client_key = p256_key();
+    let client_cert = self_signed(&client_key);
+    let client_cert_path = files.directory.join("ip-client.crt");
+    let client_key_path = files.directory.join("ip-client.key");
+    std::fs::write(&client_cert_path, client_cert.to_pem().unwrap()).unwrap();
+    std::fs::write(
+        &client_key_path,
+        client_key.private_key_to_pem_pkcs8().unwrap(),
+    )
+    .unwrap();
+
+    let ipv4: std::net::Ipv4Addr = "10.89.0.44".parse().unwrap();
+    let ipv6: std::net::Ipv6Addr = "fd00:abcd::44".parse().unwrap();
+    let mut config = http2_config(&files);
+    config.ip_proxy.enabled = true;
+    config.listeners[0].auth.enabled = true;
+    config.listeners[0].auth.mode = AuthMode::ClientCert;
+    config.clients = vec![ClientEntry {
+        name: "h2-ip-client".into(),
+        public_key: STANDARD.encode(client_key.public_key_to_der().unwrap()),
+        ipv4: Some(ipv4.to_string()),
+        ipv6: Some(ipv6.to_string()),
+    }];
+
+    let (server_addr, server_task) = spawn_http2_config(config).await;
+    let (mut client, driver) =
+        connect_h2_with_identity(server_addr, Some((&client_cert_path, &client_key_path))).await;
+    let (response, mut request_body) = client
+        .send_request(cloudflare_h2_connect_ip_request(), false)
+        .unwrap();
+    let response = response.await.unwrap();
+    assert!(!response.headers().contains_key("capsule-protocol"));
+    let (frames, mut response_body) = read_connect_ip_setup(response).await;
+    let CapsuleFrame::AddressAssign(addresses) = &frames[0] else {
+        panic!("first setup capsule was not ADDRESS_ASSIGN");
+    };
+    assert!(
+        addresses
+            .iter()
+            .any(|address| address.ip == IpAddress::V4(ipv4))
+    );
+    assert!(
+        addresses
+            .iter()
+            .any(|address| address.ip == IpAddress::V6(ipv6))
+    );
+    assert_eq!(addresses.len(), 2);
+
+    // usque's HTTP/2 dialect removes Context ID zero from the DATAGRAM capsule
+    // value. A standard-mode decoder would reject this one-byte payload before
+    // the stream can close cleanly.
+    let mut legacy_capsule = Vec::new();
+    encoder::encode_datagram(&[0x45], &mut legacy_capsule);
+    // Packetized CONNECT-IP legitimately produces many small DATA frames (TCP
+    // ACK packets are a common example). Send enough in one burst to exceed
+    // h2's generic HTTP framing budget and prove the transport-specific budget
+    // remains effective. The one-byte payload is intentionally not a complete
+    // IP packet; the server consumes and drops it after decoding the capsule.
+    for _ in 0..512 {
+        request_body
+            .send_data(Bytes::copy_from_slice(&legacy_capsule), false)
+            .unwrap();
+    }
+    request_body.send_data(Bytes::new(), true).unwrap();
+    let end = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+        .await
+        .unwrap();
+    if let Some(data) = end {
+        assert!(data.unwrap().is_empty());
+        let end = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+            .await
+            .unwrap();
+        assert!(end.is_none(), "legacy CONNECT-IP stream was reset");
+    }
+    server_task.abort();
+    driver.abort();
+}

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -199,9 +199,9 @@ grep -q '^\[\[clients\]\]$' "$CONFIG_PATH" ||
 # The server itself must agree about what those listeners are.
 "$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/dual-check.log" 2>&1 ||
     die "the dual configuration failed check-config"
-grep -q '^listener 0.0.0.0:8449 auth=basic shards=1$' "$TEST_TMP/dual-check.log" ||
+grep -q '^listener 0.0.0.0:8449 transport=http3 auth=basic shards=1$' "$TEST_TMP/dual-check.log" ||
     die "the Basic listener was not reported by check-config"
-grep -q '^listener 0.0.0.0:8450 auth=client_cert shards=1$' "$TEST_TMP/dual-check.log" ||
+grep -q '^listener 0.0.0.0:8450 transport=http3 auth=client_cert shards=1$' "$TEST_TMP/dual-check.log" ||
     die "the certificate listener was not reported by check-config"
 # The installed binary must be able to add a third listener to the file the
 # installer wrote, in place, without an operator editing TOML.
@@ -222,7 +222,7 @@ grep -q '^\[quic\]$' "$CONFIG_PATH" ||
     die "add-listener changed the configuration file's owner or mode"
 "$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/added-check.log" 2>&1 ||
     die "the configuration failed check-config after add-listener"
-grep -q '^listener 0.0.0.0:8451 auth=client_cert shards=1$' "$TEST_TMP/added-check.log" ||
+grep -q '^listener 0.0.0.0:8451 transport=http3 auth=client_cert shards=1$' "$TEST_TMP/added-check.log" ||
     die "the added listener was not reported by check-config"
 
 printf '\n# private-upgrade-log-marker\n' >>"$CONFIG_PATH"
@@ -240,7 +240,7 @@ assert_sha_unchanged "$CONFIG_PATH" "$added_config_sha"
 assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
 assert_upgrade_output_is_summary_only "$TEST_TMP/dual-upgrade.log"
-grep -q '^listener 0.0.0.0:8451 auth=client_cert shards=1$' "$TEST_TMP/dual-upgrade.log" ||
+grep -q '^listener 0.0.0.0:8451 transport=http3 auth=client_cert shards=1$' "$TEST_TMP/dual-upgrade.log" ||
     die "the upgrade summary did not report the added listener"
 grep -q 'add-listener' "$TEST_TMP/dual-upgrade.log" ||
     die "the upgrade summary did not name the command that adds a listener"


### PR DESCRIPTION
## Summary

- add HTTP/2 listeners for CONNECT, CONNECT-UDP, and CONNECT-IP
- support both standards-based capsules and the Cloudflare/usque HTTP/2 dialect
- preserve listener-scoped authentication, policy, observability, enrollment, and deployment workflows
- prepare package metadata and changelog for v0.7.0

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --locked`
- `cargo test --workspace --locked`
- `cargo test --workspace --release --locked`
- `shellcheck install-latest.sh deploy/install.sh scripts/*.sh tests/*.sh tests/e2e/*.sh`
- `scripts/validate-release.sh v0.7.0`
- official usque v4.2.1 interoperability over IPv4 and IPv6 CONNECT-IP on Linux TUN
- repeated 192 MiB transfer over one HTTP/2 connection with matching checksums
- HTTP/3 throughput regression check