### PR TITLE
feat: add adaptive Retry and transport verification

### DIFF
--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -1,0 +1,78 @@
+name: Scheduled verification
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-verification
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  linux-network:
+    name: Linux E2E and transport smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal
+          rustup default 1.97.1
+
+      - name: Install native tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang cmake openssl
+
+      - name: Restore Cargo cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: scheduled-${{ runner.os }}-1.97.1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            scheduled-${{ runner.os }}-1.97.1-
+
+      - name: Run Docker CONNECT-IP E2E
+        run: scripts/e2e-test.sh
+
+      - name: Exercise HTTP/2, HTTP/3, and QUIC Retry
+        env:
+          MASQUE_BENCH_MODE: smoke
+          MASQUE_BENCH_TRANSPORT: both
+          MASQUE_BENCH_QUIC_RETRY: always
+        run: scripts/network-bench.sh
+
+  parser-fuzz:
+    name: Protocol parser fuzz smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install nightly Rust
+        run: rustup toolchain install nightly --profile minimal
+
+      - name: Install native tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang cmake
+
+      - name: Install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz --version 0.13.2 --locked
+
+      - name: Fuzz public protocol parsers
+        run: cargo +nightly fuzz run protocol_parsers -- -max_total_time=180

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /dist
 certs/
+/fuzz/artifacts
+/fuzz/corpus
+/fuzz/target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ pre-1.0.
 
 ## Unreleased
 
+### Added
+
+- The network benchmark can drive HTTP/2 and HTTP/3 with the same TCP origin,
+  UDP echo target, authentication, payload sizes, flow-control windows, direct
+  baselines, and machine-readable result fields. `MASQUE_BENCH_TRANSPORT=both`
+  runs the transports sequentially against TCP and UDP listeners sharing one
+  numeric address.
+- Adaptive QUIC Retry validates source addresses before allocating connection
+  state once a shard reaches its configured threshold; `always` and `off`
+  policies are available for hardened deployments and controlled comparisons.
+- HTTP/2 and HTTP/3 share process-wide per-source limits for live connections
+  and queued or running Basic credential checks. Prometheus distinguishes
+  source-limit rejections and QUIC Retry outcomes.
+- A scheduled Linux workflow runs CONNECT-IP Docker E2E, dual-transport smoke
+  tests with QUIC Retry forced on, and bounded fuzzing of public protocol
+  parsers without adding those expensive jobs to every commit.
+
+### Fixed
+
+- Cross-shard QUIC migration now looks up the server-issued destination CID
+  directly before considering an Initial-derived CID, so an established packet
+  that moves to another `SO_REUSEPORT` socket reaches its owner.
+
 ## 0.7.0 - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ a staging environment.
 - Multiple listeners in one process, each with its own Basic or client-certificate
   authentication mode while sharing proxy policies, client roster, and TUN state
 - CIDR allow and deny policies for TCP and UDP targets
+- Adaptive QUIC Retry plus process-wide per-source connection and Basic-auth
+  admission limits
 - Bounded queues and backpressure across authentication and tunnel I/O
 - Linux `recvmmsg`/`sendmmsg`, UDP GRO, optional UDP GSO, and TUN offload
 - Multi-core sharding with `SO_REUSEPORT`
@@ -170,6 +172,7 @@ src/                    Server library and CLI
 tools/masque-e2e/       E2E client and load generator
 tests/e2e/              Docker E2E environment and fixtures
 benches/                In-process microbenchmarks
+fuzz/                   Scheduled libFuzzer targets for public protocol parsers
 deploy/                 Example config, installer, systemd unit, and monitoring assets
 docs/                   Operator and contributor documentation
 scripts/                Test, benchmark, certificate, and packaging helpers

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -4,6 +4,10 @@
 # its own keepalive against the timeout.
 idle_timeout_secs = 60
 max_connections = 10000
+# Shared by HTTP/2 and HTTP/3. IPv4-mapped IPv6 addresses use the IPv4 count.
+max_connections_per_ip = 64
+# Running plus queued Basic/Argon2 checks one source may occupy process-wide.
+max_pending_auth_per_ip = 8
 max_tunnels_per_connection = 100
 
 # Optional loopback-only operational endpoint. Uncomment to expose health,
@@ -109,6 +113,14 @@ dgram_send_queue_len = 2048
 # Path MTU discovery probes stop at max_datagram_size, so enabling this only
 # helps if that value is also raised (e.g. to 1500 on a path known to carry it).
 discover_pmtu = false
+
+# "adaptive" adds no handshake RTT at low load, then validates source
+# addresses statelessly before allocating new QUIC connection state.
+# "always" validates every new connection; "off" is intended for trusted
+# networks and controlled latency comparisons only.
+retry_mode = "adaptive"
+retry_connection_threshold = 64
+retry_token_ttl_secs = 30
 
 [tcp_proxy]
 enabled = true

--- a/deploy/monitoring/prometheus-rules.yml
+++ b/deploy/monitoring/prometheus-rules.yml
@@ -13,7 +13,7 @@ groups:
             minutes. Check systemd state and the service journal.
 
       - alert: MasqueConnectionLimitReached
-        expr: increase(masque_connections_rejected_total{reason="limit"}[5m]) > 0
+        expr: increase(masque_connections_rejected_total[5m]) > 0
         for: 1m
         labels:
           severity: warning

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,8 @@ bounded drain begins. The packaged watchdog uses the same liveness decision.
 | `src/server/http2/support.rs` | Shared H2 flow-control, activity, and metrics lifecycle helpers |
 | `src/server/request.rs` | CONNECT classification, auth precheck, and authorized dispatch |
 | `src/server/authentication.rs` | Bounded Argon2 scheduling, cancellation, and request resumption |
+| `src/server/retry.rs` | Authenticated QUIC Retry token encoding and admission policy |
+| `src/admission.rs` | Process-wide per-source connection and authentication guards |
 | `src/connection.rs` | Per-client QUIC/H3 state and deferred sends |
 | `src/metrics.rs` | Low-cardinality atomic counters and Prometheus rendering |
 | `src/observability.rs` | Bounded loopback health/readiness/metrics HTTP endpoint |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,8 @@ default; `--log-format json` emits newline-delimited structured JSON.
 [server]
 idle_timeout_secs = 60
 max_connections = 10000
+max_connections_per_ip = 64
+max_pending_auth_per_ip = 8
 max_tunnels_per_connection = 100
 ```
 
@@ -66,6 +68,8 @@ max_tunnels_per_connection = 100
 | --- | --- |
 | `idle_timeout_secs` | Inactive tunnel lifetime |
 | `max_connections` | Per-HTTP/3-shard or per-HTTP/2-listener connection cap |
+| `max_connections_per_ip` | Process-wide live H2 + H3 connections from one source IP |
+| `max_pending_auth_per_ip` | Process-wide running + queued Basic/Argon2 checks from one source; `1..256` |
 | `max_tunnels_per_connection` | CONNECT streams retained per connection |
 
 This section contains process-wide connection limits only. Socket addresses and
@@ -549,6 +553,9 @@ max_stream_window = 16777216
 dgram_recv_queue_len = 2048
 dgram_send_queue_len = 2048
 discover_pmtu = false
+retry_mode = "adaptive"
+retry_connection_threshold = 64
+retry_token_ttl_secs = 30
 ```
 
 Important relationships:
@@ -562,6 +569,15 @@ Important relationships:
 - Supported congestion controllers are `cubic`, `reno`, and `bbr2`. CUBIC is
   the current default because the server's deferred-send behavior penalizes
   BBR2's fine-grained pacing.
+- `retry_mode = "adaptive"` accepts tokenless Initial packets below
+  `retry_connection_threshold`, avoiding an extra low-load round trip. At or
+  above the per-shard threshold, the server sends a stateless, authenticated
+  Retry token before allocating connection state. `always` validates every
+  source address; `off` is appropriate only for trusted networks or controlled
+  comparisons. Tokens expire after `retry_token_ttl_secs` (`1..300`), are
+  listener-bound, and tolerate source-port changes behind NAT.
+  A threshold above `server.max_connections` is valid: the smaller connection
+  cap then bounds state before adaptive Retry would activate.
 
 Queue depths trade memory and latency for burst tolerance. QUIC DATAGRAM frames
 are not retransmitted; a full queue drops traffic.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -98,6 +98,7 @@ All metric names start with `masque_`.
 | `masque_connections_active` | gauge | `listener`, `transport`, `auth` | Live HTTP transport connections |
 | `masque_connections_accepted_total` | counter | `listener`, `transport`, `auth` | Accepted connection objects |
 | `masque_connections_rejected_total` | counter | `listener`, `transport`, `auth`, `reason` | Connections rejected at a resource limit |
+| `masque_quic_retries_total` | counter | `listener`, `transport`, `auth`, `result` | Retry packets sent or invalid Retry tokens received |
 | `masque_quic_receive_batches_total` | counter | `listener`, `transport`, `auth` | Non-empty HTTP/3 network receive batches |
 | `masque_quic_receive_packets_total` | counter | `listener`, `transport`, `auth` | Received HTTP/3 QUIC UDP datagrams |
 | `masque_quic_receive_bytes_total` | counter | `listener`, `transport`, `auth` | Received HTTP/3 QUIC UDP bytes |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -26,10 +26,14 @@ head-of-line blocking and nested loss recovery that HTTP/3 DATAGRAM avoids.
 Treat HTTP/2 as a reachability fallback, not as a replacement for HTTP/3 in
 performance comparisons.
 
-The current network benchmark drives HTTP/3. HTTP/2 is covered by real TLS/H2
-relay integration tests, but no HTTP/2 throughput number should be compared to
-the network benchmark until the same harness can drive both transports with
-the same targets, payloads, windows, and CPU placement.
+The network benchmark drives either transport with the same direct targets,
+credentials, payload sizes, windows, expiry rules, and result fields. Use
+`MASQUE_BENCH_TRANSPORT=both` to run HTTP/3 and HTTP/2 sequentially against two
+listeners sharing one numeric address. It still does not make the transports
+semantically identical: HTTP/2 DATAGRAM capsules are reliable and ordered,
+while HTTP/3 DATAGRAM frames are not. Compare reachability cost, application
+goodput, CPU, latency, and response shortfall rather than treating the result as
+a claim that the wire protocols have equal behavior.
 
 ## Linux fast paths
 
@@ -120,6 +124,7 @@ Useful controls include:
 
 ```sh
 MASQUE_BENCH_MODE=udp \
+MASQUE_BENCH_TRANSPORT=both \
 MASQUE_BENCH_DURATION_SECS=10 \
 MASQUE_BENCH_WINDOW=256 \
 MASQUE_BENCH_EXPIRY_MS=1000 \
@@ -136,6 +141,17 @@ scripts/network-bench.sh
 supporting processes needed by that measurement. `MASQUE_BENCH_SHARDS`
 selects the listener shard count; `0` retains the server's documented
 one-shard-per-core behavior.
+
+`MASQUE_BENCH_TRANSPORT` accepts `http3` (the default), `http2`, or `both` for
+the smoke, TCP, and UDP modes. `both` binds TCP and UDP on the same address and
+runs HTTP/3 first, then HTTP/2. It requires an explicit non-zero HTTP/3 shard
+count. Multi-connection `load` mode remains HTTP/3-only until its native-thread
+packet engine has an equivalent asynchronous HTTP/2 implementation.
+
+UDP runs emit one `UDP_RESULT` record per payload and path. TCP runs include a
+`transport` field in every `TCP_DOWNLOAD_RESULT` and `TCP_DOWNLOAD_SUMMARY`, so
+automation does not have to infer which listener produced a number from output
+order.
 
 For a repeatable multi-connection run:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,7 +26,8 @@ prechecks.
 
 Argon2 work runs outside shard event loops. Running plus queued verifications
 are globally bounded, concurrent hashes are permit-limited, and each
-connection has a pending-request cap. Closing a stream or connection cancels
+connection has a pending-request cap. A per-source fair-share cap prevents one
+address from filling the global queue. Closing a stream or connection cancels
 work that has not started and discards results for work already running.
 
 Use a unique, high-entropy password. Basic credentials are protected by QUIC
@@ -67,6 +68,14 @@ buffer limits prevent application-level unbounded growth. These bounds do not
 replace host controls. Apply reasonable systemd limits, provider firewall rate
 limits, and monitoring for memory, CPU, file descriptors, authentication
 failures, connections, and datagram drops.
+
+HTTP/2 and HTTP/3 share a process-wide live-connection cap per canonical source
+IP. HTTP/3 additionally uses authenticated QUIC Retry tokens adaptively: once a
+shard reaches the configured threshold, a new source must prove it can receive
+at its claimed address before the server allocates connection state. The token
+binds the source IP and listener but not the source port, so normal NAT remaps
+do not break it. Use `retry_mode = "always"` where spoofed floods are a primary
+risk; it costs one extra handshake round trip.
 
 The optional operational endpoint has no authentication and therefore accepts
 only loopback addresses. It must stay host-local: use a local collector or a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,7 @@
 | Config preflight | `cargo test --test check_config` | `check-config` accepts what a server accepts, including multi-listener files |
 | Config editing | `cargo test --test add_listener` | `add-listener` writes a listener that starts, or leaves the file untouched |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
+| Parser fuzzing | `cargo +nightly fuzz run protocol_parsers` | Incremental capsule, datagram, varint, IP, and URI parser safety |
 
 ## Local tests
 
@@ -57,6 +58,25 @@ Run several repetitions and preserve the direct UDP baseline. When changing
 batching, readiness, pacing, flow control, or buffers, test both 64-byte and
 1200-byte payloads. Use multiple connections for shard tests.
 
+Select one transport or run the directly comparable sequence with:
+
+```sh
+MASQUE_BENCH_MODE=udp \
+MASQUE_BENCH_TRANSPORT=both \
+MASQUE_BENCH_DURATION_SECS=10 \
+scripts/network-bench.sh
+```
+
+The `smoke`, `tcp`, and `udp` modes support `http2`, `http3`, and `both`.
+Multi-connection `load` mode is currently HTTP/3-only. Machine consumers should
+read `UDP_RESULT`, `TCP_DOWNLOAD_RESULT`, and `TCP_DOWNLOAD_SUMMARY` and retain
+their explicit `transport` field.
+
+HTTP/3 uses the production `adaptive` Retry policy by default. Set
+`MASQUE_BENCH_QUIC_RETRY=always` to exercise address validation on every
+benchmark connection; use `off` only for a controlled handshake-latency
+comparison.
+
 CONNECT-TCP runs include an alternating direct-origin sample by default and
 print `TCP_DOWNLOAD_SUMMARY` with both medians. Useful controls are:
 
@@ -88,6 +108,18 @@ keeps payload, duration, window, expiry, shards, CPU placement, and offload
 settings fixed, and compares both goodput and response shortfall.
 
 See [Performance](performance.md) for methodology and reporting requirements.
+
+## Scheduled verification
+
+The weekly and manually dispatchable `Scheduled verification` workflow keeps
+the expensive checks off ordinary commits. It runs the Docker CONNECT-IP E2E,
+an HTTP/2 + HTTP/3 smoke test with QUIC Retry forced on, and a bounded parser
+fuzz session. A longer local parser run is:
+
+```sh
+cargo +nightly install cargo-fuzz --version 0.13.2 --locked
+cargo +nightly fuzz run protocol_parsers -- -max_total_time=3600
+```
 
 ## Linux-specific checks
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,11 +228,13 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -386,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encoding_rs"
@@ -690,6 +698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +728,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -753,26 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "masque-e2e"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64",
- "boring",
- "bytes",
- "h2",
- "http",
- "libc",
- "masque-server",
- "quiche",
- "ring",
- "tokio",
- "tokio-boring",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "masque-server"
 version = "0.7.0"
 dependencies = [
@@ -789,7 +797,6 @@ dependencies = [
  "quiche",
  "ring",
  "serde",
- "serde_json",
  "subtle",
  "thiserror",
  "tokio",
@@ -799,6 +806,14 @@ dependencies = [
  "tracing-subscriber",
  "tun-rs",
  "zeroize",
+]
+
+[[package]]
+name = "masque-server-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "masque-server",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "masque-server-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4.13"
+masque-server = { path = ".." }
+
+[[bin]]
+name = "protocol_parsers"
+path = "fuzz_targets/protocol_parsers.rs"
+test = false
+doc = false
+bench = false
+
+[workspace]
+members = ["."]

--- a/fuzz/fuzz_targets/protocol_parsers.rs
+++ b/fuzz/fuzz_targets/protocol_parsers.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use masque::capsule::decoder::CapsuleDecoder;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = masque::varint::decode(data);
+    let _ = masque::datagram::decode_ref(data);
+    let _ = masque::ip_packet::parse(data);
+    let _ = masque::ip_packet::src_addr(data);
+    let _ = masque::ip_packet::dst_addr(data);
+
+    // Exercise the incremental state machine across different split points,
+    // not only the one-shot parser path.
+    let chunk_size = data
+        .first()
+        .map_or(1, |byte| usize::from(*byte % 32) + 1);
+    let mut capsules = CapsuleDecoder::with_max_capsule_size(64 * 1024);
+    for chunk in data.chunks(chunk_size) {
+        if capsules.decode(chunk).is_err() {
+            break;
+        }
+    }
+
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = masque::uri::parse_connect_authority(text);
+        let _ = masque::uri::parse_udp_path(
+            text,
+            "/.well-known/masque/udp/{target_host}/{target_port}/",
+        );
+        let _ = masque::uri::parse_ip_path(
+            text,
+            "/.well-known/masque/ip/{target}/{ipproto}/",
+        );
+    }
+});

--- a/scripts/network-bench.sh
+++ b/scripts/network-bench.sh
@@ -12,6 +12,8 @@ TCP_DOWNLOAD_REPEATS="${MASQUE_TCP_DOWNLOAD_REPEATS:-2}"
 TCP_DIRECT_BASELINE="${MASQUE_TCP_DIRECT_BASELINE:-1}"
 BENCH_MODE="${MASQUE_BENCH_MODE:-all}"
 BENCH_SHARDS="${MASQUE_BENCH_SHARDS:-1}"
+BENCH_TRANSPORT="${MASQUE_BENCH_TRANSPORT:-http3}"
+BENCH_QUIC_RETRY="${MASQUE_BENCH_QUIC_RETRY:-adaptive}"
 LOAD_CONNS="${MASQUE_LOAD_CONNS:-}"
 
 cleanup() {
@@ -39,12 +41,40 @@ case "$BENCH_MODE" in
         ;;
 esac
 
+case "$BENCH_TRANSPORT" in
+    http2) BENCH_TRANSPORTS="http2" ;;
+    http3) BENCH_TRANSPORTS="http3" ;;
+    both) BENCH_TRANSPORTS="http3 http2" ;;
+    *)
+        echo "MASQUE_BENCH_TRANSPORT must be http2, http3, or both" >&2
+        exit 2
+        ;;
+esac
+
+case "$BENCH_QUIC_RETRY" in
+    adaptive|always|off) ;;
+    *)
+        echo "MASQUE_BENCH_QUIC_RETRY must be adaptive, always, or off" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$BENCH_MODE" = load ] && [ "$BENCH_TRANSPORT" != http3 ]; then
+    echo "MASQUE_BENCH_MODE=load currently requires MASQUE_BENCH_TRANSPORT=http3" >&2
+    exit 2
+fi
+
 case "$BENCH_SHARDS" in
     ''|*[!0-9]*)
         echo "MASQUE_BENCH_SHARDS must be a non-negative integer" >&2
         exit 2
         ;;
 esac
+
+if [ "$BENCH_TRANSPORT" = both ] && [ "$BENCH_SHARDS" = 0 ]; then
+    echo "MASQUE_BENCH_SHARDS=0 is ambiguous with two listeners; choose an explicit HTTP/3 shard count" >&2
+    exit 2
+fi
 
 case "$LOAD_CONNS" in
     ''|0) ;;
@@ -91,19 +121,11 @@ idle_timeout_secs = 30
 cert_path = "$BENCH_DIR/certs/server.crt"
 key_path = "$BENCH_DIR/certs/server.key"
 
-[[listeners]]
-listen_addr = "127.0.0.1:4433"
-shards = $BENCH_SHARDS
-
-[listeners.auth]
-enabled = true
-username = "test"
-password_hash = "\$argon2id\$v=19\$m=19456,t=2,p=1\$1xNVXhqKU7jJ6cqTBJKphQ\$GXXAINVTW1qhloFtN1IR8lSr7pI7QEY79fq4K6d8scQ"
-
 [quic]
 max_datagram_size = 1350
 enable_dgram = true
 enable_udp_gso = $QUIC_GSO_TOML
+retry_mode = "$BENCH_QUIC_RETRY"
 
 [tcp_proxy]
 enabled = true
@@ -119,6 +141,37 @@ deny_targets = []
 [ip_proxy]
 enabled = false
 EOF
+
+
+if [ "$BENCH_TRANSPORT" = http3 ] || [ "$BENCH_TRANSPORT" = both ]; then
+    cat >>"$BENCH_DIR/masque.toml" <<EOF
+
+[[listeners]]
+listen_addr = "127.0.0.1:4433"
+transport = "http3"
+shards = $BENCH_SHARDS
+
+[listeners.auth]
+enabled = true
+username = "test"
+password_hash = "\$argon2id\$v=19\$m=19456,t=2,p=1\$1xNVXhqKU7jJ6cqTBJKphQ\$GXXAINVTW1qhloFtN1IR8lSr7pI7QEY79fq4K6d8scQ"
+EOF
+fi
+
+if [ "$BENCH_TRANSPORT" = http2 ] || [ "$BENCH_TRANSPORT" = both ]; then
+    cat >>"$BENCH_DIR/masque.toml" <<'EOF'
+
+[[listeners]]
+listen_addr = "127.0.0.1:4433"
+transport = "http2"
+shards = 1
+
+[listeners.auth]
+enabled = true
+username = "test"
+password_hash = "$argon2id$v=19$m=19456,t=2,p=1$1xNVXhqKU7jJ6cqTBJKphQ$GXXAINVTW1qhloFtN1IR8lSr7pI7QEY79fq4K6d8scQ"
+EOF
+fi
 
 case "${MASQUE_BENCH_OBSERVABILITY:-0}" in
     0) ;;
@@ -161,45 +214,64 @@ SERVER_PID=$!
 
 case "$BENCH_MODE" in
     all|smoke)
-        MASQUE_AUTH_CHECK=1 \
-        MASQUE_SERVER_ADDR=127.0.0.1:4433 \
-        ECHO_SERVER_ADDR=127.0.0.1:9999 \
-        RUST_LOG=warn \
-        target/release/masque-e2e
+        for transport in $BENCH_TRANSPORTS; do
+            MASQUE_AUTH_CHECK=1 \
+            MASQUE_BENCH_TRANSPORT="$transport" \
+            MASQUE_SERVER_ADDR=127.0.0.1:4433 \
+            ECHO_SERVER_ADDR=127.0.0.1:9999 \
+            RUST_LOG=warn \
+            target/release/masque-e2e
 
-        MASQUE_TCP_CHECK=1 \
-        MASQUE_SERVER_ADDR=127.0.0.1:4433 \
-        ECHO_SERVER_ADDR=127.0.0.1:9999 \
-        MASQUE_USERNAME=test \
-        MASQUE_PASSWORD=test-password \
-        RUST_LOG=warn \
-        target/release/masque-e2e
+            MASQUE_TCP_CHECK=1 \
+            MASQUE_BENCH_TRANSPORT="$transport" \
+            MASQUE_SERVER_ADDR=127.0.0.1:4433 \
+            ECHO_SERVER_ADDR=127.0.0.1:9999 \
+            MASQUE_USERNAME=test \
+            MASQUE_PASSWORD=test-password \
+            RUST_LOG=warn \
+            target/release/masque-e2e
+
+            MASQUE_UDP_CHECK=1 \
+            MASQUE_BENCH_TRANSPORT="$transport" \
+            MASQUE_SERVER_ADDR=127.0.0.1:4433 \
+            ECHO_SERVER_ADDR=127.0.0.1:9999 \
+            MASQUE_USERNAME=test \
+            MASQUE_PASSWORD=test-password \
+            RUST_LOG=warn \
+            target/release/masque-e2e
+        done
         ;;
 esac
 
 case "$BENCH_MODE" in
     all|tcp)
-        MASQUE_TCP_DOWNLOAD=1 \
-        MASQUE_SERVER_ADDR=127.0.0.1:4433 \
-        MASQUE_TCP_TARGET=127.0.0.1:9998 \
-        MASQUE_TCP_DOWNLOAD_BYTES="$TCP_DOWNLOAD_BYTES" \
-        MASQUE_TCP_DOWNLOAD_REPEATS="$TCP_DOWNLOAD_REPEATS" \
-        MASQUE_USERNAME=test \
-        MASQUE_PASSWORD=test-password \
-        RUST_LOG=warn \
-        target/release/masque-e2e
+        for transport in $BENCH_TRANSPORTS; do
+            MASQUE_TCP_DOWNLOAD=1 \
+            MASQUE_BENCH_TRANSPORT="$transport" \
+            MASQUE_SERVER_ADDR=127.0.0.1:4433 \
+            MASQUE_TCP_TARGET=127.0.0.1:9998 \
+            MASQUE_TCP_DOWNLOAD_BYTES="$TCP_DOWNLOAD_BYTES" \
+            MASQUE_TCP_DOWNLOAD_REPEATS="$TCP_DOWNLOAD_REPEATS" \
+            MASQUE_USERNAME=test \
+            MASQUE_PASSWORD=test-password \
+            RUST_LOG=warn \
+            target/release/masque-e2e
+        done
         ;;
 esac
 
 case "$BENCH_MODE" in
     all|udp)
-        MASQUE_BENCH=1 \
-        MASQUE_SERVER_ADDR=127.0.0.1:4433 \
-        ECHO_SERVER_ADDR=127.0.0.1:9999 \
-        MASQUE_USERNAME=test \
-        MASQUE_PASSWORD=test-password \
-        RUST_LOG=warn \
-        target/release/masque-e2e
+        for transport in $BENCH_TRANSPORTS; do
+            MASQUE_BENCH=1 \
+            MASQUE_BENCH_TRANSPORT="$transport" \
+            MASQUE_SERVER_ADDR=127.0.0.1:4433 \
+            ECHO_SERVER_ADDR=127.0.0.1:9999 \
+            MASQUE_USERNAME=test \
+            MASQUE_PASSWORD=test-password \
+            RUST_LOG=warn \
+            target/release/masque-e2e
+        done
         ;;
 esac
 
@@ -208,6 +280,7 @@ if [ "$BENCH_MODE" = load ] || {
 }; then
     MASQUE_LOAD=1 \
     MASQUE_LOAD_CONNS="${LOAD_CONNS:-32}" \
+    MASQUE_BENCH_TRANSPORT=http3 \
     MASQUE_SERVER_ADDR=127.0.0.1:4433 \
     ECHO_SERVER_ADDR=127.0.0.1:9999 \
     MASQUE_USERNAME=test \

--- a/src/admission.rs
+++ b/src/admission.rs
@@ -1,0 +1,123 @@
+//! Process-wide source admission for transport connections.
+//!
+//! One source may legitimately use several HTTP/2 and HTTP/3 connections, but
+//! it must not be able to consume the entire process-wide connection budget.
+//! The table is bounded by live admissions: every key owns at least one guard,
+//! and every guard is released when its connection task or QUIC state drops.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+
+struct Inner {
+    max_per_ip: usize,
+    // Source addresses are attacker-influenced, so retain HashMap's randomized
+    // hashing rather than using the packet-path FxHashMap here.
+    counts: Mutex<HashMap<IpAddr, usize>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SourceAdmissionLimiter {
+    inner: Arc<Inner>,
+}
+
+impl SourceAdmissionLimiter {
+    pub(crate) fn new(max_per_ip: usize) -> Self {
+        debug_assert!(max_per_ip > 0);
+        Self {
+            inner: Arc::new(Inner {
+                max_per_ip,
+                counts: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    pub(crate) fn try_acquire(&self, source: IpAddr) -> Option<SourceAdmission> {
+        let source = canonical_ip(source);
+        let mut counts = self
+            .inner
+            .counts
+            .lock()
+            .expect("source admissions poisoned");
+        let count = counts.entry(source).or_default();
+        if *count >= self.inner.max_per_ip {
+            return None;
+        }
+        *count += 1;
+        Some(SourceAdmission {
+            source,
+            inner: Arc::clone(&self.inner),
+        })
+    }
+}
+
+pub(crate) struct SourceAdmission {
+    source: IpAddr,
+    inner: Arc<Inner>,
+}
+
+impl SourceAdmission {
+    pub(crate) fn source(&self) -> IpAddr {
+        self.source
+    }
+}
+
+impl Drop for SourceAdmission {
+    fn drop(&mut self) {
+        let mut counts = self
+            .inner
+            .counts
+            .lock()
+            .expect("source admissions poisoned");
+        let Some(count) = counts.get_mut(&self.source) else {
+            debug_assert!(false, "live source admission has no counter");
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            counts.remove(&self.source);
+        }
+    }
+}
+
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(ip) => ip
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(ip)),
+        ip => ip,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_source_is_bounded_and_release_restores_capacity() {
+        let limiter = SourceAdmissionLimiter::new(2);
+        let first = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+        let second = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+        assert!(limiter.try_acquire("192.0.2.1".parse().unwrap()).is_none());
+
+        drop(first);
+        assert!(limiter.try_acquire("192.0.2.1".parse().unwrap()).is_some());
+        drop(second);
+    }
+
+    #[test]
+    fn independent_sources_do_not_share_a_limit() {
+        let limiter = SourceAdmissionLimiter::new(1);
+        let _first = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+        let _second = limiter.try_acquire("192.0.2.2".parse().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_uses_the_ipv4_counter() {
+        let limiter = SourceAdmissionLimiter::new(1);
+        let _first = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+        let mapped = "::ffff:192.0.2.1".parse::<IpAddr>().unwrap();
+        assert!(limiter.try_acquire(mapped).is_none());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,12 @@ pub struct ServerConfig {
 pub struct ServerSection {
     pub idle_timeout_secs: u64,
     pub max_connections: usize,
+    /// Process-wide cap for live HTTP/2 and HTTP/3 connections admitted from
+    /// one canonical source IP address.
+    pub max_connections_per_ip: usize,
+    /// Basic-auth requests from one source that may be running or waiting for
+    /// Argon2 verification across every listener and transport.
+    pub max_pending_auth_per_ip: usize,
     pub max_tunnels_per_connection: usize,
 }
 
@@ -82,6 +88,22 @@ pub enum ListenerTransport {
     #[default]
     Http3,
     Http2,
+}
+
+/// When an HTTP/3 listener validates a client's address before allocating
+/// connection state.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuicRetryMode {
+    /// Accept tokenless Initial packets until the configured live-state
+    /// threshold is reached, then require a valid Retry token.
+    #[default]
+    Adaptive,
+    /// Always allocate immediately. Useful only on a trusted network or for a
+    /// controlled latency comparison.
+    Off,
+    /// Require address validation for every new HTTP/3 connection.
+    Always,
 }
 
 impl ListenerTransport {
@@ -235,6 +257,13 @@ pub struct QuicSection {
     /// value is also raised above the path MTU the server would otherwise
     /// assume (for example to 1500 on a network known to carry it).
     pub discover_pmtu: bool,
+    /// Stateless address-validation policy for new HTTP/3 connections.
+    pub retry_mode: QuicRetryMode,
+    /// In adaptive mode, tokenless Initial packets stop allocating state when
+    /// this many connections are already live on the receiving shard.
+    pub retry_connection_threshold: usize,
+    /// Lifetime of an authenticated Retry token.
+    pub retry_token_ttl_secs: u64,
 }
 
 /// HTTP/2 flow-control and resource limits.
@@ -351,6 +380,8 @@ impl Default for ServerSection {
             // race its own keepalive to the timeout.
             idle_timeout_secs: 60,
             max_connections: 10_000,
+            max_connections_per_ip: 64,
+            max_pending_auth_per_ip: 8,
             max_tunnels_per_connection: 100,
         }
     }
@@ -408,6 +439,9 @@ impl Default for QuicSection {
             dgram_recv_queue_len: 2048,
             dgram_send_queue_len: 2048,
             discover_pmtu: false,
+            retry_mode: QuicRetryMode::Adaptive,
+            retry_connection_threshold: 64,
+            retry_token_ttl_secs: 30,
         }
     }
 }
@@ -549,6 +583,8 @@ idle_timeout_secs = 75
         assert_eq!(cfg.server.idle_timeout_secs, 75);
         // Other fields keep defaults
         assert_eq!(cfg.server.max_connections, 10_000);
+        assert_eq!(cfg.server.max_connections_per_ip, 64);
+        assert_eq!(cfg.server.max_pending_auth_per_ip, 8);
     }
 
     #[test]
@@ -562,6 +598,21 @@ key_path = "/etc/masque/key.pem"
         );
         assert_eq!(cfg.tls.cert_path, PathBuf::from("/etc/masque/cert.pem"));
         assert_eq!(cfg.tls.key_path, PathBuf::from("/etc/masque/key.pem"));
+    }
+
+    #[test]
+    fn parse_quic_retry_policy() {
+        let cfg = parse_with_listener(
+            r#"
+[quic]
+retry_mode = "always"
+retry_connection_threshold = 128
+retry_token_ttl_secs = 15
+"#,
+        );
+        assert_eq!(cfg.quic.retry_mode, QuicRetryMode::Always);
+        assert_eq!(cfg.quic.retry_connection_threshold, 128);
+        assert_eq!(cfg.quic.retry_token_ttl_secs, 15);
     }
 
     #[test]
@@ -865,6 +916,8 @@ ipv6_pool = "fd01::/64"
 [server]
 idle_timeout_secs = 60
 max_connections = 10000
+max_connections_per_ip = 64
+max_pending_auth_per_ip = 8
 max_tunnels_per_connection = 100
 
 [tls]
@@ -884,6 +937,9 @@ max_stream_window = 16777216
 dgram_recv_queue_len = 2048
 dgram_send_queue_len = 2048
 discover_pmtu = false
+retry_mode = "adaptive"
+retry_connection_threshold = 64
+retry_token_ttl_secs = 30
 
 [tcp_proxy]
 enabled = true

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::admission::SourceAdmission;
 use crate::client_identity::ClientIdentity;
 use crate::fxhash::FxHashMap;
 use crate::metrics::ShardMetrics;
@@ -116,12 +117,19 @@ pub struct ClientConnection {
     /// The deadline this connection currently holds in the server's timer
     /// queue, used to tell a live wakeup from one a later deadline superseded.
     pub(crate) scheduled_deadline: Option<std::time::Instant>,
+    /// Releases this source's process-wide connection admission on drop.
+    _source_admission: SourceAdmission,
     metrics: Arc<ShardMetrics>,
     published_tunnels: [usize; 3],
 }
 
 impl ClientConnection {
-    pub(crate) fn new(quic: quiche::Connection, index: u64, metrics: Arc<ShardMetrics>) -> Self {
+    pub(crate) fn new(
+        quic: quiche::Connection,
+        index: u64,
+        metrics: Arc<ShardMetrics>,
+        source_admission: SourceAdmission,
+    ) -> Self {
         metrics.connection_opened();
         Self {
             quic,
@@ -135,9 +143,14 @@ impl ClientConnection {
             identity: None,
             deferred_send: DeferredSend::default(),
             scheduled_deadline: None,
+            _source_admission: source_admission,
             metrics,
             published_tunnels: [0; 3],
         }
+    }
+
+    pub(crate) fn source_ip(&self) -> std::net::IpAddr {
+        self._source_admission.source()
     }
 
     /// The next instant this connection needs the event loop's attention:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod address_pool;
+mod admission;
 pub mod auth;
 pub mod capsule;
 pub mod client_identity;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -325,6 +325,27 @@ impl ListenerMetrics {
             self.sum(|shard| &shard.connections_rejected_limit)
         )
         .unwrap();
+        writeln!(
+            out,
+            "masque_connections_rejected_total{{{label},reason=\"source_limit\"}} {}",
+            self.sum(|shard| &shard.connections_rejected_source_limit)
+        )
+        .unwrap();
+        for (result, field) in [
+            (
+                "sent",
+                (|shard: &ShardMetrics| &shard.quic_retries_sent)
+                    as fn(&ShardMetrics) -> &AtomicU64,
+            ),
+            ("invalid", |shard| &shard.quic_retries_invalid),
+        ] {
+            writeln!(
+                out,
+                "masque_quic_retries_total{{{label},result=\"{result}\"}} {}",
+                self.sum(field)
+            )
+            .unwrap();
+        }
         for (name, field) in [
             (
                 "masque_quic_receive_batches_total",
@@ -434,6 +455,9 @@ pub(crate) struct ShardMetrics {
     connections_active: AtomicU64,
     connections_accepted: AtomicU64,
     connections_rejected_limit: AtomicU64,
+    connections_rejected_source_limit: AtomicU64,
+    quic_retries_sent: AtomicU64,
+    quic_retries_invalid: AtomicU64,
     quic_receive_batches: AtomicU64,
     quic_receive_packets: AtomicU64,
     quic_receive_bytes: AtomicU64,
@@ -466,6 +490,9 @@ impl ShardMetrics {
             connections_active: AtomicU64::new(0),
             connections_accepted: AtomicU64::new(0),
             connections_rejected_limit: AtomicU64::new(0),
+            connections_rejected_source_limit: AtomicU64::new(0),
+            quic_retries_sent: AtomicU64::new(0),
+            quic_retries_invalid: AtomicU64::new(0),
             quic_receive_batches: AtomicU64::new(0),
             quic_receive_packets: AtomicU64::new(0),
             quic_receive_bytes: AtomicU64::new(0),
@@ -536,6 +563,25 @@ impl ShardMetrics {
             return;
         }
         self.connections_rejected_limit.fetch_add(1, RELAXED);
+    }
+
+    pub(crate) fn connection_rejected_source_limit(&self) {
+        if !self.enabled {
+            return;
+        }
+        self.connections_rejected_source_limit.fetch_add(1, RELAXED);
+    }
+
+    pub(crate) fn record_quic_retries_sent(&self, count: usize) {
+        if self.enabled && count > 0 {
+            self.quic_retries_sent.fetch_add(count as u64, RELAXED);
+        }
+    }
+
+    pub(crate) fn record_quic_retry_invalid(&self) {
+        if self.enabled {
+            self.quic_retries_invalid.fetch_add(1, RELAXED);
+        }
     }
 
     #[inline]
@@ -757,6 +803,11 @@ fn render_listener_headers(out: &mut String) {
             "counter",
         ),
         (
+            "masque_quic_retries_total",
+            "QUIC Retry packets sent and invalid Retry tokens received.",
+            "counter",
+        ),
+        (
             "masque_quic_receive_batches_total",
             "Kernel receive batches containing QUIC packets.",
             "counter",
@@ -864,6 +915,9 @@ mod tests {
         listener.connection_opened();
         listener.record_receive_batch(4, 4800);
         listener.record_send_batch(3, 3600);
+        listener.connection_rejected_source_limit();
+        listener.record_quic_retries_sent(2);
+        listener.record_quic_retry_invalid();
         listener.record_tcp_relay_batch(4, 256 * 1024);
         listener.update_tunnels([0, 0, 0], [1, 2, 1]);
         listener.record_auth_success();
@@ -890,6 +944,15 @@ mod tests {
         ));
         assert!(rendered.contains(
             "masque_tcp_relay_bytes_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 262144"
+        ));
+        assert!(rendered.contains(
+            "masque_connections_rejected_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",reason=\"source_limit\"} 1"
+        ));
+        assert!(rendered.contains(
+            "masque_quic_retries_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",result=\"sent\"} 2"
+        ));
+        assert!(rendered.contains(
+            "masque_quic_retries_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",result=\"invalid\"} 1"
         ));
         assert!(rendered.contains(
             "masque_tunnels_active{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",protocol=\"udp\"} 2"
@@ -947,6 +1010,9 @@ mod tests {
         shard.record_receive_batch(8, 9600);
         shard.record_send_batch(8, 9600);
         shard.record_tcp_relay_batch(4, 256 * 1024);
+        shard.connection_rejected_source_limit();
+        shard.record_quic_retries_sent(2);
+        shard.record_quic_retry_invalid();
         shard.update_tunnels([0; 3], [1; 3]);
         shard.record_heartbeat(123, Duration::from_millis(25));
         let _pending = shard.auth_pending_guard();
@@ -955,6 +1021,9 @@ mod tests {
         assert_eq!(shard.quic_receive_packets.load(RELAXED), 0);
         assert_eq!(shard.quic_send_packets.load(RELAXED), 0);
         assert_eq!(shard.tcp_relay_events.load(RELAXED), 0);
+        assert_eq!(shard.connections_rejected_source_limit.load(RELAXED), 0);
+        assert_eq!(shard.quic_retries_sent.load(RELAXED), 0);
+        assert_eq!(shard.quic_retries_invalid.load(RELAXED), 0);
         assert_eq!(shard.auth_pending.load(RELAXED), 0);
         assert_eq!(shard.last_heartbeat_millis.load(RELAXED), 123);
         assert_eq!(shard.event_loop_lag_micros.load(RELAXED), 0);

--- a/src/server/authentication.rs
+++ b/src/server/authentication.rs
@@ -35,6 +35,13 @@ impl Shard {
         let Some(conn_id) = self.conn_by_index.get(&conn_idx).cloned() else {
             return;
         };
+        let Some(source_ip) = self
+            .connections
+            .get(&conn_id)
+            .map(|client| client.source_ip())
+        else {
+            return;
+        };
 
         for request in pending {
             let stream_id = request.stream_id;
@@ -48,6 +55,20 @@ impl Shard {
                 continue;
             };
 
+            let source_slot = match self.shared.auth_source_admissions.try_acquire(source_ip) {
+                Some(slot) => slot,
+                None => {
+                    self.metrics.record_auth_overloaded();
+                    warn!(stream_id, %source_ip, "source credential verification limit reached");
+                    if let Some(client) = self.connections.get_mut(&conn_id) {
+                        client.awaiting_auth.remove(&stream_id);
+                        if let Some(h3) = &mut client.h3 {
+                            Self::send_error_response(h3, &mut client.quic, stream_id, 503);
+                        }
+                    }
+                    continue;
+                }
+            };
             let queue_slot = match Arc::clone(&self.shared.auth_queue_slots).try_acquire_owned() {
                 Ok(slot) => slot,
                 Err(_) => {
@@ -84,6 +105,8 @@ impl Shard {
                 let running_gauge = metrics.auth_running_guard();
 
                 let verified = tokio::task::spawn_blocking(move || {
+                    let _source_slot = source_slot;
+                    let _queue_slot = queue_slot;
                     let _running_gauge = running_gauge;
                     // Aborting an async task cannot stop spawn_blocking after
                     // it begins. This check prevents queued blocking work from
@@ -120,7 +143,6 @@ impl Shard {
                         authorized,
                     })
                     .await;
-                drop(queue_slot);
             });
 
             if let Some(waiting) = self

--- a/src/server/http2.rs
+++ b/src/server/http2.rs
@@ -149,6 +149,14 @@ impl Http2Listener {
                             continue;
                         }
                     };
+                    let source_admission = match self.shared.source_admissions.try_acquire(peer.ip()) {
+                        Some(admission) => admission,
+                        None => {
+                            self.metrics.connection_rejected_source_limit();
+                            warn!(%peer, "HTTP/2 source connection limit reached");
+                            continue;
+                        }
+                    };
 
                     let context = ConnectionContext {
                         acceptor: Arc::clone(&self.acceptor),
@@ -166,6 +174,7 @@ impl Http2Listener {
                         context,
                         connection_shutdown.clone(),
                         connection_slot,
+                        source_admission,
                     ));
                 }
             }

--- a/src/server/http2/auth.rs
+++ b/src/server/http2/auth.rs
@@ -12,6 +12,7 @@ use zeroize::Zeroizing;
 
 use super::ConnectionContext;
 use super::support::send_error;
+use crate::admission::SourceAdmission;
 use crate::auth::{AuthPrecheck, BasicAuthenticator};
 use crate::client_identity::{ClientIdentity, SharedRoster};
 use crate::metrics::ShardMetrics;
@@ -46,6 +47,7 @@ pub(super) async fn authorize_request(
     respond: &mut SendResponse<Bytes>,
     context: &ConnectionContext,
     auth_slots: Arc<Semaphore>,
+    source_ip: std::net::IpAddr,
 ) -> Authorization {
     let Some(auth) = &context.auth else {
         return Authorization::Granted;
@@ -72,6 +74,14 @@ pub(super) async fn authorize_request(
             return Authorization::ResponseSent;
         }
     };
+    let source_slot = match context.shared.auth_source_admissions.try_acquire(source_ip) {
+        Some(slot) => slot,
+        None => {
+            context.metrics.record_auth_overloaded();
+            let _ = send_error(respond, StatusCode::SERVICE_UNAVAILABLE);
+            return Authorization::ResponseSent;
+        }
+    };
     let verification = verify_password(
         Arc::clone(auth),
         password,
@@ -79,6 +89,7 @@ pub(super) async fn authorize_request(
         Arc::clone(&context.shared.auth_permits),
         Arc::clone(&context.metrics),
         auth_slot,
+        source_slot,
     );
     tokio::pin!(verification);
     let authorized = tokio::select! {
@@ -111,6 +122,7 @@ async fn verify_password(
     permits: Arc<Semaphore>,
     metrics: Arc<ShardMetrics>,
     _connection_slot: OwnedSemaphorePermit,
+    source_slot: SourceAdmission,
 ) -> AuthResult {
     let queue_slot = match queue_slots.try_acquire_owned() {
         Ok(slot) => slot,
@@ -128,6 +140,7 @@ async fn verify_password(
     let running = metrics.auth_running_guard();
     let completion_metrics = Arc::clone(&metrics);
     match tokio::task::spawn_blocking(move || {
+        let _source_slot = source_slot;
         let _queue_slot = queue_slot;
         let _permit = permit;
         let _running = running;

--- a/src/server/http2/connection.rs
+++ b/src/server/http2/connection.rs
@@ -19,6 +19,7 @@ use super::support::{ConnectionMetricsGuard, send_error};
 use super::{
     ConnectionContext, DRAIN_TIMEOUT, HEARTBEAT_INTERVAL, TLS_HANDSHAKE_TIMEOUT, ip, tcp, udp,
 };
+use crate::admission::SourceAdmission;
 use crate::client_identity::ClientIdentity;
 
 pub(super) async fn serve(
@@ -27,6 +28,7 @@ pub(super) async fn serve(
     context: ConnectionContext,
     mut shutdown: watch::Receiver<bool>,
     _connection_slot: OwnedSemaphorePermit,
+    _source_admission: SourceAdmission,
 ) {
     let _connection_metrics = ConnectionMetricsGuard::new(Arc::clone(&context.metrics));
     let tls = match tokio::time::timeout(
@@ -157,8 +159,11 @@ pub(super) async fn serve(
                             context.clone(),
                             connection_index,
                             authenticated_identity.as_ref().map(Arc::clone),
-                            Arc::clone(&tunnel_slots),
-                            Arc::clone(&auth_slots),
+                            RequestAdmission {
+                                tunnel_slots: Arc::clone(&tunnel_slots),
+                                auth_slots: Arc::clone(&auth_slots),
+                                source_ip: peer.ip(),
+                            },
                         ));
                     }
                     Some(Ok((_request, mut respond))) => {
@@ -179,14 +184,19 @@ pub(super) async fn serve(
     debug!(%peer, "HTTP/2 connection closed");
 }
 
+struct RequestAdmission {
+    tunnel_slots: Arc<Semaphore>,
+    auth_slots: Arc<Semaphore>,
+    source_ip: std::net::IpAddr,
+}
+
 async fn handle_request(
     request: Request<h2::RecvStream>,
     mut respond: SendResponse<Bytes>,
     context: ConnectionContext,
     connection_index: u64,
     authenticated_identity: Option<Arc<ClientIdentity>>,
-    tunnel_slots: Arc<Semaphore>,
-    auth_slots: Arc<Semaphore>,
+    admission: RequestAdmission,
 ) {
     let stream_id = respond.stream_id().as_u32();
     let Some(recognized) = request_handling::recognize(&request, &context.config) else {
@@ -195,7 +205,14 @@ async fn handle_request(
     };
 
     if matches!(
-        auth::authorize_request(&request, &mut respond, &context, auth_slots).await,
+        auth::authorize_request(
+            &request,
+            &mut respond,
+            &context,
+            admission.auth_slots,
+            admission.source_ip,
+        )
+        .await,
         Authorization::ResponseSent
     ) {
         return;
@@ -212,7 +229,7 @@ async fn handle_request(
         }
     };
 
-    let tunnel_slot = match tunnel_slots.try_acquire_owned() {
+    let tunnel_slot = match admission.tunnel_slots.try_acquire_owned() {
         Ok(slot) => slot,
         Err(_) => {
             let _ = send_error(&mut respond, StatusCode::SERVICE_UNAVAILABLE);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,6 +3,7 @@
 mod authentication;
 mod http2;
 mod request;
+mod retry;
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -21,6 +22,7 @@ use tracing::{debug, error, info, warn};
 use self::authentication::AuthOutcome;
 use self::request::{PendingAuth, PendingConnectSetups, RequestContext};
 use crate::address_pool::{AddressPool, PoolError};
+use crate::admission::SourceAdmissionLimiter;
 use crate::auth::BasicAuthenticator;
 use crate::capsule;
 use crate::capsule::{AssignedAddress, CapsuleFrame, IpAddress, IpAddressRange};
@@ -505,6 +507,32 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
     let listeners = plan_listeners(config)?;
     let any_client_cert = any_client_cert_listener(config);
 
+    if config.server.max_connections == 0 {
+        anyhow::bail!("server.max_connections must be at least 1");
+    }
+    if config.server.max_connections_per_ip == 0 {
+        anyhow::bail!("server.max_connections_per_ip must be at least 1");
+    }
+    if !(1..=MAX_PENDING_AUTH_GLOBAL).contains(&config.server.max_pending_auth_per_ip) {
+        anyhow::bail!(
+            "server.max_pending_auth_per_ip ({}) must be between 1 and {}",
+            config.server.max_pending_auth_per_ip,
+            MAX_PENDING_AUTH_GLOBAL
+        );
+    }
+    if config.server.max_tunnels_per_connection == 0 {
+        anyhow::bail!("server.max_tunnels_per_connection must be at least 1");
+    }
+    if config.quic.retry_connection_threshold == 0 {
+        anyhow::bail!("quic.retry_connection_threshold must be at least 1");
+    }
+    if !(1..=300).contains(&config.quic.retry_token_ttl_secs) {
+        anyhow::bail!(
+            "quic.retry_token_ttl_secs ({}) must be between 1 and 300",
+            config.quic.retry_token_ttl_secs
+        );
+    }
+
     if let Some(addr) = config.observability.listen_addr
         && !is_loopback(addr.ip())
     {
@@ -790,9 +818,9 @@ impl Server {
 
         let tun = build_tun(&config)?;
 
-        let mut key_bytes = [0u8; 32];
+        let mut key_bytes = [0u8; 64];
         ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut key_bytes)
-            .map_err(|_| anyhow::anyhow!("failed to seed connection ID key"))?;
+            .map_err(|_| anyhow::anyhow!("failed to seed connection admission keys"))?;
 
         // Every shard needs a handle to every other shard's inboxes, so the
         // channels are made before the shards that read them. Shards are
@@ -826,7 +854,15 @@ impl Server {
             index_shard: RwLock::new(FxHashMap::default()),
             http2_tun_routes: RwLock::new(FxHashMap::default()),
             next_conn_index: AtomicU64::new(0),
-            conn_id_key: ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &key_bytes),
+            conn_id_key: ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &key_bytes[..32]),
+            retry_tokens: retry::RetryTokenCodec::new(
+                ring::hmac::Key::new(ring::hmac::HMAC_SHA256, &key_bytes[32..]),
+                Duration::from_secs(config.quic.retry_token_ttl_secs),
+            ),
+            source_admissions: SourceAdmissionLimiter::new(config.server.max_connections_per_ip),
+            auth_source_admissions: SourceAdmissionLimiter::new(
+                config.server.max_pending_auth_per_ip,
+            ),
             tun,
             forward_tx,
             tun_tx,
@@ -1789,6 +1825,12 @@ struct Shared {
     /// Generated per-process, so a client cannot precompute which server
     /// connection ID — or which hash bucket — its DCID will map to.
     conn_id_key: ring::hmac::Key,
+    /// Authenticated address-validation tokens shared by every QUIC shard.
+    retry_tokens: retry::RetryTokenCodec,
+    /// Process-wide connection budget keyed by canonical source IP.
+    source_admissions: SourceAdmissionLimiter,
+    /// Fair-share bound for queued or running Basic credential checks.
+    auth_source_admissions: SourceAdmissionLimiter,
     /// Shared TUN device for CONNECT-IP tunnels (None if IP proxy disabled).
     tun: Option<TunManager>,
     /// Inbox per shard for packets forwarded after a migration.
@@ -2022,6 +2064,8 @@ impl Shard {
         let mut tun_send = TunSendBatch::new();
         let mut recv_batch = RecvPacketBatch::new(MAX_QUIC_RECV_BATCH);
         let mut send_batch = SendPacketBatch::new();
+        let mut stateless_out = vec![0u8; MAX_DATAGRAM_SIZE];
+        let mut stateless_batch = SendPacketBatch::new();
         // One shard reads the shared TUN device and hands each packet to the
         // connection that owns its address. Shard 0 is an arbitrary but stable
         // choice; nothing here depends on which listener that shard serves.
@@ -2049,6 +2093,8 @@ impl Shard {
         loop {
             self.dirty.end_round();
             serviced.clear();
+            stateless_batch.clear();
+            let mut stateless_retries = 0usize;
 
             // Wake for the earliest connection deadline rather than scanning
             // every connection for it. The idle sweep and, during shutdown, the
@@ -2146,7 +2192,14 @@ impl Shard {
                         packet_count += 1;
                         byte_count += packet.len();
                         if !shutting_down {
-                            self.handle_packet(packet, from, local_addr);
+                            self.handle_packet(
+                                packet,
+                                from,
+                                local_addr,
+                                &mut stateless_out,
+                                &mut stateless_batch,
+                                &mut stateless_retries,
+                            );
                             return;
                         }
 
@@ -2193,7 +2246,14 @@ impl Shard {
                     error!(%e, "TUN recv error");
                 }
                 Event::Forwarded(Some(mut packet)) => {
-                    self.handle_packet(&mut packet.data, packet.from, local_addr);
+                    self.handle_packet(
+                        &mut packet.data,
+                        packet.from,
+                        local_addr,
+                        &mut stateless_out,
+                        &mut stateless_batch,
+                        &mut stateless_retries,
+                    );
                 }
                 Event::Forwarded(None) => {}
                 Event::TunInbound(Some(packet)) => {
@@ -2205,6 +2265,23 @@ impl Shard {
                 }
                 Event::AuthDone(None) => {}
                 Event::Timeout => {}
+            }
+
+            if !stateless_batch.is_empty() {
+                let udp_gso_before_send = self.socket.udp_gso_enabled();
+                match self.socket.send_batch(&stateless_batch).await {
+                    Ok(()) => {
+                        self.metrics.record_send_batch(
+                            stateless_batch.packet_count(),
+                            stateless_batch.byte_count(),
+                        );
+                        self.metrics.record_quic_retries_sent(stateless_retries);
+                    }
+                    Err(error) => warn!(%error, "stateless QUIC response send failed"),
+                }
+                if udp_gso_before_send && !self.socket.udp_gso_enabled() {
+                    self.metrics.disable_udp_gso();
+                }
             }
 
             // A connection whose deadline has arrived needs driving even if
@@ -2379,8 +2456,56 @@ impl Shard {
         }
     }
 
+    fn derive_connection_id(
+        &self,
+        destination: &quiche::ConnectionId<'_>,
+    ) -> quiche::ConnectionId<'static> {
+        let signed = ring::hmac::sign(&self.shared.conn_id_key, destination);
+        quiche::ConnectionId::from_vec(signed.as_ref()[..CONN_ID_LEN].to_vec())
+    }
+
+    fn forward_packet(&self, shard: usize, packet: &[u8], from: SocketAddr) {
+        let forwarded = ForwardedPacket {
+            data: packet.to_vec(),
+            from,
+        };
+        // Dropping under pressure is what the network would have done; QUIC
+        // retransmits without making this unbounded cross-shard state.
+        if self.shared.forward_tx[shard].try_send(forwarded).is_err() {
+            self.shared.record_shard_queue_drop(shard);
+            debug!(shard, "shard forward queue full, dropping packet");
+        }
+    }
+
+    fn queue_stateless_packet(
+        &self,
+        packet: &[u8],
+        from: SocketAddr,
+        to: SocketAddr,
+        batch: &mut SendPacketBatch,
+    ) {
+        batch.push(
+            packet,
+            quiche::SendInfo {
+                from,
+                to,
+                at: Instant::now(),
+            },
+            self.socket.udp_gso_enabled(),
+            MAX_DATAGRAM_SIZE,
+        );
+    }
+
     /// Process an incoming UDP packet (QUIC).
-    fn handle_packet(&mut self, buf: &mut [u8], from: SocketAddr, local: SocketAddr) {
+    fn handle_packet(
+        &mut self,
+        buf: &mut [u8],
+        from: SocketAddr,
+        local: SocketAddr,
+        stateless_out: &mut [u8],
+        stateless_batch: &mut SendPacketBatch,
+        stateless_retries: &mut usize,
+    ) {
         let hdr = match quiche::Header::from_slice(buf, CONN_ID_LEN) {
             Ok(v) => v,
             Err(e) => {
@@ -2390,60 +2515,152 @@ impl Shard {
         };
 
         // Established packets carry the server-issued CID and take this fast
-        // path. Deriving a CID requires HMAC-SHA256, so only do that for a new
-        // Initial or for packets that still carry the original destination ID.
+        // path without hashing. If migration made the packet land on another
+        // SO_REUSEPORT shard, the shared ownership map names the right inbox.
         let key = if let Some((conn_id, _)) = self.connections.get_key_value(&hdr.dcid) {
             conn_id.clone()
         } else {
-            let conn_id = ring::hmac::sign(&self.shared.conn_id_key, &hdr.dcid);
-            let conn_id = quiche::ConnectionId::from_vec(conn_id.as_ref()[..CONN_ID_LEN].to_vec());
+            let direct_owner = self
+                .shared
+                .cid_shard
+                .read()
+                .expect("cid ownership poisoned")
+                .get(&hdr.dcid)
+                .copied();
+            if let Some(owner) = direct_owner {
+                if owner != self.index {
+                    self.forward_packet(owner, buf, from);
+                } else {
+                    debug!("connection ownership published without local state");
+                }
+                return;
+            }
 
-            if !self.connections.contains_key(&conn_id) {
-                if hdr.ty != quiche::Type::Initial {
-                    // The kernel steers by 4-tuple, so a client that changed
-                    // address can land here instead of on its owner. Hand the
-                    // packet over rather than dropping the connection.
-                    let owner = self
-                        .shared
-                        .cid_shard
-                        .read()
-                        .expect("cid ownership poisoned")
-                        .get(&conn_id)
-                        .copied();
-                    match owner {
-                        Some(shard) if shard != self.index => {
-                            let forwarded = ForwardedPacket {
-                                data: buf.to_vec(),
-                                from,
-                            };
-                            // Dropping under pressure is what the network
-                            // would have done; QUIC will retransmit.
-                            if self.shared.forward_tx[shard].try_send(forwarded).is_err() {
-                                self.shared.record_shard_queue_drop(shard);
-                                debug!(shard, "shard forward queue full, dropping packet");
-                            }
-                        }
-                        _ => debug!("non-initial packet for unknown connection"),
+            if hdr.ty != quiche::Type::Initial {
+                debug!("non-initial packet for unknown connection");
+                return;
+            }
+
+            // A client Initial datagram is required to be at least 1200 bytes.
+            // Reject a short spoofed packet before emitting Version
+            // Negotiation or Retry, preserving QUIC's amplification bound.
+            if buf.len() < quiche::MIN_CLIENT_INITIAL_LEN {
+                debug!(bytes = buf.len(), "dropping undersized QUIC Initial");
+                return;
+            }
+
+            if !quiche::version_is_supported(hdr.version) {
+                match quiche::negotiate_version(&hdr.scid, &hdr.dcid, stateless_out) {
+                    Ok(written) => self.queue_stateless_packet(
+                        &stateless_out[..written],
+                        local,
+                        from,
+                        stateless_batch,
+                    ),
+                    Err(error) => debug!(%error, "failed to build QUIC version negotiation"),
+                }
+                return;
+            }
+
+            // A retransmitted first Initial still carries the client's
+            // original destination CID. Find the state created for its first
+            // copy before deciding this is a new connection.
+            let derived = self.derive_connection_id(&hdr.dcid);
+            if self.connections.contains_key(&derived) {
+                derived
+            } else {
+                let derived_owner = self
+                    .shared
+                    .cid_shard
+                    .read()
+                    .expect("cid ownership poisoned")
+                    .get(&derived)
+                    .copied();
+                if let Some(owner) = derived_owner {
+                    if owner != self.index {
+                        self.forward_packet(owner, buf, from);
+                    } else {
+                        debug!("derived connection ownership published without local state");
                     }
                     return;
                 }
 
-                // Enforce max_connections limit.
+                let token = hdr.token.as_deref().unwrap_or_default();
+                let retry_required = retry::retry_required(
+                    self.config.quic.retry_mode,
+                    self.connections.len(),
+                    self.config.quic.retry_connection_threshold,
+                );
+
+                if token.is_empty() && retry_required {
+                    let retry_token = self.shared.retry_tokens.mint(from, local, &hdr.dcid);
+                    match quiche::retry(
+                        &hdr.scid,
+                        &hdr.dcid,
+                        &derived,
+                        &retry_token,
+                        hdr.version,
+                        stateless_out,
+                    ) {
+                        Ok(written) => {
+                            self.queue_stateless_packet(
+                                &stateless_out[..written],
+                                local,
+                                from,
+                                stateless_batch,
+                            );
+                            *stateless_retries += 1;
+                        }
+                        Err(error) => debug!(%error, "failed to build QUIC Retry"),
+                    }
+                    return;
+                }
+
+                let (scid, odcid) = if token.is_empty()
+                    || self.config.quic.retry_mode == crate::config::QuicRetryMode::Off
+                {
+                    (derived, None)
+                } else {
+                    let Some(odcid) = self.shared.retry_tokens.validate(from, local, token) else {
+                        self.metrics.record_quic_retry_invalid();
+                        debug!(%from, "invalid or expired QUIC Retry token");
+                        return;
+                    };
+                    let expected = self.derive_connection_id(&odcid);
+                    if expected != hdr.dcid {
+                        self.metrics.record_quic_retry_invalid();
+                        debug!(%from, "QUIC Retry destination connection ID mismatch");
+                        return;
+                    }
+                    (
+                        quiche::ConnectionId::from_vec(hdr.dcid.to_vec()),
+                        Some(odcid),
+                    )
+                };
+
+                // Stateful admission happens only after address validation, so
+                // a spoofed flood cannot consume either connection table.
                 if self.connections.len() >= self.config.server.max_connections {
                     self.metrics.connection_rejected_limit();
                     warn!("max connections reached, rejecting new connection");
                     return;
                 }
-
-                let scid = quiche::ConnectionId::from_vec(conn_id.as_ref().to_vec());
-
-                let quic = match quiche::accept(&scid, None, local, from, &mut self.quic_config) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        error!(%e, "failed to accept connection");
-                        return;
-                    }
+                let Some(source_admission) = self.shared.source_admissions.try_acquire(from.ip())
+                else {
+                    self.metrics.connection_rejected_source_limit();
+                    warn!(%from, "source connection limit reached");
+                    return;
                 };
+
+                let quic =
+                    match quiche::accept(&scid, odcid.as_ref(), local, from, &mut self.quic_config)
+                    {
+                        Ok(connection) => connection,
+                        Err(error) => {
+                            error!(%error, "failed to accept connection");
+                            return;
+                        }
+                    };
 
                 info!(shard = self.index, ?scid, %from, "new connection");
 
@@ -2463,11 +2680,15 @@ impl Shard {
                     .expect("index ownership poisoned")
                     .insert(conn_idx, self.index);
 
-                let client = ClientConnection::new(quic, conn_idx, Arc::clone(&self.metrics));
-                self.connections.insert(scid, client);
+                let client = ClientConnection::new(
+                    quic,
+                    conn_idx,
+                    Arc::clone(&self.metrics),
+                    source_admission,
+                );
+                self.connections.insert(scid.clone(), client);
+                scid
             }
-
-            conn_id
         };
 
         let client = self.connections.get_mut(&key).unwrap();
@@ -4055,6 +4276,42 @@ mod tests {
             Err(error) => error.to_string(),
         };
         assert!(error.contains("must use a loopback address"), "{error}");
+    }
+
+    #[test]
+    fn admission_limits_and_retry_settings_are_bounded() {
+        let mut config = ServerConfig::default();
+
+        config.server.max_connections_per_ip = 0;
+        let error = match super::validate_server_config(&config) {
+            Ok(_) => panic!("zero per-source connection limit must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("max_connections_per_ip"));
+        config.server.max_connections_per_ip = 64;
+
+        config.server.max_pending_auth_per_ip = super::MAX_PENDING_AUTH_GLOBAL + 1;
+        let error = match super::validate_server_config(&config) {
+            Ok(_) => panic!("oversized per-source auth limit must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("max_pending_auth_per_ip"));
+        config.server.max_pending_auth_per_ip = 8;
+
+        config.quic.retry_connection_threshold = 0;
+        let error = match super::validate_server_config(&config) {
+            Ok(_) => panic!("zero Retry threshold must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("retry_connection_threshold"));
+        config.quic.retry_connection_threshold = 64;
+
+        config.quic.retry_token_ttl_secs = 301;
+        let error = match super::validate_server_config(&config) {
+            Ok(_) => panic!("oversized Retry token lifetime must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("retry_token_ttl_secs"));
     }
 
     /// Planning keeps the listener-specific trust boundary separate from the

--- a/src/server/retry.rs
+++ b/src/server/retry.rs
@@ -1,0 +1,276 @@
+//! Authenticated QUIC Retry tokens.
+//!
+//! Tokens are intentionally process-local: a fresh key on restart invalidates
+//! outstanding tokens, which live for only a few seconds and carry no session
+//! state. The client address is bound by IP rather than port so a NAT is free
+//! to rewrite its mapping between the Retry packet and the second Initial.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::time::{Duration, Instant};
+
+use ring::hmac;
+
+use crate::config::QuicRetryMode;
+
+const TOKEN_VERSION: u8 = 1;
+const TAG_LEN: usize = 32;
+
+pub(super) struct RetryTokenCodec {
+    key: hmac::Key,
+    epoch: Instant,
+    ttl: Duration,
+}
+
+impl RetryTokenCodec {
+    pub(super) fn new(key: hmac::Key, ttl: Duration) -> Self {
+        Self {
+            key,
+            epoch: Instant::now(),
+            ttl,
+        }
+    }
+
+    pub(super) fn mint(
+        &self,
+        source: SocketAddr,
+        local: SocketAddr,
+        original_dcid: &quiche::ConnectionId<'_>,
+    ) -> Vec<u8> {
+        let mut token = Vec::with_capacity(112);
+        token.push(TOKEN_VERSION);
+        token.extend_from_slice(&self.epoch.elapsed().as_secs().to_be_bytes());
+        encode_ip(canonical_ip(source.ip()), &mut token);
+        encode_socket(canonical_socket(local), &mut token);
+        token.push(original_dcid.len() as u8);
+        token.extend_from_slice(original_dcid);
+        let tag = hmac::sign(&self.key, &token);
+        token.extend_from_slice(tag.as_ref());
+        token
+    }
+
+    pub(super) fn validate(
+        &self,
+        source: SocketAddr,
+        local: SocketAddr,
+        token: &[u8],
+    ) -> Option<quiche::ConnectionId<'static>> {
+        self.validate_at(source, local, token, self.epoch.elapsed().as_secs())
+    }
+
+    fn validate_at(
+        &self,
+        source: SocketAddr,
+        local: SocketAddr,
+        token: &[u8],
+        now: u64,
+    ) -> Option<quiche::ConnectionId<'static>> {
+        if token.len() <= TAG_LEN {
+            return None;
+        }
+        let (body, tag) = token.split_at(token.len() - TAG_LEN);
+        hmac::verify(&self.key, body, tag).ok()?;
+
+        let mut cursor = 0usize;
+        if *take(body, &mut cursor, 1)?.first()? != TOKEN_VERSION {
+            return None;
+        }
+        let issued = u64::from_be_bytes(take(body, &mut cursor, 8)?.try_into().ok()?);
+        if issued > now || now - issued > self.ttl.as_secs() {
+            return None;
+        }
+
+        if decode_ip(body, &mut cursor)? != canonical_ip(source.ip()) {
+            return None;
+        }
+        if decode_socket(body, &mut cursor)? != canonical_socket(local) {
+            return None;
+        }
+        let odcid_len = *take(body, &mut cursor, 1)?.first()? as usize;
+        if !(1..=quiche::MAX_CONN_ID_LEN).contains(&odcid_len) {
+            return None;
+        }
+        let odcid = take(body, &mut cursor, odcid_len)?;
+        if cursor != body.len() {
+            return None;
+        }
+        Some(quiche::ConnectionId::from_vec(odcid.to_vec()))
+    }
+}
+
+pub(super) fn retry_required(
+    mode: QuicRetryMode,
+    active_connections: usize,
+    adaptive_threshold: usize,
+) -> bool {
+    match mode {
+        QuicRetryMode::Off => false,
+        QuicRetryMode::Always => true,
+        QuicRetryMode::Adaptive => active_connections >= adaptive_threshold,
+    }
+}
+
+fn take<'a>(bytes: &'a [u8], cursor: &mut usize, len: usize) -> Option<&'a [u8]> {
+    let end = cursor.checked_add(len)?;
+    let value = bytes.get(*cursor..end)?;
+    *cursor = end;
+    Some(value)
+}
+
+fn encode_ip(ip: IpAddr, out: &mut Vec<u8>) {
+    match ip {
+        IpAddr::V4(ip) => {
+            out.push(4);
+            out.extend_from_slice(&ip.octets());
+        }
+        IpAddr::V6(ip) => {
+            out.push(6);
+            out.extend_from_slice(&ip.octets());
+        }
+    }
+}
+
+fn decode_ip(bytes: &[u8], cursor: &mut usize) -> Option<IpAddr> {
+    match *take(bytes, cursor, 1)?.first()? {
+        4 => Some(IpAddr::V4(Ipv4Addr::from(
+            <[u8; 4]>::try_from(take(bytes, cursor, 4)?).ok()?,
+        ))),
+        6 => Some(IpAddr::V6(Ipv6Addr::from(
+            <[u8; 16]>::try_from(take(bytes, cursor, 16)?).ok()?,
+        ))),
+        _ => None,
+    }
+}
+
+fn encode_socket(address: SocketAddr, out: &mut Vec<u8>) {
+    encode_ip(address.ip(), out);
+    out.extend_from_slice(&address.port().to_be_bytes());
+    let scope_id = match address {
+        SocketAddr::V4(_) => 0,
+        SocketAddr::V6(address) => address.scope_id(),
+    };
+    out.extend_from_slice(&scope_id.to_be_bytes());
+}
+
+fn decode_socket(bytes: &[u8], cursor: &mut usize) -> Option<SocketAddr> {
+    let ip = decode_ip(bytes, cursor)?;
+    let port = u16::from_be_bytes(take(bytes, cursor, 2)?.try_into().ok()?);
+    let scope_id = u32::from_be_bytes(take(bytes, cursor, 4)?.try_into().ok()?);
+    match ip {
+        IpAddr::V4(ip) if scope_id == 0 => Some(SocketAddr::new(IpAddr::V4(ip), port)),
+        IpAddr::V4(_) => None,
+        IpAddr::V6(ip) => Some(SocketAddr::V6(SocketAddrV6::new(ip, port, 0, scope_id))),
+    }
+}
+
+fn canonical_ip(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(ip) => ip
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(ip)),
+        ip => ip,
+    }
+}
+
+fn canonical_socket(address: SocketAddr) -> SocketAddr {
+    match address {
+        SocketAddr::V4(address) => SocketAddr::V4(address),
+        SocketAddr::V6(address) => match address.ip().to_ipv4_mapped() {
+            Some(ip) => SocketAddr::new(IpAddr::V4(ip), address.port()),
+            None => SocketAddr::V6(SocketAddrV6::new(
+                *address.ip(),
+                address.port(),
+                0,
+                address.scope_id(),
+            )),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codec(ttl: Duration) -> RetryTokenCodec {
+        RetryTokenCodec::new(hmac::Key::new(hmac::HMAC_SHA256, &[0x42; 32]), ttl)
+    }
+
+    #[test]
+    fn token_round_trips_and_carries_the_original_dcid() {
+        let codec = codec(Duration::from_secs(30));
+        let source = "192.0.2.10:12345".parse().unwrap();
+        let local = "[2001:db8::1]:443".parse().unwrap();
+        let odcid = quiche::ConnectionId::from_ref(b"original-dcid");
+        let token = codec.mint(source, local, &odcid);
+        assert_eq!(codec.validate(source, local, &token).unwrap(), odcid);
+    }
+
+    #[test]
+    fn token_is_bound_to_source_ip_but_not_source_port() {
+        let codec = codec(Duration::from_secs(30));
+        let source = "192.0.2.10:12345".parse().unwrap();
+        let local = "192.0.2.20:443".parse().unwrap();
+        let odcid = quiche::ConnectionId::from_ref(b"original-dcid");
+        let token = codec.mint(source, local, &odcid);
+
+        assert!(
+            codec
+                .validate("192.0.2.10:54321".parse().unwrap(), local, &token)
+                .is_some()
+        );
+        assert!(
+            codec
+                .validate("192.0.2.11:12345".parse().unwrap(), local, &token)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn token_is_bound_to_listener_and_authenticated() {
+        let codec = codec(Duration::from_secs(30));
+        let source = "192.0.2.10:12345".parse().unwrap();
+        let local = "192.0.2.20:443".parse().unwrap();
+        let odcid = quiche::ConnectionId::from_ref(b"original-dcid");
+        let mut token = codec.mint(source, local, &odcid);
+        assert!(
+            codec
+                .validate(source, "192.0.2.20:8443".parse().unwrap(), &token)
+                .is_none()
+        );
+        token[10] ^= 1;
+        assert!(codec.validate(source, local, &token).is_none());
+    }
+
+    #[test]
+    fn token_keeps_a_link_local_listener_scope() {
+        let codec = codec(Duration::from_secs(30));
+        let source = "[2001:db8::10]:12345".parse().unwrap();
+        let local = "[fe80::1%2]:443".parse().unwrap();
+        let other_scope = "[fe80::1%3]:443".parse().unwrap();
+        let odcid = quiche::ConnectionId::from_ref(b"original-dcid");
+        let token = codec.mint(source, local, &odcid);
+
+        assert!(codec.validate(source, local, &token).is_some());
+        assert!(codec.validate(source, other_scope, &token).is_none());
+    }
+
+    #[test]
+    fn token_expires_after_its_ttl() {
+        let codec = codec(Duration::from_secs(30));
+        let source = "192.0.2.10:12345".parse().unwrap();
+        let local = "192.0.2.20:443".parse().unwrap();
+        let odcid = quiche::ConnectionId::from_ref(b"original-dcid");
+        let token = codec.mint(source, local, &odcid);
+
+        assert!(codec.validate_at(source, local, &token, 30).is_some());
+        assert!(codec.validate_at(source, local, &token, 31).is_none());
+    }
+
+    #[test]
+    fn policy_switches_only_at_the_adaptive_threshold() {
+        assert!(!retry_required(QuicRetryMode::Off, 1_000, 64));
+        assert!(retry_required(QuicRetryMode::Always, 0, 64));
+        assert!(!retry_required(QuicRetryMode::Adaptive, 63, 64));
+        assert!(retry_required(QuicRetryMode::Adaptive, 64, 64));
+    }
+}

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -29,7 +29,8 @@ use quiche::h3::NameValue as _;
 use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
 use masque::capsule::{CapsuleFrame, IpAddress};
 use masque::config::{
-    AuthMode, AuthSection, ClientEntry, ListenerSection, ListenerTransport, ServerConfig,
+    AuthMode, AuthSection, ClientEntry, ListenerSection, ListenerTransport, QuicRetryMode,
+    ServerConfig,
 };
 use masque::datagram::DatagramHeader;
 use masque::server::Server;
@@ -461,7 +462,7 @@ struct Fixture {
 
 /// Start a server that knows one client, pinned to fixed addresses, and mint a
 /// second unregistered key pair to test rejection with.
-fn fixture(tag: &str) -> Fixture {
+fn fixture_with_retry(tag: &str, retry_mode: QuicRetryMode) -> Fixture {
     let dir = TempDir::new(tag);
 
     let server_key = p256_key();
@@ -488,7 +489,7 @@ fn fixture(tag: &str) -> Fixture {
         &self_signed(&stranger_key, None),
     );
 
-    let peer = spawn_server(server_config(
+    let mut config = server_config(
         cert_path,
         key_path,
         ephemeral_addr(),
@@ -498,7 +499,9 @@ fn fixture(tag: &str) -> Fixture {
             ipv4: Some(CLIENT_IPV4.into()),
             ipv6: Some(CLIENT_IPV6.into()),
         }],
-    ))[0];
+    );
+    config.quic.retry_mode = retry_mode;
+    let peer = spawn_server(config)[0];
 
     Fixture {
         _dir: dir,
@@ -508,6 +511,10 @@ fn fixture(tag: &str) -> Fixture {
         stranger_cert,
         stranger_key: stranger_key_path,
     }
+}
+
+fn fixture(tag: &str) -> Fixture {
+    fixture_with_retry(tag, QuicRetryMode::Adaptive)
 }
 
 // ── Multi-listener fixture ───────────────────────────────────────────
@@ -906,6 +913,23 @@ fn a_broken_reload_keeps_the_previous_roster() {
 /// The whole point of the exercise: a client that authenticates with a
 /// certificate and asks for `cf-connect-ip` gets a working tunnel, assigned the
 /// addresses its roster entry pins it to.
+#[test]
+fn quic_retry_always_completes_a_real_handshake() {
+    let fixture = fixture_with_retry("retry", QuicRetryMode::Always);
+    let mut client =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+    let stream_id = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+}
+
 #[test]
 fn registered_client_gets_its_pinned_addresses_over_cf_connect_ip() {
     let fixture = fixture("happy");

--- a/tools/masque-e2e/Cargo.toml
+++ b/tools/masque-e2e/Cargo.toml
@@ -12,7 +12,13 @@ masque = { package = "masque-server", path = "../.." }
 quiche = "0.29.3"
 anyhow = "1"
 base64 = "0.22.1"
+boring = "4.3"
+bytes = "1"
+h2 = "0.4.18"
+http = "1"
 ring = "0.17"
+tokio = { version = "1", features = ["full"] }
+tokio-boring = "4.19"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/tools/masque-e2e/src/http2.rs
+++ b/tools/masque-e2e/src/http2.rs
@@ -1,0 +1,733 @@
+//! HTTP/2 client paths used by the transport-parity benchmark.
+//!
+//! The production server treats HTTP/2 as a compatibility transport, but its
+//! performance still needs to be measured with the same targets, payloads,
+//! windows, and result fields as HTTP/3. Keeping this client in the existing
+//! E2E binary ensures both transports share all benchmark configuration and
+//! direct baselines.
+
+use std::future::poll_fn;
+use std::net::SocketAddr;
+use std::task::Poll;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use bytes::{Buf as _, Bytes};
+use h2::client::SendRequest;
+use http::{Method, Request, StatusCode};
+use tokio::net::TcpStream;
+use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
+
+use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
+use masque::capsule::{CapsuleFrame, encoder};
+
+use super::{
+    HttpDownloadResponse, InFlight, TcpDownloadResult, UdpBenchConfig,
+    benchmark_direct_tcp_download, median, print_udp_result, proxy_authorization_value,
+};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const H2_INITIAL_CONNECTION_WINDOW: u32 = 25_165_824;
+const H2_INITIAL_STREAM_WINDOW: u32 = 16_777_216;
+const H2_SEND_BUFFER: usize = 16_777_216;
+const H2_DATA_FRAME_BUDGET: usize = 256 * 1024;
+const UDP_CAPSULE_BATCH_BYTES: usize = 64 * 1024;
+
+fn runtime() -> Result<Runtime> {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .context("build HTTP/2 benchmark runtime")
+}
+
+struct Connection {
+    sender: SendRequest<Bytes>,
+    driver: JoinHandle<Result<(), h2::Error>>,
+}
+
+impl Connection {
+    async fn connect(server_addr: &str) -> Result<Self> {
+        let peer: SocketAddr = server_addr.parse().context("parse HTTP/2 server address")?;
+        let tcp = TcpStream::connect(peer)
+            .await
+            .with_context(|| format!("connect HTTP/2 TCP socket to {peer}"))?;
+        tcp.set_nodelay(true)?;
+
+        let mut connector =
+            boring::ssl::SslConnector::builder(boring::ssl::SslMethod::tls_client())
+                .context("create HTTP/2 TLS connector")?;
+        connector.set_verify(boring::ssl::SslVerifyMode::NONE);
+        connector.set_alpn_protos(b"\x02h2")?;
+        let server_name = std::env::var("MASQUE_SERVER_NAME").unwrap_or_else(|_| "server".into());
+        let tls = tokio_boring::connect(connector.build().configure()?, &server_name, tcp)
+            .await
+            .with_context(|| format!("complete HTTP/2 TLS handshake with {peer}"))?;
+        if tls.ssl().selected_alpn_protocol() != Some(b"h2") {
+            bail!("server did not negotiate h2 ALPN");
+        }
+
+        let mut builder = h2::client::Builder::new();
+        builder
+            .initial_window_size(H2_INITIAL_STREAM_WINDOW)
+            .initial_connection_window_size(H2_INITIAL_CONNECTION_WINDOW)
+            .max_send_buffer_size(H2_SEND_BUFFER)
+            .data_frame_budget(H2_DATA_FRAME_BUDGET);
+        let (sender, connection) = builder.handshake(tls).await?;
+        let driver = tokio::spawn(connection);
+        let sender = sender.ready().await?;
+        let settings_deadline = tokio::time::Instant::now() + CONNECT_TIMEOUT;
+        while !sender.is_extended_connect_protocol_enabled() {
+            if driver.is_finished() {
+                bail!("HTTP/2 connection ended before server SETTINGS arrived");
+            }
+            if tokio::time::Instant::now() >= settings_deadline {
+                bail!("server did not advertise HTTP/2 Extended CONNECT");
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        Ok(Self { sender, driver })
+    }
+
+    async fn ready_sender(&self) -> Result<SendRequest<Bytes>> {
+        self.sender.clone().ready().await.map_err(Into::into)
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.driver.abort();
+    }
+}
+
+fn add_auth(request: &mut Request<()>) -> Result<()> {
+    if let Some(value) = proxy_authorization_value()? {
+        request.headers_mut().insert(
+            http::header::PROXY_AUTHORIZATION,
+            value.parse().context("build Proxy-Authorization header")?,
+        );
+    }
+    Ok(())
+}
+
+fn tcp_request(target: &str, authenticated: bool) -> Result<Request<()>> {
+    let uri = http::Uri::builder()
+        .authority(target)
+        .build()
+        .context("build HTTP/2 CONNECT authority")?;
+    let mut request = Request::builder()
+        .method(Method::CONNECT)
+        .uri(uri)
+        .body(())?;
+    if authenticated {
+        add_auth(&mut request)?;
+    }
+    Ok(request)
+}
+
+fn udp_request(server_addr: &str, target: SocketAddr, authenticated: bool) -> Result<Request<()>> {
+    let uri = format!(
+        "https://{server_addr}/.well-known/masque/udp/{}/{}/",
+        target.ip(),
+        target.port()
+    );
+    let mut request = Request::builder()
+        .method(Method::CONNECT)
+        .uri(uri)
+        .header("capsule-protocol", "?1")
+        .body(())?;
+    request
+        .extensions_mut()
+        .insert(h2::ext::Protocol::from_static("connect-udp"));
+    if authenticated {
+        add_auth(&mut request)?;
+    }
+    Ok(request)
+}
+
+async fn response_with_timeout(
+    response: h2::client::ResponseFuture,
+) -> Result<http::Response<h2::RecvStream>> {
+    tokio::time::timeout(CONNECT_TIMEOUT, response)
+        .await
+        .context("HTTP/2 CONNECT response timeout")?
+        .context("HTTP/2 CONNECT response failed")
+}
+
+async fn send_data_all(
+    send: &mut h2::SendStream<Bytes>,
+    mut data: Bytes,
+    end_stream: bool,
+) -> Result<()> {
+    if data.is_empty() {
+        send.send_data(data, end_stream)?;
+        return Ok(());
+    }
+
+    while data.has_remaining() {
+        send.reserve_capacity(data.remaining());
+        let capacity = poll_fn(|cx| send.poll_capacity(cx))
+            .await
+            .context("HTTP/2 request stream closed while waiting for flow-control capacity")??;
+        let take = capacity.min(data.remaining());
+        let chunk = data.split_to(take);
+        let finished = end_stream && data.is_empty();
+        send.send_data(chunk, finished)?;
+    }
+    Ok(())
+}
+
+pub(super) fn wait_for_server(server_addr: &str) -> Result<()> {
+    runtime()?.block_on(async {
+        let connection = Connection::connect(server_addr).await?;
+        let sender = connection.ready_sender().await?;
+        if !sender.is_extended_connect_protocol_enabled() {
+            bail!("server did not advertise HTTP/2 Extended CONNECT");
+        }
+        Ok(())
+    })
+}
+
+pub(super) fn test_auth_required(server_addr: &str, echo_addr: &str) -> Result<()> {
+    runtime()?.block_on(async {
+        let connection = Connection::connect(server_addr).await?;
+        let mut sender = connection.ready_sender().await?;
+        let (response, _) = sender.send_request(
+            udp_request(
+                server_addr,
+                echo_addr.parse().context("parse UDP echo address")?,
+                false,
+            )?,
+            false,
+        )?;
+        let response = response_with_timeout(response).await?;
+        if response.status() != StatusCode::PROXY_AUTHENTICATION_REQUIRED {
+            bail!(
+                "expected HTTP/2 CONNECT-UDP status 407, got {}",
+                response.status()
+            );
+        }
+        if response.headers().get("proxy-authenticate")
+            != Some(&http::HeaderValue::from_static(
+                "Basic realm=\"masque\", charset=\"UTF-8\"",
+            ))
+        {
+            bail!("HTTP/2 407 response has no expected Proxy-Authenticate challenge");
+        }
+        Ok(())
+    })
+}
+
+pub(super) fn test_tcp(server_addr: &str, echo_addr: &str) -> Result<()> {
+    runtime()?.block_on(async {
+        let connection = Connection::connect(server_addr).await?;
+        let mut sender = connection.ready_sender().await?;
+        let (response, mut request_body) =
+            sender.send_request(tcp_request(echo_addr, true)?, false)?;
+        let response = response_with_timeout(response).await?;
+        if response.status() != StatusCode::OK {
+            bail!(
+                "expected HTTP/2 CONNECT status 200, got {}",
+                response.status()
+            );
+        }
+
+        let payload = Bytes::from_static(b"standard HTTP/2 CONNECT echo test");
+        send_data_all(&mut request_body, payload.clone(), true).await?;
+        let mut response_body = response.into_body();
+        let mut echoed = Vec::with_capacity(payload.len());
+        while echoed.len() < payload.len() {
+            let chunk = tokio::time::timeout(CONNECT_TIMEOUT, response_body.data())
+                .await
+                .context("HTTP/2 CONNECT echo timeout")?
+                .context("HTTP/2 CONNECT response ended early")??;
+            response_body.flow_control().release_capacity(chunk.len())?;
+            echoed.extend_from_slice(&chunk);
+        }
+        if echoed != payload {
+            bail!("HTTP/2 CONNECT echo payload mismatch");
+        }
+        Ok(())
+    })
+}
+
+struct UdpTunnel {
+    _connection: Connection,
+    request_body: h2::SendStream<Bytes>,
+    response_body: h2::RecvStream,
+    decoder: CapsuleDecoder,
+}
+
+impl UdpTunnel {
+    async fn connect(server_addr: &str, echo_addr: &str) -> Result<Self> {
+        let connection = Connection::connect(server_addr).await?;
+        let mut sender = connection.ready_sender().await?;
+        if !sender.is_extended_connect_protocol_enabled() {
+            bail!("server did not advertise HTTP/2 Extended CONNECT");
+        }
+        let target = echo_addr.parse().context("parse UDP echo address")?;
+        let (response, request_body) =
+            sender.send_request(udp_request(server_addr, target, true)?, false)?;
+        let response = response_with_timeout(response).await?;
+        if response.status() != StatusCode::OK {
+            bail!(
+                "expected HTTP/2 CONNECT-UDP status 200, got {}",
+                response.status()
+            );
+        }
+        if response.headers().get("capsule-protocol") != Some(&http::HeaderValue::from_static("?1"))
+        {
+            bail!("HTTP/2 CONNECT-UDP response omitted Capsule-Protocol");
+        }
+        Ok(Self {
+            _connection: connection,
+            request_body,
+            response_body: response.into_body(),
+            decoder: CapsuleDecoder::new(),
+        })
+    }
+
+    async fn send_payload(&mut self, payload: &[u8]) -> Result<()> {
+        let mut capsule = Vec::with_capacity(payload.len() + 16);
+        encoder::encode_datagram_context_zero(payload, &mut capsule);
+        send_data_all(&mut self.request_body, Bytes::from(capsule), false).await
+    }
+
+    fn decode_chunk(&mut self, chunk: &Bytes, payloads: &mut Vec<Vec<u8>>) -> Result<()> {
+        let frames = match self.decoder.decode(chunk) {
+            Ok(frames) => frames,
+            Err(DecodeError::Incomplete) => Vec::new(),
+            Err(error) => bail!("decode HTTP/2 DATAGRAM capsule: {error:?}"),
+        };
+        for frame in frames {
+            let CapsuleFrame::Datagram(value) = frame else {
+                continue;
+            };
+            let (context_id, context_len) = masque::varint::decode(&value)
+                .map_err(|_| anyhow::anyhow!("HTTP/2 DATAGRAM capsule has no Context ID"))?;
+            if context_id == 0 {
+                payloads.push(value[context_len..].to_vec());
+            }
+        }
+        Ok(())
+    }
+
+    async fn recv_payload(&mut self, timeout: Duration) -> Result<Vec<u8>> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let chunk = tokio::time::timeout_at(deadline, self.response_body.data())
+                .await
+                .context("HTTP/2 DATAGRAM capsule timeout")?
+                .context("HTTP/2 CONNECT-UDP response ended")??;
+            self.response_body
+                .flow_control()
+                .release_capacity(chunk.len())?;
+            let mut payloads = Vec::new();
+            self.decode_chunk(&chunk, &mut payloads)?;
+            if let Some(payload) = payloads.into_iter().next() {
+                return Ok(payload);
+            }
+        }
+    }
+
+    async fn poll_data_now(&mut self) -> Poll<Option<Result<Bytes, h2::Error>>> {
+        poll_fn(|cx| Poll::Ready(self.response_body.poll_data(cx))).await
+    }
+
+    fn consume_chunk(
+        &mut self,
+        chunk: Bytes,
+        in_flight: &mut InFlight,
+        received: &mut u64,
+    ) -> Result<()> {
+        self.response_body
+            .flow_control()
+            .release_capacity(chunk.len())?;
+        let mut payloads = Vec::new();
+        self.decode_chunk(&chunk, &mut payloads)?;
+        for payload in payloads {
+            if payload.len() < 8 {
+                continue;
+            }
+            let sequence = u64::from_be_bytes(payload[..8].try_into().unwrap());
+            if in_flight.remove(&sequence) {
+                *received += 1;
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_echo_throughput(
+        &mut self,
+        payload_size: usize,
+        duration: Duration,
+        window: usize,
+        expiry: Duration,
+    ) -> Result<(u64, u64, u64)> {
+        if payload_size < 8 {
+            bail!("benchmark payload must be at least 8 bytes");
+        }
+
+        let started = Instant::now();
+        let deadline = started + duration;
+        let drain_deadline = deadline + expiry;
+        let mut payload = vec![0x5a; payload_size];
+        let mut in_flight = InFlight::with_capacity(window);
+        let mut next_sequence = 0_u64;
+        let mut sent = 0_u64;
+        let mut received = 0_u64;
+        let mut expired = 0_u64;
+
+        while Instant::now() < drain_deadline {
+            let now = Instant::now();
+            expired += in_flight.expire(now, expiry);
+            let mut made_progress = false;
+
+            if now < deadline && in_flight.len() < window {
+                let available = window - in_flight.len();
+                let mut capsule_batch = Vec::with_capacity(
+                    UDP_CAPSULE_BATCH_BYTES.min(available.saturating_mul(payload_size + 16)),
+                );
+                let mut sequences = Vec::with_capacity(available);
+                while sequences.len() < available {
+                    payload[..8].copy_from_slice(&next_sequence.to_be_bytes());
+                    let before = capsule_batch.len();
+                    encoder::encode_datagram_context_zero(&payload, &mut capsule_batch);
+                    if before != 0 && capsule_batch.len() > UDP_CAPSULE_BATCH_BYTES {
+                        capsule_batch.truncate(before);
+                        break;
+                    }
+                    sequences.push(next_sequence);
+                    next_sequence += 1;
+                }
+                send_data_all(&mut self.request_body, Bytes::from(capsule_batch), false).await?;
+                let sent_at = Instant::now();
+                for sequence in sequences {
+                    in_flight.insert(sequence, sent_at);
+                    sent += 1;
+                }
+                made_progress = true;
+            }
+
+            loop {
+                match self.poll_data_now().await {
+                    Poll::Ready(Some(Ok(chunk))) => {
+                        self.consume_chunk(chunk, &mut in_flight, &mut received)?;
+                        made_progress = true;
+                    }
+                    Poll::Ready(Some(Err(error))) => return Err(error.into()),
+                    Poll::Ready(None) => {
+                        if in_flight.is_empty() && now >= deadline {
+                            break;
+                        }
+                        bail!("HTTP/2 CONNECT-UDP response ended during benchmark");
+                    }
+                    Poll::Pending => break,
+                }
+            }
+
+            if now >= deadline && in_flight.is_empty() {
+                break;
+            }
+            if !made_progress {
+                match tokio::time::timeout(Duration::from_millis(1), self.response_body.data())
+                    .await
+                {
+                    Ok(Some(Ok(chunk))) => {
+                        self.consume_chunk(chunk, &mut in_flight, &mut received)?;
+                    }
+                    Ok(Some(Err(error))) => return Err(error.into()),
+                    Ok(None) => bail!("HTTP/2 CONNECT-UDP response ended during benchmark"),
+                    Err(_) => {}
+                }
+            }
+        }
+
+        expired += in_flight.len() as u64;
+        Ok((sent, received, expired))
+    }
+}
+
+pub(super) fn test_udp(server_addr: &str, echo_addr: &str) -> Result<()> {
+    runtime()?.block_on(async {
+        let mut tunnel = UdpTunnel::connect(server_addr, echo_addr).await?;
+        let payload = b"HTTP/2 CONNECT-UDP echo test";
+        tunnel.send_payload(payload).await?;
+        let echoed = tunnel.recv_payload(CONNECT_TIMEOUT).await?;
+        if echoed != payload {
+            bail!("HTTP/2 CONNECT-UDP echo payload mismatch");
+        }
+        Ok(())
+    })
+}
+
+pub(super) fn benchmark_udp(
+    server_addr: &str,
+    echo_addr: &str,
+    config: UdpBenchConfig,
+) -> Result<()> {
+    runtime()?.block_on(async {
+        println!("MASQUE CONNECT-UDP (transport=http2):");
+        let setup_started = Instant::now();
+        let mut tunnel = UdpTunnel::connect(server_addr, echo_addr).await?;
+        let setup = setup_started.elapsed();
+
+        let latency_payload = vec![0x3c; 64];
+        let mut latencies = Vec::with_capacity(config.latency_samples);
+        for _ in 0..config.latency_samples {
+            let started = Instant::now();
+            tunnel.send_payload(&latency_payload).await?;
+            let response = tunnel.recv_payload(Duration::from_secs(2)).await?;
+            if response != latency_payload {
+                bail!("HTTP/2 latency probe payload mismatch");
+            }
+            latencies.push(started.elapsed().as_secs_f64() * 1e6);
+        }
+        latencies.sort_by(f64::total_cmp);
+        let percentile = |p: f64| super::percentile_nearest_rank(&latencies, p).unwrap();
+        println!(
+            "  setup {:.3} ms; RTT 64B ({} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
+            setup.as_secs_f64() * 1e3,
+            config.latency_samples,
+            percentile(0.50),
+            percentile(0.95),
+            percentile(0.99),
+        );
+
+        drop(tunnel);
+        for payload_size in [64, 1_200] {
+            let mut tunnel = UdpTunnel::connect(server_addr, echo_addr).await?;
+            let (sent, received, expired) = tunnel
+                .run_echo_throughput(payload_size, config.duration, config.window, config.expiry)
+                .await?;
+            print_udp_result(
+                "http2",
+                "masque",
+                payload_size,
+                config.duration,
+                sent,
+                received,
+                expired,
+            );
+        }
+        Ok(())
+    })
+}
+
+async fn run_tcp_download(
+    connection: &Connection,
+    target: &str,
+    path: &str,
+    configured_body_bytes: Option<u64>,
+    timeout: Duration,
+) -> Result<(TcpDownloadResult, Instant, Instant)> {
+    let mut sender = connection.ready_sender().await?;
+    let (response, mut request_body) = sender.send_request(tcp_request(target, true)?, false)?;
+    let response = response_with_timeout(response).await?;
+    if response.status() != StatusCode::OK {
+        bail!(
+            "expected HTTP/2 CONNECT status 200, got {}",
+            response.status()
+        );
+    }
+    let connected_at = Instant::now();
+
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: {target}\r\nAccept-Encoding: identity\r\nConnection: close\r\n\r\n"
+    );
+    let request_started = Instant::now();
+    send_data_all(&mut request_body, Bytes::from(request), true).await?;
+    let mut response_body = response.into_body();
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut parsed = HttpDownloadResponse::new();
+    let mut stream_finished = false;
+    loop {
+        let chunk = tokio::time::timeout_at(deadline, response_body.data())
+            .await
+            .with_context(|| {
+                format!(
+                    "HTTP/2 CONNECT download timed out after {} body bytes",
+                    parsed.body_bytes
+                )
+            })?;
+        match chunk {
+            Some(Ok(chunk)) => {
+                response_body.flow_control().release_capacity(chunk.len())?;
+                parsed.ingest(&chunk, Instant::now())?;
+            }
+            Some(Err(error)) => return Err(error.into()),
+            None => {
+                stream_finished = true;
+                break;
+            }
+        }
+
+        if let Some(expected) = parsed.expected_body_bytes(configured_body_bytes) {
+            if parsed.body_bytes > expected {
+                bail!(
+                    "HTTP/2 CONNECT received {} HTTP body bytes, expected {expected}",
+                    parsed.body_bytes
+                );
+            }
+            if parsed.body_bytes == expected {
+                break;
+            }
+        }
+    }
+
+    if !parsed.header_complete || parsed.status != Some(200) {
+        bail!("HTTP/2 CONNECT origin returned an incomplete or unsuccessful response");
+    }
+    if let Some(expected) = parsed.expected_body_bytes(configured_body_bytes)
+        && parsed.body_bytes != expected
+    {
+        bail!(
+            "HTTP/2 CONNECT download finished after {} of {expected} body bytes",
+            parsed.body_bytes
+        );
+    }
+    Ok((
+        TcpDownloadResult {
+            response: parsed,
+            finished_at: Instant::now(),
+            stream_finished,
+        },
+        connected_at,
+        request_started,
+    ))
+}
+
+pub(super) fn benchmark_tcp_download(server_addr: &str) -> Result<()> {
+    let target = std::env::var("MASQUE_TCP_TARGET")
+        .context("MASQUE_TCP_TARGET must be set to origin-host:port")?;
+    let path = std::env::var("MASQUE_TCP_PATH").unwrap_or_else(|_| "/masque-bench.bin".into());
+    let configured_body_bytes = std::env::var("MASQUE_TCP_DOWNLOAD_BYTES")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .context("MASQUE_TCP_DOWNLOAD_BYTES must be an integer")
+        })
+        .transpose()?;
+    let timeout_secs = std::env::var("MASQUE_TCP_TIMEOUT_SECS")
+        .unwrap_or_else(|_| "120".into())
+        .parse::<u64>()
+        .context("MASQUE_TCP_TIMEOUT_SECS must be an integer")?;
+    let repeats = std::env::var("MASQUE_TCP_DOWNLOAD_REPEATS")
+        .unwrap_or_else(|_| "1".into())
+        .parse::<u32>()
+        .context("MASQUE_TCP_DOWNLOAD_REPEATS must be an integer")?;
+    let direct_baseline = std::env::var_os("MASQUE_TCP_DIRECT_BASELINE").is_some();
+    if target.is_empty()
+        || target
+            .chars()
+            .any(|ch| ch.is_control() || ch.is_whitespace())
+    {
+        bail!("MASQUE_TCP_TARGET contains invalid characters");
+    }
+    if !path.starts_with('/') || path.chars().any(char::is_control) {
+        bail!("MASQUE_TCP_PATH must be an absolute path without control characters");
+    }
+    if configured_body_bytes == Some(0) || timeout_secs == 0 || repeats == 0 || repeats > 16 {
+        bail!("download size and timeout must be non-zero; repeats must be between 1 and 16");
+    }
+
+    let runtime = runtime()?;
+    let setup_started = Instant::now();
+    let connection = runtime.block_on(Connection::connect(server_addr))?;
+    let transport_setup = setup_started.elapsed();
+    let mut direct_transfer_rates = Vec::with_capacity(repeats as usize);
+    let mut masque_transfer_rates = Vec::with_capacity(repeats as usize);
+
+    for sample in 1..=repeats {
+        if direct_baseline {
+            let (direct, direct_started, connected_at, request_started) =
+                benchmark_direct_tcp_download(
+                    &target,
+                    &path,
+                    configured_body_bytes,
+                    Duration::from_secs(timeout_secs),
+                )?;
+            let first_body_at = direct
+                .response
+                .first_body_at
+                .context("direct HTTP response contained no body")?;
+            let body_bytes = direct.response.body_bytes;
+            let connect_elapsed = connected_at.saturating_duration_since(direct_started);
+            let ttfb = first_body_at.saturating_duration_since(request_started);
+            let request_elapsed = direct
+                .finished_at
+                .saturating_duration_since(request_started);
+            let transfer_elapsed = direct.finished_at.saturating_duration_since(first_body_at);
+            let sample_elapsed = direct.finished_at.saturating_duration_since(direct_started);
+            let mbps = |elapsed: Duration| {
+                body_bytes as f64 * 8.0 / elapsed.as_secs_f64().max(f64::EPSILON) / 1_000_000.0
+            };
+            let transfer_mbps = mbps(transfer_elapsed);
+            direct_transfer_rates.push(transfer_mbps);
+            println!(
+                "DIRECT_TCP_DOWNLOAD_RESULT transport=http2 sample={sample} body_bytes={body_bytes} connect_ms={:.3} ttfb_ms={:.3} request_ms={:.3} transfer_ms={:.3} sample_ms={:.3} request_mbps={:.3} transfer_mbps={transfer_mbps:.3} sample_mbps={:.3} stream_finished={}",
+                connect_elapsed.as_secs_f64() * 1e3,
+                ttfb.as_secs_f64() * 1e3,
+                request_elapsed.as_secs_f64() * 1e3,
+                transfer_elapsed.as_secs_f64() * 1e3,
+                sample_elapsed.as_secs_f64() * 1e3,
+                mbps(request_elapsed),
+                mbps(sample_elapsed),
+                direct.stream_finished,
+            );
+        }
+
+        let sample_started = Instant::now();
+        let (result, connected_at, request_started) = runtime.block_on(run_tcp_download(
+            &connection,
+            &target,
+            &path,
+            configured_body_bytes,
+            Duration::from_secs(timeout_secs),
+        ))?;
+        let first_body_at = result
+            .response
+            .first_body_at
+            .context("HTTP/2 origin response contained no body")?;
+        let body_bytes = result.response.body_bytes;
+        let connect_elapsed = connected_at.saturating_duration_since(sample_started);
+        let ttfb = first_body_at.saturating_duration_since(request_started);
+        let request_elapsed = result
+            .finished_at
+            .saturating_duration_since(request_started);
+        let transfer_elapsed = result.finished_at.saturating_duration_since(first_body_at);
+        let sample_elapsed = result.finished_at.saturating_duration_since(sample_started);
+        let mbps = |elapsed: Duration| {
+            body_bytes as f64 * 8.0 / elapsed.as_secs_f64().max(f64::EPSILON) / 1_000_000.0
+        };
+        let transfer_mbps = mbps(transfer_elapsed);
+        masque_transfer_rates.push(transfer_mbps);
+        println!(
+            "TCP_DOWNLOAD_RESULT transport=http2 sample={sample} body_bytes={body_bytes} transport_setup_ms={:.3} connect_ms={:.3} ttfb_ms={:.3} request_ms={:.3} transfer_ms={:.3} sample_ms={:.3} request_mbps={:.3} transfer_mbps={transfer_mbps:.3} sample_mbps={:.3} stream_finished={}",
+            transport_setup.as_secs_f64() * 1e3,
+            connect_elapsed.as_secs_f64() * 1e3,
+            ttfb.as_secs_f64() * 1e3,
+            request_elapsed.as_secs_f64() * 1e3,
+            transfer_elapsed.as_secs_f64() * 1e3,
+            sample_elapsed.as_secs_f64() * 1e3,
+            mbps(request_elapsed),
+            mbps(sample_elapsed),
+            result.stream_finished,
+        );
+    }
+
+    let masque_median = median(&mut masque_transfer_rates).expect("at least one sample");
+    if let Some(direct_median) = median(&mut direct_transfer_rates) {
+        println!(
+            "TCP_DOWNLOAD_SUMMARY transport=http2 samples={repeats} direct_transfer_mbps_median={direct_median:.3} masque_transfer_mbps_median={masque_median:.3} direct_ratio_pct={:.2}",
+            masque_median * 100.0 / direct_median,
+        );
+    } else {
+        println!(
+            "TCP_DOWNLOAD_SUMMARY transport=http2 samples={repeats} masque_transfer_mbps_median={masque_median:.3}"
+        );
+    }
+    Ok(())
+}

--- a/tools/masque-e2e/src/main.rs
+++ b/tools/masque-e2e/src/main.rs
@@ -17,11 +17,39 @@ use quiche::h3::NameValue;
 use ring::rand::SecureRandom;
 use tracing::{error, info, warn};
 
+mod http2;
+
 const MAX_DATAGRAM_SIZE: usize = 1350;
 const BUF_SIZE: usize = 65535;
 const MAX_HTTP_RESPONSE_HEADER_SIZE: usize = 64 * 1024;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 const CLIENT_UDP_RECEIVE_BUFFER_SIZE: libc::c_int = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BenchTransport {
+    Http3,
+    Http2,
+}
+
+impl BenchTransport {
+    fn from_env() -> Result<Self> {
+        match std::env::var("MASQUE_BENCH_TRANSPORT").as_deref() {
+            Ok("http2") => Ok(Self::Http2),
+            Ok("http3") | Err(std::env::VarError::NotPresent) => Ok(Self::Http3),
+            Ok(other) => bail!("MASQUE_BENCH_TRANSPORT must be http2 or http3, got {other:?}"),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                bail!("MASQUE_BENCH_TRANSPORT is not valid UTF-8")
+            }
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Http3 => "http3",
+            Self::Http2 => "http2",
+        }
+    }
+}
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn tune_udp_receive_buffer(socket: &UdpSocket) {
@@ -1029,16 +1057,24 @@ fn run_direct_echo_throughput(
 // Server readiness check
 // ---------------------------------------------------------------------------
 
-fn wait_for_server(server_addr: &str) -> Result<()> {
+fn wait_for_server(server_addr: &str, transport: BenchTransport) -> Result<()> {
     let mut delay = Duration::from_millis(250);
 
     for attempt in 1..=20 {
-        info!(attempt, "checking server readiness…");
-        match Client::connect(server_addr).and_then(|mut c| {
-            c.handshake()?;
-            c.init_h3()?;
-            Ok(())
-        }) {
+        info!(
+            attempt,
+            transport = transport.as_str(),
+            "checking server readiness…"
+        );
+        let ready = match transport {
+            BenchTransport::Http3 => Client::connect(server_addr).and_then(|mut client| {
+                client.handshake()?;
+                client.init_h3()?;
+                Ok(())
+            }),
+            BenchTransport::Http2 => http2::wait_for_server(server_addr),
+        };
+        match ready {
             Ok(()) => {
                 info!("server ready");
                 return Ok(());
@@ -1050,7 +1086,7 @@ fn wait_for_server(server_addr: &str) -> Result<()> {
             }
         }
     }
-    bail!("server not ready after 20 attempts")
+    bail!("{} server not ready after 20 attempts", transport.as_str())
 }
 
 // ---------------------------------------------------------------------------
@@ -1058,10 +1094,21 @@ fn wait_for_server(server_addr: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn append_proxy_authorization(headers: &mut Vec<quiche::h3::Header>) -> Result<()> {
+    let Some(value) = proxy_authorization_value()? else {
+        return Ok(());
+    };
+    headers.push(quiche::h3::Header::new(
+        b"proxy-authorization",
+        value.as_bytes(),
+    ));
+    Ok(())
+}
+
+fn proxy_authorization_value() -> Result<Option<String>> {
     let username = std::env::var_os("MASQUE_USERNAME");
     let password = std::env::var_os("MASQUE_PASSWORD");
     let (username, password) = match (username, password) {
-        (None, None) => return Ok(()),
+        (None, None) => return Ok(None),
         (Some(username), Some(password)) => (username, password),
         _ => bail!("MASQUE_USERNAME and MASQUE_PASSWORD must be set together"),
     };
@@ -1081,11 +1128,7 @@ fn append_proxy_authorization(headers: &mut Vec<quiche::h3::Header>) -> Result<(
 
     let user_pass = format!("{username}:{password}");
     let value = format!("Basic {}", STANDARD.encode(user_pass));
-    headers.push(quiche::h3::Header::new(
-        b"proxy-authorization",
-        value.as_bytes(),
-    ));
-    Ok(())
+    Ok(Some(value))
 }
 
 fn connect_udp_headers_without_auth(
@@ -1368,7 +1411,7 @@ fn benchmark_standard_connect_download(server_addr: &str) -> Result<()> {
             let sample_mbps = mbps(sample_elapsed);
             direct_transfer_rates.push(transfer_mbps);
             println!(
-                "DIRECT_TCP_DOWNLOAD_RESULT sample={sample} body_bytes={body_bytes} \
+                "DIRECT_TCP_DOWNLOAD_RESULT transport=http3 sample={sample} body_bytes={body_bytes} \
 connect_ms={:.3} ttfb_ms={:.3} request_ms={:.3} transfer_ms={:.3} sample_ms={:.3} \
 request_mbps={:.3} transfer_mbps={:.3} sample_mbps={:.3} stream_finished={}",
                 connect_elapsed.as_secs_f64() * 1000.0,
@@ -1462,13 +1505,14 @@ request_mbps={:.3} transfer_mbps={:.3} sample_mbps={:.3} stream_finished={}",
             .unwrap_or((0.0, 0, 0, 0.0));
 
         println!(
-            "TCP_DOWNLOAD_RESULT sample={sample} body_bytes={body_bytes} quic_setup_ms={:.3} \
+            "TCP_DOWNLOAD_RESULT transport=http3 sample={sample} body_bytes={body_bytes} transport_setup_ms={:.3} quic_setup_ms={:.3} \
 connect_ms={:.3} ttfb_ms={:.3} request_ms={:.3} transfer_ms={:.3} sample_ms={:.3} \
 request_mbps={:.3} transfer_mbps={:.3} sample_mbps={:.3} rtt_ms={rtt_ms:.3} \
 client_cwnd={client_cwnd} pmtu={pmtu} \
 client_delivery_rate_mbps={client_delivery_rate_mbps:.3} recv_packets={} \
 recv_wire_bytes={} client_lost_packets={} client_lost_bytes={} \
 data_blocked_received={} stream_blocked_received={} stream_finished={}",
+            quic_setup.as_secs_f64() * 1000.0,
             quic_setup.as_secs_f64() * 1000.0,
             connect_elapsed.as_secs_f64() * 1000.0,
             ttfb.as_secs_f64() * 1000.0,
@@ -1496,13 +1540,13 @@ data_blocked_received={} stream_blocked_received={} stream_finished={}",
         .expect("at least one MASQUE TCP download sample was required");
     if let Some(direct_median) = median(&mut direct_transfer_rates) {
         println!(
-            "TCP_DOWNLOAD_SUMMARY samples={repeats} direct_transfer_mbps_median={direct_median:.3} \
+            "TCP_DOWNLOAD_SUMMARY transport=http3 samples={repeats} direct_transfer_mbps_median={direct_median:.3} \
 masque_transfer_mbps_median={masque_median:.3} direct_ratio_pct={:.2}",
             masque_median * 100.0 / direct_median,
         );
     } else {
         println!(
-            "TCP_DOWNLOAD_SUMMARY samples={repeats} masque_transfer_mbps_median={masque_median:.3}"
+            "TCP_DOWNLOAD_SUMMARY transport=http3 samples={repeats} masque_transfer_mbps_median={masque_median:.3}"
         );
     }
 
@@ -1831,40 +1875,97 @@ fn median(values: &mut [f64]) -> Option<f64> {
     }
 }
 
-fn benchmark_connect_udp(server_addr: &str, echo_addr: &str) -> Result<()> {
-    let duration_secs = std::env::var("MASQUE_BENCH_DURATION_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(5);
-    let window = std::env::var("MASQUE_BENCH_WINDOW")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(256);
-    let latency_samples = std::env::var("MASQUE_BENCH_RTT_SAMPLES")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(50);
-    let expiry_ms = std::env::var("MASQUE_BENCH_EXPIRY_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(1_000);
+#[derive(Debug, Clone, Copy)]
+struct UdpBenchConfig {
+    duration: Duration,
+    window: usize,
+    latency_samples: usize,
+    expiry: Duration,
+}
 
-    if duration_secs == 0 || window == 0 || latency_samples == 0 || expiry_ms == 0 {
-        bail!("benchmark duration, window, RTT samples, and expiry must be non-zero");
+impl UdpBenchConfig {
+    fn from_env() -> Result<Self> {
+        const MAX_DURATION_SECS: usize = 3_600;
+        const MAX_WINDOW: usize = 1_000;
+        const MAX_RTT_SAMPLES: usize = 10_000;
+        const MAX_EXPIRY_MS: usize = 60_000;
+
+        let duration_secs = env_usize("MASQUE_BENCH_DURATION_SECS", 5)?;
+        let window = env_usize("MASQUE_BENCH_WINDOW", 256)?;
+        let latency_samples = env_usize("MASQUE_BENCH_RTT_SAMPLES", 50)?;
+        let expiry_ms = env_usize("MASQUE_BENCH_EXPIRY_MS", 1_000)?;
+
+        if duration_secs == 0 || window == 0 || latency_samples == 0 || expiry_ms == 0 {
+            bail!("benchmark duration, window, RTT samples, and expiry must be non-zero");
+        }
+        if duration_secs > MAX_DURATION_SECS {
+            bail!("MASQUE_BENCH_DURATION_SECS must not exceed {MAX_DURATION_SECS}");
+        }
+        if window > MAX_WINDOW {
+            bail!("MASQUE_BENCH_WINDOW must not exceed {MAX_WINDOW}");
+        }
+        if latency_samples > MAX_RTT_SAMPLES {
+            bail!("MASQUE_BENCH_RTT_SAMPLES must not exceed {MAX_RTT_SAMPLES}");
+        }
+        if expiry_ms > MAX_EXPIRY_MS {
+            bail!("MASQUE_BENCH_EXPIRY_MS must not exceed {MAX_EXPIRY_MS}");
+        }
+
+        Ok(Self {
+            duration: Duration::from_secs(duration_secs as u64),
+            window,
+            latency_samples,
+            expiry: Duration::from_millis(expiry_ms as u64),
+        })
     }
+}
 
-    let expiry = Duration::from_millis(expiry_ms);
+fn print_udp_result(
+    transport: &str,
+    path: &str,
+    payload_size: usize,
+    duration: Duration,
+    sent: u64,
+    received: u64,
+    expired: u64,
+) {
+    let seconds = duration.as_secs_f64();
+    let tx_pps = sent as f64 / seconds;
+    let rx_pps = received as f64 / seconds;
+    let goodput_gbps = received as f64 * payload_size as f64 * 8.0 / seconds / 1e9;
+    let response_shortfall_pct = sent.saturating_sub(received) as f64 * 100.0 / sent.max(1) as f64;
+    let relay_gbps = if path == "masque" {
+        Some(goodput_gbps * 2.0)
+    } else {
+        None
+    };
+
+    if let Some(relay_gbps) = relay_gbps {
+        println!(
+            "  Throughput {payload_size:>4}B: tx {tx_pps:>10.0} pkt/s, echo {rx_pps:>10.0} pkt/s, app goodput {goodput_gbps:.3} Gbit/s, bidirectional relay {relay_gbps:.3} Gbit/s, interval shortfall {response_shortfall_pct:.2}% ({expired} expired)"
+        );
+    } else {
+        println!(
+            "  Throughput {payload_size:>4}B: tx {tx_pps:>10.0} pkt/s, echo {rx_pps:>10.0} pkt/s, app goodput {goodput_gbps:.3} Gbit/s, interval shortfall {response_shortfall_pct:.2}% ({expired} expired)"
+        );
+    }
     println!(
-        "CONNECT-UDP benchmark: {duration_secs}s per payload, window {window}, expiry {expiry_ms}ms"
+        "UDP_RESULT transport={transport} path={path} payload_bytes={payload_size} duration_secs={seconds:.3} windowed_tx_packets={sent} rx_packets={received} tx_pps={tx_pps:.3} rx_pps={rx_pps:.3} app_goodput_gbps={goodput_gbps:.6} response_shortfall_pct={response_shortfall_pct:.6} expired_packets={expired}"
     );
+}
 
+fn benchmark_direct_udp(
+    echo_addr: &str,
+    config: UdpBenchConfig,
+    transport: BenchTransport,
+) -> Result<()> {
     println!("Direct UDP echo baseline:");
     let direct_socket = connect_echo_socket(echo_addr)?;
     direct_socket.set_read_timeout(Some(Duration::from_secs(2)))?;
     let latency_payload = vec![0x3c; 64];
     let mut response = [0u8; BUF_SIZE];
-    let mut direct_latencies = Vec::with_capacity(latency_samples);
-    for _ in 0..latency_samples {
+    let mut direct_latencies = Vec::with_capacity(config.latency_samples);
+    for _ in 0..config.latency_samples {
         let started = Instant::now();
         direct_socket.send(&latency_payload)?;
         let len = direct_socket.recv(&mut response)?;
@@ -1874,33 +1975,45 @@ fn benchmark_connect_udp(server_addr: &str, echo_addr: &str) -> Result<()> {
         direct_latencies.push(started.elapsed().as_secs_f64() * 1e6);
     }
     direct_latencies.sort_by(f64::total_cmp);
-    let percentile = |values: &[f64], p: f64| values[((values.len() - 1) as f64 * p) as usize];
+    let percentile = |p: f64| percentile_nearest_rank(&direct_latencies, p).unwrap();
     println!(
-        "  RTT 64B ({latency_samples} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
-        percentile(&direct_latencies, 0.50),
-        percentile(&direct_latencies, 0.95),
-        percentile(&direct_latencies, 0.99),
+        "  RTT 64B ({} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
+        config.latency_samples,
+        percentile(0.50),
+        percentile(0.95),
+        percentile(0.99),
     );
 
-    let duration = Duration::from_secs(duration_secs);
     for payload_size in [64, 1_200] {
-        let (sent, received, expired) =
-            run_direct_echo_throughput(echo_addr, payload_size, duration, window, expiry)?;
-        let seconds = duration.as_secs_f64();
-        let tx_pps = sent as f64 / seconds;
-        let rx_pps = received as f64 / seconds;
-        let goodput_gbps = received as f64 * payload_size as f64 * 8.0 / seconds / 1e9;
-        let response_shortfall = (sent - received) as f64 * 100.0 / sent.max(1) as f64;
-        println!(
-            "  Throughput {payload_size:>4}B: tx {tx_pps:>10.0} pkt/s, echo {rx_pps:>10.0} pkt/s, app goodput {goodput_gbps:.3} Gbit/s, interval shortfall {response_shortfall:.2}% ({expired} expired)"
+        let (sent, received, expired) = run_direct_echo_throughput(
+            echo_addr,
+            payload_size,
+            config.duration,
+            config.window,
+            config.expiry,
+        )?;
+        print_udp_result(
+            transport.as_str(),
+            "direct",
+            payload_size,
+            config.duration,
+            sent,
+            received,
+            expired,
         );
     }
+    Ok(())
+}
 
-    println!("MASQUE CONNECT-UDP:");
+fn benchmark_http3_udp(server_addr: &str, echo_addr: &str, config: UdpBenchConfig) -> Result<()> {
+    println!("MASQUE CONNECT-UDP (transport=http3):");
+    let setup_started = Instant::now();
     let (mut client, stream_id) = connect_udp_tunnel(server_addr, echo_addr)?;
+    let setup = setup_started.elapsed();
 
-    let mut latencies = Vec::with_capacity(latency_samples);
-    for _ in 0..latency_samples {
+    let latency_payload = vec![0x3c; 64];
+    let mut latencies = Vec::with_capacity(config.latency_samples);
+    for _ in 0..config.latency_samples {
         let started = Instant::now();
         client.send_dgram(stream_id, &latency_payload)?;
         let response = client.recv_dgram(Duration::from_secs(2))?;
@@ -1910,34 +2023,58 @@ fn benchmark_connect_udp(server_addr: &str, echo_addr: &str) -> Result<()> {
         latencies.push(started.elapsed().as_secs_f64() * 1e6);
     }
     latencies.sort_by(f64::total_cmp);
+    let percentile = |p: f64| percentile_nearest_rank(&latencies, p).unwrap();
     println!(
-        "  RTT 64B ({latency_samples} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
-        percentile(&latencies, 0.50),
-        percentile(&latencies, 0.95),
-        percentile(&latencies, 0.99),
+        "  setup {:.3} ms; RTT 64B ({} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
+        setup.as_secs_f64() * 1e3,
+        config.latency_samples,
+        percentile(0.50),
+        percentile(0.95),
+        percentile(0.99),
     );
 
     drop(client);
 
     for payload_size in [64, 1_200] {
         let (mut client, stream_id) = connect_udp_tunnel(server_addr, echo_addr)?;
-        let (sent, received, expired) =
-            client.run_echo_throughput(stream_id, payload_size, duration, window, expiry)?;
-        let seconds = duration.as_secs_f64();
-        let tx_pps = sent as f64 / seconds;
-        let rx_pps = received as f64 / seconds;
-        let goodput_gbps = received as f64 * payload_size as f64 * 8.0 / seconds / 1e9;
-        let relay_gbps = goodput_gbps * 2.0;
-        let response_shortfall = if sent == 0 {
-            0.0
-        } else {
-            (sent - received) as f64 * 100.0 / sent as f64
-        };
-        println!(
-            "  Throughput {payload_size:>4}B: tx {tx_pps:>10.0} pkt/s, echo {rx_pps:>10.0} pkt/s, app goodput {goodput_gbps:.3} Gbit/s, bidirectional relay {relay_gbps:.3} Gbit/s, interval shortfall {response_shortfall:.2}% ({expired} expired)"
+        let (sent, received, expired) = client.run_echo_throughput(
+            stream_id,
+            payload_size,
+            config.duration,
+            config.window,
+            config.expiry,
+        )?;
+        print_udp_result(
+            "http3",
+            "masque",
+            payload_size,
+            config.duration,
+            sent,
+            received,
+            expired,
         );
     }
     Ok(())
+}
+
+fn benchmark_connect_udp(
+    server_addr: &str,
+    echo_addr: &str,
+    transport: BenchTransport,
+) -> Result<()> {
+    let config = UdpBenchConfig::from_env()?;
+    println!(
+        "CONNECT-UDP benchmark: transport={}, {:.0}s per payload, window {}, expiry {:.0}ms",
+        transport.as_str(),
+        config.duration.as_secs_f64(),
+        config.window,
+        config.expiry.as_secs_f64() * 1e3,
+    );
+    benchmark_direct_udp(echo_addr, config, transport)?;
+    match transport {
+        BenchTransport::Http3 => benchmark_http3_udp(server_addr, echo_addr, config),
+        BenchTransport::Http2 => http2::benchmark_udp(server_addr, echo_addr, config),
+    }
 }
 
 fn test_connect_udp_policy_deny(server_addr: &str, _echo_addr: &str) -> Result<()> {
@@ -2224,16 +2361,27 @@ fn main() {
     let server_addr =
         std::env::var("MASQUE_SERVER_ADDR").unwrap_or_else(|_| "127.0.0.1:4433".into());
     let echo_addr = std::env::var("ECHO_SERVER_ADDR").unwrap_or_else(|_| "127.0.0.1:9999".into());
+    let transport = match BenchTransport::from_env() {
+        Ok(transport) => transport,
+        Err(error) => {
+            error!(%error, "invalid benchmark transport");
+            std::process::exit(2);
+        }
+    };
 
-    info!(%server_addr, %echo_addr, "MASQUE E2E test suite");
+    info!(%server_addr, %echo_addr, transport = transport.as_str(), "MASQUE E2E test suite");
 
-    if let Err(e) = wait_for_server(&server_addr) {
+    if let Err(e) = wait_for_server(&server_addr, transport) {
         error!(%e, "server not ready");
         std::process::exit(1);
     }
 
     if std::env::var_os("MASQUE_AUTH_CHECK").is_some() {
-        if let Err(e) = test_proxy_auth_required(&server_addr, &echo_addr) {
+        let result = match transport {
+            BenchTransport::Http3 => test_proxy_auth_required(&server_addr, &echo_addr),
+            BenchTransport::Http2 => http2::test_auth_required(&server_addr, &echo_addr),
+        };
+        if let Err(e) = result {
             error!(%e, "proxy authentication check failed");
             std::process::exit(1);
         }
@@ -2241,7 +2389,11 @@ fn main() {
     }
 
     if std::env::var_os("MASQUE_TCP_DOWNLOAD").is_some() {
-        if let Err(e) = benchmark_standard_connect_download(&server_addr) {
+        let result = match transport {
+            BenchTransport::Http3 => benchmark_standard_connect_download(&server_addr),
+            BenchTransport::Http2 => http2::benchmark_tcp_download(&server_addr),
+        };
+        if let Err(e) = result {
             error!(%e, "standard CONNECT download benchmark failed");
             std::process::exit(1);
         }
@@ -2249,6 +2401,14 @@ fn main() {
     }
 
     if std::env::var_os("MASQUE_TCP_CHECK").is_some() {
+        if transport == BenchTransport::Http2 {
+            if let Err(error) = http2::test_tcp(&server_addr, &echo_addr) {
+                error!(%error, "HTTP/2 standard CONNECT check failed");
+                std::process::exit(1);
+            }
+            info!("MASQUE HTTP/2 TCP compatibility checks passed");
+            return;
+        }
         for (name, test) in [
             (
                 "server_capabilities",
@@ -2276,7 +2436,24 @@ fn main() {
         return;
     }
 
+    if std::env::var_os("MASQUE_UDP_CHECK").is_some() {
+        let result = match transport {
+            BenchTransport::Http3 => test_connect_udp_happy_path(&server_addr, &echo_addr),
+            BenchTransport::Http2 => http2::test_udp(&server_addr, &echo_addr),
+        };
+        if let Err(error) = result {
+            error!(%error, "CONNECT-UDP check failed");
+            std::process::exit(1);
+        }
+        info!(transport = transport.as_str(), "CONNECT-UDP check passed");
+        return;
+    }
+
     if std::env::var_os("MASQUE_LOAD").is_some() {
+        if transport == BenchTransport::Http2 {
+            error!("HTTP/2 multi-connection load mode is not implemented; use tcp or udp mode");
+            std::process::exit(2);
+        }
         if let Err(e) = load_test(&server_addr, &echo_addr) {
             error!(%e, "load test failed");
             std::process::exit(1);
@@ -2285,10 +2462,27 @@ fn main() {
     }
 
     if std::env::var_os("MASQUE_BENCH").is_some() {
-        if let Err(e) = benchmark_connect_udp(&server_addr, &echo_addr) {
+        if let Err(e) = benchmark_connect_udp(&server_addr, &echo_addr, transport) {
             error!(%e, "network benchmark failed");
             std::process::exit(1);
         }
+        return;
+    }
+
+    if transport == BenchTransport::Http2 {
+        for (name, result) in [
+            (
+                "standard_connect",
+                http2::test_tcp(&server_addr, &echo_addr),
+            ),
+            ("connect_udp", http2::test_udp(&server_addr, &echo_addr)),
+        ] {
+            if let Err(error) = result {
+                error!(%error, "{name} failed");
+                std::process::exit(1);
+            }
+        }
+        info!("HTTP/2 E2E checks passed");
         return;
     }
 


### PR DESCRIPTION
## Summary

- add comparable HTTP/2 and HTTP/3 TCP/UDP benchmark paths with machine-readable results
- add adaptive QUIC Retry with authenticated, expiring tokens
- enforce process-wide per-source connection and pending-authentication limits across HTTP/2 and HTTP/3
- expose Retry and source-admission metrics and update the monitoring rules
- add scheduled Linux CONNECT-IP/dual-transport verification and parser fuzzing
- document the new configuration, security model, observability, and benchmark procedure

## Security behavior

- Retry tokens bind the source IP, listener address, original destination connection ID, and expiry window
- source ports are intentionally excluded so tokens remain usable through NAT rebinding
- adaptive mode avoids an extra handshake round trip at low load and enables Retry at the configured pressure threshold
- Basic authentication now applies a per-source fair-share limit before the global Argon2 queue

## Validation

- `cargo +1.88.0 check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `shellcheck scripts/network-bench.sh`
- forced-Retry HTTP/2 and HTTP/3 authentication, TCP, and UDP smoke tests
- 10,000 local parser fuzz iterations on the latest nightly

A short one-second loopback sanity run produced 1.498 Gbit/s for HTTP/3 and 1.428 Gbit/s for HTTP/2 with 1200-byte payloads, both with zero response shortfall. These figures are regression checks rather than formal deployment benchmarks.