### PR TITLE
chore: prepare v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.8.0 - 2026-08-22
+
 ### Added
 
 - The network benchmark can drive HTTP/2 and HTTP/3 with the same TCP origin,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,7 +310,7 @@ the server will actually run rather than the ones written down
 — `shards = 0` expanded to one per core, and any excess capped:
 
 ```
-configuration is compatible with masque-server 0.7.0: /etc/masque/masque.toml
+configuration is compatible with masque-server 0.8.0: /etc/masque/masque.toml
 listener 0.0.0.0:443 transport=http3 auth=basic shards=1
 listener 0.0.0.0:4443 transport=http2 auth=client_cert shards=1
 ```

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -782,7 +782,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "masque-server"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "argon2",


### PR DESCRIPTION
## Summary

- bump `masque-server` from 0.7.0 to 0.8.0
- synchronize the workspace and fuzz lockfiles
- move the adaptive Retry, source admission, transport benchmark, and scheduled verification notes into the dated 0.8.0 changelog section
- update the documented `check-config` version output

## Validation

- `scripts/validate-release.sh v0.8.0`
- `sh tests/release-metadata.sh`
- `cargo +1.88.0 check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `shellcheck scripts/package-linux.sh scripts/validate-release.sh`

After this PR is merged, tag the merge commit as `v0.8.0` to trigger the release workflow and Linux x86_64 package build.