### PR TITLE
fix: harden protocol parsing and scheduled E2E

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -62,9 +62,9 @@ fn percent_decode(s: &str) -> String {
     while i < bytes.len() {
         if bytes[i] == b'%'
             && i + 2 < bytes.len()
-            && let Ok(byte) = u8::from_str_radix(&s[i + 1..i + 3], 16)
+            && let (Some(high), Some(low)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2]))
         {
-            result.push(byte);
+            result.push((high << 4) | low);
             i += 3;
             continue;
         }
@@ -72,6 +72,15 @@ fn percent_decode(s: &str) -> String {
         i += 1;
     }
     String::from_utf8_lossy(&result).into_owned()
+}
+
+fn hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// Parse a CONNECT-UDP URI path.
@@ -408,6 +417,18 @@ mod tests {
     #[test]
     fn percent_decode_space() {
         assert_eq!(percent_decode("hello%20world"), "hello world");
+    }
+
+    #[test]
+    fn percent_decode_does_not_slice_through_utf8() {
+        // Regression for the scheduled fuzz crash: URI positions are byte
+        // offsets, so parsing the two bytes after '%' must not slice `str` at
+        // a possible UTF-8 continuation byte.
+        assert_eq!(percent_decode("%%%\u{6e1}065"), "%%%\u{6e1}065");
+
+        let error = parse_udp_path("/.well-known/masque/udp/host/%%%\u{6e1}065/", UDP_TEMPLATE)
+            .unwrap_err();
+        assert!(matches!(error, UriError::InvalidPort(_)));
     }
 
     // ── extract_prefix ────────────────────────────────────────────────

--- a/tests/e2e/client.Dockerfile
+++ b/tests/e2e/client.Dockerfile
@@ -6,19 +6,22 @@ RUN apt-get update && apt-get install -y cmake golang-go && rm -rf /var/lib/apt/
 
 WORKDIR /build
 
-# Dependency caching layer.
+# Dependency caching layer. Cargo validates every declared target before it
+# builds the selected package, so the root benchmark needs a stub here too.
 COPY Cargo.toml Cargo.lock ./
 COPY tools/masque-e2e/Cargo.toml tools/masque-e2e/Cargo.toml
-RUN mkdir -p src tools/masque-e2e/src \
+RUN mkdir -p src benches tools/masque-e2e/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
+    && echo "fn main() {}" > benches/core.rs \
     && echo "fn main() {}" > tools/masque-e2e/src/main.rs \
     && cargo build --release -p masque-e2e 2>/dev/null || true \
     && rm -f target/release/masque-e2e target/release/deps/masque* \
-    && rm -rf src tools/masque-e2e/src
+    && rm -rf src benches tools/masque-e2e/src
 
 # Copy real source and build.
 COPY src/ src/
+COPY benches/ benches/
 COPY tools/masque-e2e/ tools/masque-e2e/
 RUN touch src/main.rs src/lib.rs tools/masque-e2e/src/main.rs \
     && cargo build --release -p masque-e2e

--- a/tests/e2e/client.Dockerfile
+++ b/tests/e2e/client.Dockerfile
@@ -2,7 +2,9 @@
 # Stage 1: build
 FROM rust:1.88-bookworm AS builder
 
-RUN apt-get update && apt-get install -y cmake golang-go && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y cmake golang-go clang libclang-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 

--- a/tests/e2e/echo-server.py
+++ b/tests/e2e/echo-server.py
@@ -1,15 +1,40 @@
 #!/usr/bin/env python3
-"""Minimal UDP echo server for E2E testing."""
+"""Minimal TCP and UDP echo server for E2E testing."""
 
 import socket
 import sys
+import threading
 
 PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 9999
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.bind(("0.0.0.0", PORT))
-print(f"UDP echo server listening on 0.0.0.0:{PORT}", flush=True)
+
+def echo_tcp_connection(connection):
+    with connection:
+        while data := connection.recv(65535):
+            connection.sendall(data)
+
+
+def serve_tcp(listener):
+    while True:
+        connection, _ = listener.accept()
+        threading.Thread(
+            target=echo_tcp_connection,
+            args=(connection,),
+            daemon=True,
+        ).start()
+
+
+tcp_listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+tcp_listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+tcp_listener.bind(("0.0.0.0", PORT))
+tcp_listener.listen()
+
+udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+udp_socket.bind(("0.0.0.0", PORT))
+
+threading.Thread(target=serve_tcp, args=(tcp_listener,), daemon=True).start()
+print(f"TCP and UDP echo server listening on 0.0.0.0:{PORT}", flush=True)
 
 while True:
-    data, addr = sock.recvfrom(65535)
-    sock.sendto(data, addr)
+    data, addr = udp_socket.recvfrom(65535)
+    udp_socket.sendto(data, addr)


### PR DESCRIPTION
## Summary

- decode percent escapes from bytes so malformed UTF-8-adjacent URI input cannot panic a worker
- add a regression test for the parser input found by scheduled fuzzing
- make the E2E client image provide the declared benchmark target and install bindgen tooling
- serve TCP and UDP from the Docker echo target so standard CONNECT is exercised alongside CONNECT-UDP and CONNECT-IP

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test --workspace --release --locked`
- `cargo +1.88.0 check --workspace --locked`
- replayed the fuzz regression input locally
- [Scheduled verification run 32695093421](https://github.com/Vincent-bin/masque-server/actions/runs/32695093421): Linux E2E/transport smoke and parser fuzz both passed

## Release impact

This fixes a runtime panic reachable through malformed CONNECT-UDP paths. It is suitable for a v0.8.3 patch release and does not change configuration compatibility.