### PR TITLE
chore: prepare v0.8.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.8.3 - 2026-08-24
+
+### Fixed
+
+- CONNECT-UDP URI percent decoding now reads hexadecimal escapes entirely from
+  bytes, so a malformed escape next to multibyte UTF-8 cannot panic a proxy
+  worker. The parser fuzz regression is covered by a permanent unit test.
+- Scheduled Linux verification now supplies the E2E client image with its
+  declared benchmark target and bindgen dependencies, while its echo target
+  serves TCP and UDP together so CONNECT, CONNECT-UDP, and CONNECT-IP all run.
+
 ## 0.8.2 - 2026-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -782,14 +782,16 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "masque-server"
-version = "0.8.0"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "argon2",
  "base64",
  "boring",
+ "boring-sys",
  "bytes",
  "clap",
+ "foreign-types",
  "h2",
  "http",
  "ipnet",


### PR DESCRIPTION
## Summary

- bump the server and lockfile versions to 0.8.3
- synchronize the fuzz lockfile with the current package and TLS dependencies
- document the CONNECT-UDP parser hardening and scheduled E2E repairs

## Validation

- `scripts/validate-release.sh v0.8.3`
- `sh tests/release-metadata.sh`
- `cargo +1.88.0 check --workspace --locked`
- `cargo test --workspace --locked`
- the implementation PR's [full Scheduled verification](https://github.com/Vincent-bin/masque-server/actions/runs/32695093421) passed