### PR TITLE
chore: prepare v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.9.0 - 2026-08-26
+
 ### Added
 
 - One Basic listener can authenticate multiple independently managed accounts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"


### PR DESCRIPTION
## Summary

- bump masque-server from 0.8.3 to 0.9.0
- publish the multi-account Basic authentication work in the dated changelog
- keep Cargo.toml and Cargo.lock release metadata aligned

## Verification

- scripts/validate-release.sh v0.9.0
- cargo fmt --all --check
- cargo test --workspace --locked (422 tests)
- git diff --check

After merge, tag v0.9.0 on the merge commit. The tag workflow will rerun release-mode tests, build the Linux x86_64 musl archive, publish checksums, and create the GitHub Release.