### PR TITLE
Prepare v0.10.0 diagnostics and ARM64 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,15 +146,24 @@ jobs:
             CI=true \
             MASQUE_INSTALLER_TEST=1 \
             MASQUE_TEST_PACKAGE_BIN="$PWD/target/debug/masque-server" \
+            MASQUE_TEST_PACKAGE_PROBE="$PWD/target/debug/masque-probe" \
             "$PWD/tests/install-upgrade.sh"
 
   release-build:
-    name: Linux musl release build
+    name: Linux ${{ matrix.arch }} release build
     # Packaging is deliberately omitted from ordinary PR commits. It runs once
     # after merge and can still be exercised together with every other job via
     # workflow_dispatch.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-musl
+          - arch: aarch64
+            target: aarch64-unknown-linux-musl
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -162,13 +171,13 @@ jobs:
       - name: Install native tools
         run: |
           sudo apt-get update
-          sudo apt-get install --yes clang cmake musl-tools
+          sudo apt-get install --yes clang cmake
 
       - name: Install Rust target
         run: |
           rustup toolchain install 1.97.1 --profile minimal
           rustup default 1.97.1
-          rustup target add x86_64-unknown-linux-musl
+          rustup target add "${{ matrix.target }}"
 
       - name: Install Zig cross-linker
         run: |
@@ -182,20 +191,21 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ runner.os }}-1.97.1-musl-${{ hashFiles('Cargo.lock') }}
+          key: cargo-${{ runner.os }}-1.97.1-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            cargo-${{ runner.os }}-1.97.1-musl-
+            cargo-${{ runner.os }}-1.97.1-${{ matrix.target }}-
 
       - name: Build archive
         env:
-          TARGET: x86_64-unknown-linux-musl
+          TARGET: ${{ matrix.target }}
+          ARCH: ${{ matrix.arch }}
           USE_ZIGBUILD: "1"
           VERSION: ci-${{ github.sha }}
         run: scripts/package-linux.sh
 
       - name: Inspect archive
         run: |
-          tar tzf dist/masque-vci-${GITHUB_SHA}-linux-x86_64.tar.gz
+          tar tzf "dist/masque-vci-${GITHUB_SHA}-linux-${{ matrix.arch }}.tar.gz"
           cd dist
           sha256sum --check \
-            masque-vci-${GITHUB_SHA}-linux-x86_64.tar.gz.sha256
+            "masque-vci-${GITHUB_SHA}-linux-${{ matrix.arch }}.tar.gz.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  verify:
+    name: Validate and test
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -32,22 +31,13 @@ jobs:
       - name: Install native build tools
         run: |
           sudo apt-get update
-          sudo apt-get install --yes clang cmake musl-tools
+          sudo apt-get install --yes clang cmake
 
-      - name: Install Rust target
+      - name: Install Rust
         run: |
           rustup toolchain install 1.97.1 --profile minimal
           rustup default 1.97.1
-          rustup target add x86_64-unknown-linux-musl
 
-      - name: Install Zig cross-linker
-        run: |
-          python3 -m pip install --user cargo-zigbuild==0.23.0
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/cargo-zigbuild" --version
-
-      # Tag builds can restore the trusted cache populated by main's packaging
-      # job, but the release archive is always rebuilt from the tagged source.
       - name: Restore Cargo cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -55,16 +45,61 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ runner.os }}-1.97.1-musl-${{ hashFiles('Cargo.lock') }}
+          key: cargo-${{ runner.os }}-1.97.1-native-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            cargo-${{ runner.os }}-1.97.1-musl-
+            cargo-${{ runner.os }}-1.97.1-native-
 
       - name: Test
         run: cargo test --workspace --release --locked
 
+  build:
+    name: Build Linux ${{ matrix.arch }}
+    needs: verify
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-musl
+          - arch: aarch64
+            target: aarch64-unknown-linux-musl
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install native build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang cmake
+
+      - name: Install Rust target
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal
+          rustup default 1.97.1
+          rustup target add "${{ matrix.target }}"
+
+      - name: Install Zig cross-linker
+        run: |
+          python3 -m pip install --user cargo-zigbuild==0.23.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/cargo-zigbuild" --version
+
+      - name: Restore Cargo cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-1.97.1-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-1.97.1-${{ matrix.target }}-
+
       - name: Build release archive
         env:
-          TARGET: x86_64-unknown-linux-musl
+          TARGET: ${{ matrix.target }}
+          ARCH: ${{ matrix.arch }}
           USE_ZIGBUILD: "1"
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
@@ -77,12 +112,34 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: masque-server-linux-x86_64
+          name: masque-server-linux-${{ matrix.arch }}
           path: dist/*
           if-no-files-found: error
 
+  publish:
+    name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download release archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: masque-server-linux-*
+          path: dist
+          merge-multiple: true
+
+      - name: Verify downloaded checksums
+        run: |
+          cd dist
+          sha256sum --check ./*.sha256
+
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.10.0 - 2026-08-26
+
+### Added
+
+- `masque-probe` is shipped beside the server and diagnoses an endpoint from
+  the affected client network. It supports Basic and enrollment credentials,
+  HTTP/3 with HTTP/2 fallback, public TLS validation or endpoint-key pinning,
+  real CONNECT-TCP establishment and a CONNECT-UDP round trip, optional
+  CONNECT-IP setup, fake-DNS overrides, interface binding, and stable JSON
+  output.
+- Basic listener and account creation can emit a mode-`0600` Surge configuration
+  while the plaintext password is available. The standalone `client-config`
+  command provides the same safe output for an already known credential, and
+  fresh installs can generate it through installer prompts or environment
+  variables.
+- `masque-server support-bundle` writes a mode-`0600` structured JSON report
+  containing version, platform, effective listener/tuning summaries, TLS file
+  state and validity window, CONNECT-IP diagnostics, and bounded systemd state.
+  It is built from typed fields and excludes raw TOML, usernames, hashes,
+  roster identities, keys, environment variables, logs, and traffic details.
+- GitHub releases now include static Linux ARM64 (`aarch64`) archives in
+  addition to x86_64. Both architectures package and transactionally install
+  the server and client probe.
+
 ## 0.9.0 - 2026-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,8 +773,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "masque-probe"
+version = "0.10.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "boring",
+ "bytes",
+ "clap",
+ "h2",
+ "http",
+ "libc",
+ "masque-server",
+ "quiche",
+ "ring",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-boring",
+ "zeroize",
+]
+
+[[package]]
 name = "masque-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
-members = [".", "tools/masque-e2e"]
+members = [".", "tools/masque-e2e", "tools/masque-probe"]
 resolver = "3"
 
 [package]
 name = "masque-server"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"
@@ -44,6 +44,7 @@ ipnet = "2"
 quiche = "0.29.3"
 ring = "0.17"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-boring = "4.19"
@@ -53,9 +54,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tun-rs = { version = "2", features = ["async_tokio"] }
 zeroize = "1"
-
-[dev-dependencies]
-serde_json = "1"
 
 # Linux uses this for the packet path (recvmmsg, GSO/GRO, TUN offload); every
 # Unix uses it to turn terminal echo off while `add-listener` reads a password

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ a staging environment.
   updates disconnect only revoked certificate clients
 - Read-only `doctor` checks for CONNECT-IP TUN, forwarding, route, firewall,
   and NAT prerequisites without modifying the host
-- Static Linux x86_64 release archives with a systemd installer
+- A packaged client-side `masque-probe` that verifies TLS, authentication,
+  CONNECT-TCP, CONNECT-UDP, and optional CONNECT-IP over HTTP/3 or HTTP/2
+- Credential-safe client configuration generation and a redacted JSON support
+  bundle for reproducible troubleshooting
+- Static Linux x86_64 and ARM64 release archives with a systemd installer
 
 ## Quick start
 
@@ -103,7 +107,9 @@ Every value, including `--transport http2|http3`, is also available as a flag
 for provisioning scripts. See
 [Adding a listener](docs/configuration.md#adding-a-listener). A new socket is
 bound at startup, so open UDP for HTTP/3 or TCP for HTTP/2, restart the service,
-and confirm it came up.
+and confirm it came up. A new HTTP/3 Basic listener accepts the same
+`--emit-client surge --client-endpoint ... --client-out ...` options shown
+below, so its only plaintext credential can be delivered in the same operation.
 
 Basic accounts on an existing listener can be managed without editing TOML or
 restarting the server. If the file has only one Basic listener, its address can
@@ -112,7 +118,9 @@ be omitted:
 ```sh
 printf '%s\n' 'a-strong-password' | sudo masque-server \
   --config /etc/masque/masque.toml add-user \
-  --username phone --password-stdin
+  --username phone --password-stdin \
+  --emit-client surge --client-endpoint proxy.example.com:8449 \
+  --client-out /root/phone-surge.conf
 sudo masque-server --config /etc/masque/masque.toml list-users
 sudo systemctl reload masque
 ```
@@ -121,6 +129,16 @@ sudo systemctl reload masque
 last account is refused. Existing scalar `username` / `password_hash` files are
 accepted and are migrated to the multi-account form by the first account edit.
 See [Basic account management](docs/configuration.md#basic-account-management).
+
+The generated Surge file is created as mode `0600` and contains the plaintext
+password. If an account already exists and its password is still known, generate
+the same file without changing the server configuration:
+
+```sh
+printf '%s' 'a-strong-password' | masque-server client-config surge \
+  --endpoint proxy.example.com:8449 --username phone \
+  --out /root/phone-surge.conf
+```
 
 CONNECT-IP is independent of the authentication mode: it needs Linux host
 forwarding because it carries complete IP packets through `masque0`, while
@@ -134,9 +152,33 @@ sudo masque-server --config /etc/masque/masque.toml doctor
 The command and the server's startup check are read-only. They never change
 routing, firewall, sysctl, or NAT state.
 
+Run the packaged probe from the same client network that is failing. It tries
+HTTP/3 first and falls back to HTTP/2, then establishes a real upstream TCP
+CONNECT and performs a DNS-over-UDP round trip through the proxy:
+
+```sh
+printf '%s' 'a-strong-password' | masque-probe proxy.example.com:8449 \
+  --username phone --password-stdin
+masque-probe proxy.example.com:4443 --client-config laptop.json --connect-ip
+```
+
+For a shareable server-side report, create a structured bundle rather than
+copying the TOML or logs by hand:
+
+```sh
+sudo masque-server --config /etc/masque/masque.toml support-bundle \
+  --out /root/masque-support.json
+```
+
+The report omits raw configuration, credentials, identities, key material,
+environment variables, logs, and traffic details. Review it before sharing.
+See [Troubleshooting](docs/troubleshooting.md) for probe options and result
+codes.
+
 ## One-command Linux install
 
-On Linux x86_64, download, verify, and install the latest stable release with:
+On Linux x86_64 or ARM64, download, verify, and install the latest stable
+release with:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/install-latest.sh | sudo sh
@@ -144,7 +186,8 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
 
 For a new configuration the installer prompts for `basic`, `client_cert`, or
 `dual` authentication and optional TLS file locations. Basic mode creates the
-first account and generates a random password when none is supplied.
+first account, generates a random password when none is supplied, and can write
+a ready-to-import Surge configuration while the plaintext is still available.
 Client-certificate mode enrolls the first
 client, adds its `[[clients]]` entry, writes its secret JSON as mode `0600`, and
 prints the matching usque and mihomo configuration. Dual mode does both, writing
@@ -156,23 +199,24 @@ the installer never configures forwarding, firewall rules, routes, or NAT.
 
 The same command is also the upgrade command. When
 `/etc/masque/masque.toml` already exists, the candidate binary checks that
-configuration without binding a port or creating a TUN, then upgrades the
-binary, systemd unit, and versioned monitoring assets. It never rewrites the
+configuration without binding a port or creating a TUN, then upgrades both
+binaries, the systemd unit, and versioned monitoring assets. It never rewrites the
 TOML or referenced TLS files, and it does not copy the existing configuration
 into unattended upgrade logs. An
 incompatible configuration aborts before replacement; a failed service restart
-restores the prior binary, unit, monitoring assets, and service state. See
+restores the prior binaries, unit, monitoring assets, and service state. See
 [Deployment](docs/deployment.md#one-command-install) for non-interactive
 variables, certificate requirements, and installing a specific release.
 
 ## Install a downloaded release on Linux
 
-Release archives contain the binary, an example configuration, a hardened
-systemd unit, Prometheus rules, a Grafana dashboard, and an installer:
+Release archives contain `masque-server`, `masque-probe`, an example
+configuration, a hardened systemd unit, Prometheus rules, a Grafana dashboard,
+and an installer. Replace `ARCH` with `x86_64` or `aarch64`:
 
 ```sh
-tar xzf masque-vVERSION-linux-x86_64.tar.gz
-cd masque-vVERSION-linux-x86_64
+tar xzf masque-vVERSION-linux-ARCH.tar.gz
+cd masque-vVERSION-linux-ARCH
 sudo ./install.sh
 ```
 
@@ -197,6 +241,7 @@ upgrades, and diagnostics.
 | [Protocols](docs/protocols.md) | Supported RFCs and CONNECT request behavior |
 | [Performance](docs/performance.md) | Benchmark methodology and Linux fast paths |
 | [Observability](docs/observability.md) | Health/readiness, metrics, alerts, dashboard, and structured logs |
+| [Troubleshooting](docs/troubleshooting.md) | Client probe, redacted support bundle, and failure isolation |
 | [Testing](docs/testing.md) | Unit, E2E, benchmark, and release validation |
 | [Security](docs/security.md) | Threat model, safe defaults, and operational guidance |
 
@@ -208,6 +253,7 @@ src/                    Server library and CLI
   net/                  Platform UDP adapters and Linux batch I/O
   tunnel/               TCP, UDP, and IP tunnel implementations
 tools/masque-e2e/       E2E client and load generator
+tools/masque-probe/     Packaged end-user connectivity diagnostic
 tests/e2e/              Docker E2E environment and fixtures
 benches/                In-process microbenchmarks
 fuzz/                   Scheduled libFuzzer targets for public protocol parsers

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -8,7 +8,9 @@ fi
 
 PACKAGE_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 CANDIDATE_BIN=$PACKAGE_DIR/bin/masque-server
+CANDIDATE_PROBE=$PACKAGE_DIR/bin/masque-probe
 BIN_PATH=/usr/local/bin/masque-server
+PROBE_PATH=/usr/local/bin/masque-probe
 CONFIG_PATH=/etc/masque/masque.toml
 TLS_CERT_PATH=/etc/masque/certs/server.crt
 TLS_KEY_PATH=/etc/masque/certs/server.key
@@ -29,13 +31,17 @@ CHECK_CONFIG_OUTPUT=
 ENROLL_OUTPUT=
 CLIENT_BLOCK_TMP=
 CLIENT_CONFIG_OUT=
+BASIC_CLIENT_CONFIG_OUT=
+BASIC_CLIENT_CONFIG_CREATED=0
 BINARY_INSTALL_TMP=
+PROBE_INSTALL_TMP=
 UNIT_INSTALL_TMP=
 PROMETHEUS_RULES_INSTALL_TMP=
 GRAFANA_DASHBOARD_INSTALL_TMP=
 UPGRADE_BACKUP_DIR=
 ROLLBACK_PENDING=0
 HAD_BINARY=0
+HAD_PROBE=0
 HAD_UNIT=0
 HAD_PROMETHEUS_RULES=0
 HAD_GRAFANA_DASHBOARD=0
@@ -58,10 +64,14 @@ cleanup() {
     [ -z "$ENROLL_OUTPUT" ] || rm -f -- "$ENROLL_OUTPUT"
     [ -z "$CLIENT_BLOCK_TMP" ] || rm -f -- "$CLIENT_BLOCK_TMP"
     [ -z "$BINARY_INSTALL_TMP" ] || rm -f -- "$BINARY_INSTALL_TMP"
+    [ -z "$PROBE_INSTALL_TMP" ] || rm -f -- "$PROBE_INSTALL_TMP"
     [ -z "$UNIT_INSTALL_TMP" ] || rm -f -- "$UNIT_INSTALL_TMP"
     [ -z "$PROMETHEUS_RULES_INSTALL_TMP" ] || rm -f -- "$PROMETHEUS_RULES_INSTALL_TMP"
     [ -z "$GRAFANA_DASHBOARD_INSTALL_TMP" ] || rm -f -- "$GRAFANA_DASHBOARD_INSTALL_TMP"
     [ -z "$UPGRADE_BACKUP_DIR" ] || rm -rf -- "$UPGRADE_BACKUP_DIR"
+    if [ "$cleanup_status" -ne 0 ] && [ "$BASIC_CLIENT_CONFIG_CREATED" -eq 1 ]; then
+        rm -f -- "$BASIC_CLIENT_CONFIG_OUT"
+    fi
     exit "$cleanup_status"
 }
 trap cleanup EXIT
@@ -82,6 +92,16 @@ rollback_installation() {
         fi
     elif ! rm -f -- "$BIN_PATH"; then
         echo "error: could not remove the newly installed $BIN_PATH" >&2
+        rollback_ok=0
+    fi
+
+    if [ "$HAD_PROBE" -eq 1 ]; then
+        if ! cp -p -- "$UPGRADE_BACKUP_DIR/masque-probe" "$PROBE_PATH"; then
+            echo "error: could not restore $PROBE_PATH" >&2
+            rollback_ok=0
+        fi
+    elif ! rm -f -- "$PROBE_PATH"; then
+        echo "error: could not remove the newly installed $PROBE_PATH" >&2
         rollback_ok=0
     fi
 
@@ -142,7 +162,7 @@ rollback_installation() {
 
     ROLLBACK_PENDING=0
     if [ "$rollback_ok" -eq 1 ]; then
-        echo "Previous binary, systemd unit, monitoring assets, and service state restored." >&2
+        echo "Previous binaries, systemd unit, monitoring assets, and service state restored." >&2
     else
         echo "error: rollback was incomplete; inspect the paths and service above" >&2
     fi
@@ -311,6 +331,51 @@ generate_auth_credentials() {
         GENERATED_PASSWORD=1
     fi
     AUTH_PASSWORD_HASH=$(printf '%s' "$AUTH_PASSWORD" | "$CANDIDATE_BIN" hash-password)
+}
+
+generate_basic_client_config() {
+    basic_client_endpoint=${MASQUE_BASIC_CLIENT_ENDPOINT:-}
+    if [ -z "$basic_client_endpoint" ] && can_prompt; then
+        {
+            echo
+            echo "A Surge configuration can be generated while the plaintext Basic"
+            echo "password is available. The server cannot recover it from its hash later."
+        } >/dev/tty
+        basic_client_endpoint=$(prompt_value \
+            "Public Basic endpoint (host:port; leave empty to skip)" "")
+    fi
+    [ -n "$basic_client_endpoint" ] || return
+
+    BASIC_CLIENT_CONFIG_OUT=${MASQUE_BASIC_CLIENT_CONFIG_OUT:-}
+    if [ -z "$BASIC_CLIENT_CONFIG_OUT" ]; then
+        if can_prompt; then
+            BASIC_CLIENT_CONFIG_OUT=$(prompt_value \
+                "Secret Surge configuration output path" /root/masque-surge.conf)
+        else
+            BASIC_CLIENT_CONFIG_OUT=/root/masque-surge.conf
+        fi
+    fi
+    case "$BASIC_CLIENT_CONFIG_OUT" in
+        /*) ;;
+        *) die "the Basic client configuration output path must be absolute" ;;
+    esac
+    [ ! -e "$BASIC_CLIENT_CONFIG_OUT" ] || die \
+        "refusing to overwrite existing client configuration: $BASIC_CLIENT_CONFIG_OUT"
+
+    set -- "$CANDIDATE_BIN" client-config surge \
+        --endpoint "$basic_client_endpoint" --username "$AUTH_USERNAME" \
+        --out "$BASIC_CLIENT_CONFIG_OUT"
+    if [ -n "${MASQUE_BASIC_CLIENT_NAME:-}" ]; then
+        set -- "$@" --name "$MASQUE_BASIC_CLIENT_NAME"
+    fi
+    if ! printf '%s' "$AUTH_PASSWORD" | "$@"; then
+        # client-config normally creates atomically and then exits. If a later
+        # output/sync error happens after creation, do not leave a secret for a
+        # credential the fresh installation will not commit.
+        rm -f -- "$BASIC_CLIENT_CONFIG_OUT"
+        die "failed to generate the Basic client configuration"
+    fi
+    BASIC_CLIENT_CONFIG_CREATED=1
 }
 
 install_tls_material() {
@@ -581,6 +646,10 @@ snapshot_installed_files() {
         cp -p -- "$BIN_PATH" "$UPGRADE_BACKUP_DIR/masque-server"
         HAD_BINARY=1
     fi
+    if [ -e "$PROBE_PATH" ]; then
+        cp -p -- "$PROBE_PATH" "$UPGRADE_BACKUP_DIR/masque-probe"
+        HAD_PROBE=1
+    fi
     if [ -e "$UNIT_PATH" ]; then
         cp -p -- "$UNIT_PATH" "$UPGRADE_BACKUP_DIR/masque.service"
         HAD_UNIT=1
@@ -603,10 +672,12 @@ snapshot_installed_files() {
 
 install_program_and_unit() {
     BINARY_INSTALL_TMP=$(mktemp /usr/local/bin/.masque-server.install.XXXXXX)
+    PROBE_INSTALL_TMP=$(mktemp /usr/local/bin/.masque-probe.install.XXXXXX)
     UNIT_INSTALL_TMP=$(mktemp /etc/systemd/system/.masque.service.install.XXXXXX)
     PROMETHEUS_RULES_INSTALL_TMP=$(mktemp "$MONITORING_DIR/.prometheus-rules.install.XXXXXX")
     GRAFANA_DASHBOARD_INSTALL_TMP=$(mktemp "$MONITORING_DIR/.grafana-dashboard.install.XXXXXX")
     install -m 0755 "$CANDIDATE_BIN" "$BINARY_INSTALL_TMP"
+    install -m 0755 "$CANDIDATE_PROBE" "$PROBE_INSTALL_TMP"
     install -m 0644 "$PACKAGE_DIR/systemd/masque.service" "$UNIT_INSTALL_TMP"
     install -m 0644 "$PACKAGE_DIR/monitoring/prometheus-rules.yml" \
         "$PROMETHEUS_RULES_INSTALL_TMP"
@@ -618,6 +689,8 @@ install_program_and_unit() {
 
     mv -f -- "$BINARY_INSTALL_TMP" "$BIN_PATH"
     BINARY_INSTALL_TMP=
+    mv -f -- "$PROBE_INSTALL_TMP" "$PROBE_PATH"
+    PROBE_INSTALL_TMP=
     mv -f -- "$UNIT_INSTALL_TMP" "$UNIT_PATH"
     UNIT_INSTALL_TMP=
     mv -f -- "$PROMETHEUS_RULES_INSTALL_TMP" "$PROMETHEUS_RULES_PATH"
@@ -664,6 +737,19 @@ run_host_diagnostics() {
 }
 
 [ -x "$CANDIDATE_BIN" ] || die "release package is missing executable $CANDIDATE_BIN"
+[ -x "$CANDIDATE_PROBE" ] || die "release package is missing executable $CANDIDATE_PROBE"
+if ! CANDIDATE_VERSION_OUTPUT=$("$CANDIDATE_BIN" --version); then
+    die "the packaged server binary cannot run on this host"
+fi
+if ! CANDIDATE_PROBE_VERSION_OUTPUT=$("$CANDIDATE_PROBE" --version); then
+    die "the packaged probe binary cannot run on this host"
+fi
+CANDIDATE_VERSION=$(printf '%s\n' "$CANDIDATE_VERSION_OUTPUT" | awk '{print $NF}')
+CANDIDATE_PROBE_VERSION=$(printf '%s\n' "$CANDIDATE_PROBE_VERSION_OUTPUT" | awk '{print $NF}')
+[ -n "$CANDIDATE_VERSION" ] && [ -n "$CANDIDATE_PROBE_VERSION" ] || die \
+    "could not read the packaged binary versions"
+[ "$CANDIDATE_VERSION" = "$CANDIDATE_PROBE_VERSION" ] || die \
+    "packaged binary versions differ: server $CANDIDATE_VERSION, probe $CANDIDATE_PROBE_VERSION"
 parse_start_requested
 parse_host_diagnostics_requested
 
@@ -694,6 +780,10 @@ if [ "$FRESH_CONFIG" -eq 1 ]; then
     render_new_config
     configure_fresh_listen_port
 
+    if mode_uses_basic; then
+        generate_basic_client_config
+    fi
+
     if mode_uses_client_certs; then
         enroll_first_client
     fi
@@ -715,6 +805,7 @@ echo
 echo "MASQUE installation result"
 echo "  Version:        $("$BIN_PATH" --version)"
 echo "  Binary:         $BIN_PATH"
+echo "  Probe:          $PROBE_PATH"
 echo "  Configuration:  $CONFIG_PATH"
 echo "  Authentication: $AUTH_MODE"
 echo "  Service:        $SERVICE_RESULT"
@@ -745,6 +836,9 @@ if [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
     else
         echo "  Password: supplied through MASQUE_AUTH_PASSWORD (not repeated)"
     fi
+    if [ -n "$BASIC_CLIENT_CONFIG_OUT" ]; then
+        echo "  Secret Surge configuration: $BASIC_CLIENT_CONFIG_OUT"
+    fi
 fi
 
 if [ "$CONFIG_CHANGED" -eq 1 ]; then
@@ -774,6 +868,8 @@ elif [ "$START_REQUESTED" -eq 0 ]; then
     echo "Start the service with: systemctl start masque"
 fi
 echo "Review $CONFIG_PATH, especially the proxy allow/deny policy."
+echo "Diagnose from a client host with: masque-probe <host:port> --username <user> --password-stdin"
+echo "Create a support report with: masque-server --config $CONFIG_PATH support-bundle --out masque-support.json"
 
 # Listeners are written only for a fresh installation; an upgrade keeps the
 # existing file. Adding one later is a separate, deliberate command, so name it

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@
 - [Performance](performance.md): fast paths, tuning, and benchmark rules.
 - [Observability](observability.md): health, readiness, Prometheus, Grafana,
   structured logs, and systemd notification.
+- [Troubleshooting](troubleshooting.md): client-side protocol probing,
+  shareable server diagnostics, and failure isolation.
 - [Testing](testing.md): local, E2E, Linux, and release validation.
 - [Security](security.md): threat model and operator hardening.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,8 +14,10 @@ file is the canonical deployable example and is tested by the release flow.
 ```text
 masque-server [OPTIONS]
 masque-server hash-password
+masque-server client-config surge --endpoint <HOST:PORT> --username <NAME> [OPTIONS]
 masque-server --config <PATH> check-config
 masque-server --config <PATH> doctor
+masque-server --config <PATH> support-bundle --out <PATH>
 masque-server --config <PATH> add-listener [OPTIONS]
 masque-server --config <PATH> list-users [OPTIONS]
 masque-server --config <PATH> add-user --username <NAME> [OPTIONS]
@@ -44,6 +46,12 @@ are advisory because the service may be stopped and routing may live in
 nftables, a network namespace, or an upstream gateway. The command prints what
 it could not prove and exits nonzero only for hard prerequisites. It is
 read-only and never configures the host.
+
+`support-bundle` runs configuration validation and the same read-only host
+inspection, then writes a new mode-`0600` JSON report. It summarizes only typed
+operational fields and deliberately excludes the raw TOML, credential values,
+client identities and addresses, key material, environment, logs, and traffic
+details. See [Troubleshooting](troubleshooting.md#server-side-support-bundle).
 
 `add-listener` appends a `[[listeners]]` block to the configuration file, and is
 described under [Adding a listener](#adding-a-listener).
@@ -229,6 +237,33 @@ Duplicate additions and unknown users are rejected without changing the file;
 the final account cannot be removed. Send `SIGHUP` after a successful edit.
 Future requests on existing HTTP/2 and HTTP/3 connections use the new account
 snapshot, while tunnels already authorized continue uninterrupted.
+
+When adding an account, the same command can write the matching Surge proxy
+declaration before discarding the plaintext password:
+
+```sh
+printf '%s' 'phone-password' | sudo masque-server \
+  --config /etc/masque/masque.toml add-user \
+  --username phone --password-stdin \
+  --emit-client surge --client-endpoint proxy.example.com:8449 \
+  --client-name phone --client-out /root/phone-surge.conf
+```
+
+`--client-endpoint` is intentionally explicit: a wildcard listener such as
+`0.0.0.0:8449` is not an address a remote client can dial. Surge MASQUE uses
+HTTP/3, so client output is refused for an HTTP/2 listener. The output is a new
+mode-`0600` file and an existing path is never replaced. If `--client-out` is
+omitted the secret declaration goes to stdout with a warning.
+
+The server retains only Argon2id hashes, so it cannot export an old account's
+password. If the plaintext is known, generate a client file without editing the
+account:
+
+```sh
+printf '%s' 'phone-password' | masque-server client-config surge \
+  --endpoint proxy.example.com:8449 --username phone \
+  --out /root/phone-surge.conf
+```
 
 ### `mode = "client_cert"`
 
@@ -529,6 +564,10 @@ add-listener options:
       --username <NAME>     Basic username
       --password-hash <PHC>  Argon2id hash, as printed by hash-password
       --password-stdin      Read the password from stdin and hash it here
+      --emit-client surge   Emit the Basic credential in Surge syntax
+      --client-endpoint <HOST:PORT>  Public endpoint written to that client config
+      --client-name <NAME>  Optional Surge proxy name
+      --client-out <PATH>   Create a private client file instead of using stdout
       --disable-auth        Write enabled = false (trusted networks only)
       --no-bind-check       Do not test-bind the new address
       --dry-run             Print the block; leave the file unchanged
@@ -539,6 +578,12 @@ Combinations that would be ignored are refused rather than dropped:
 `--username`, `--password-hash`, and `--password-stdin` apply to `--mode basic`
 only, and `--disable-auth` cannot be combined with `--mode`, since a listener
 that demands nothing has no mode to record.
+
+The four client-output options have the same safety and file format described
+under [Basic account management](#basic-account-management). They apply only to
+an authenticated HTTP/3 Basic listener; `--password-hash` cannot produce a
+client file because the plaintext is intentionally unrecoverable, and
+`--dry-run` cannot promise a two-file result.
 
 A Basic `--dry-run` must be given a password through `--password-stdin` or an
 existing hash through `--password-hash`. It never generates a password whose

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,10 +2,12 @@
 
 ## Supported release artifact
 
-GitHub Actions builds a static `x86_64-unknown-linux-musl` binary and packages:
+GitHub Actions builds static `x86_64-unknown-linux-musl` and
+`aarch64-unknown-linux-musl` binaries and packages:
 
 ```text
 bin/masque-server
+bin/masque-probe
 config/masque.toml
 monitoring/prometheus-rules.yml
 monitoring/grafana-dashboard.json
@@ -17,14 +19,14 @@ README.md
 Verify the archive before extraction:
 
 ```sh
-sha256sum --check masque-vVERSION-linux-x86_64.tar.gz.sha256
+sha256sum --check masque-vVERSION-linux-ARCH.tar.gz.sha256
 ```
 
 ## One-command install
 
-On Linux x86_64, the bootstrap installer resolves the latest stable GitHub
-release, downloads its archive and checksum, verifies SHA-256, and invokes the
-installer from that archive:
+On Linux x86_64 or ARM64, the bootstrap installer detects the architecture,
+resolves the latest stable GitHub release, downloads its archive and checksum,
+verifies SHA-256, and invokes the installer from that archive:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/install-latest.sh | sudo sh
@@ -34,7 +36,8 @@ Although the script arrives on standard input, interactive answers are read
 from `/dev/tty`. A new installation offers three modes:
 
 - `basic` creates the first account, generates a high-entropy password unless
-  one is provided, and prints the credentials once;
+  one is provided, prints the credentials once, and optionally writes a secret
+  Surge configuration while the plaintext is available;
 - `client_cert` enrolls the first client, appends the generated `[[clients]]`
   entry, writes the usque JSON to a new `0600` file, and prints the mihomo block;
 - `dual` does both, writing a
@@ -66,6 +69,9 @@ The following environment variables make provisioning non-interactive:
 | `MASQUE_AUTH_MODE` | `basic`, `client_cert`, or `dual` |
 | `MASQUE_AUTH_USERNAME` | Basic username; defaults to `masque` |
 | `MASQUE_AUTH_PASSWORD` | Basic password; random when omitted |
+| `MASQUE_BASIC_CLIENT_ENDPOINT` | Optional public Basic endpoint in `host:port` form; enables Surge configuration generation |
+| `MASQUE_BASIC_CLIENT_NAME` | Optional proxy name in the generated Surge configuration |
+| `MASQUE_BASIC_CLIENT_CONFIG_OUT` | Absolute secret Surge output path; defaults to `/root/masque-surge.conf` when generation is enabled |
 | `MASQUE_LISTEN_PORT` | Public UDP listen port; defaults to `443` |
 | `MASQUE_CERT_LISTEN_PORT` | `dual` only; certificate listener port, defaults to `4443` |
 | `MASQUE_TLS_CERT` / `MASQUE_TLS_KEY` | Source PEM certificate and key copied into `/etc/masque/certs` |
@@ -102,8 +108,8 @@ exist.
 The same one-command installer is safe to reuse for later releases. If the
 configuration already exists, the downloaded candidate runs `check-config`
 against it before any installed file is replaced. A failed check leaves the
-binary, systemd unit, monitoring assets, configuration, TLS files, and running
-service untouched. On success, the binary, packaged systemd unit, Prometheus
+server/probe binaries, systemd unit, monitoring assets, configuration, TLS
+files, and running service untouched. On success, both binaries, the packaged systemd unit, Prometheus
 rules, and Grafana dashboard are upgraded; the TOML and every TLS path it
 references remain unchanged. If the requested service restart then fails, the
 installer restores the previous release-managed files, enabled state, and
@@ -113,8 +119,8 @@ summary but does not print the existing configuration contents.
 ## Install a downloaded archive
 
 ```sh
-tar xzf masque-vVERSION-linux-x86_64.tar.gz
-cd masque-vVERSION-linux-x86_64
+tar xzf masque-vVERSION-linux-ARCH.tar.gz
+cd masque-vVERSION-linux-ARCH
 sudo ./install.sh
 ```
 
@@ -137,6 +143,7 @@ sets it to `1` by default.
 The installer creates:
 
 - `/usr/local/bin/masque-server`;
+- `/usr/local/bin/masque-probe`;
 - `/etc/masque/masque.toml`;
 - `/etc/masque/certs/`;
 - `/etc/systemd/system/masque.service`;
@@ -309,8 +316,8 @@ The candidate first runs the equivalent of:
 masque-server --config /etc/masque/masque.toml check-config
 ```
 
-This validates the parts of startup that do not need live resources. A 0.2
-configuration, a file that no longer satisfies fail-closed authentication, a bad
+This validates the parts of startup that do not need live resources. A file
+that no longer satisfies fail-closed authentication, a bad
 certificate/key pair, an unsupported HTTP/2 or QUIC setting, or an invalid
 client/address pool therefore stops the upgrade before replacement. Edit and validate such a
 configuration deliberately; the installer never migrates it automatically.
@@ -318,7 +325,7 @@ configuration deliberately; the installer never migrates it automatically.
 After a successful upgrade, inspect service status and run a client
 connectivity and throughput smoke test. Keep independent backups as part of
 normal operations even though the installer performs a temporary transactional
-rollback around the binary, unit, and packaged monitoring-asset replacement.
+rollback around both binaries, the unit, and packaged monitoring-asset replacement.
 
 For optional health checks, Prometheus scraping, alert rules, and the dashboard
 JSON, see [Observability](observability.md). The installer copies those static
@@ -337,6 +344,28 @@ sudo ss -t -l -p | grep masque-server
 systemctl show masque -p MainPID -p ActiveState -p SubState
 ```
 
+From the affected client network, run `masque-probe` with Basic credentials or
+an enrollment JSON. It validates real upstream TCP CONNECT establishment and a
+CONNECT-UDP DNS round trip instead of merely checking whether the port opens:
+
+```sh
+printf '%s' 'client-password' | masque-probe proxy.example.com:8449 \
+  --username client-name --password-stdin
+masque-probe proxy.example.com:4443 --client-config client.json --connect-ip
+```
+
+Create a private, shareable server report with:
+
+```sh
+sudo masque-server --config /etc/masque/masque.toml support-bundle \
+  --out /root/masque-support.json
+```
+
+The command refuses to overwrite an existing file and excludes raw
+configuration, credentials, client identities, key material, environment,
+logs, and traffic details. Review it before sharing. See
+[Troubleshooting](troubleshooting.md) for the full diagnostic flow.
+
 Inspect UDP batching during a controlled benchmark:
 
 ```sh
@@ -347,7 +376,7 @@ sudo strace -f -c -e trace=sendmmsg,sendmsg,recvmmsg \
 The musl release should show real `sendmmsg` and `recvmmsg` calls. Run tracing
 only briefly; it changes timing.
 
-For persistent failures, collect the version, configuration with secrets
-redacted, kernel version, interface offload state, service status, and a short
-log excerpt. Never publish certificates, password hashes, credentials, or
-captured user traffic.
+For persistent failures, attach the support bundle and the probe's `--json`
+output. Keep any separately requested log excerpt private until it has been
+reviewed; never publish certificates, password hashes, credentials, or captured
+user traffic.

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,6 +91,14 @@ connection IDs.
 Do not respond to overload by making queues arbitrarily deep; this can turn
 packet loss into seconds of latency and make memory exhaustion easier.
 
+`masque-server support-bundle` is deliberately a metadata-only diagnostic. It
+does not copy the configuration, logs, environment, usernames, password hashes,
+client labels or keys, certificate identities, target addresses, or traffic
+data. The generated file is created as mode `0600` and never overwrites an
+existing path. It can still reveal operational details such as listener counts,
+enabled transports, kernel version, and certificate validity windows, so review
+the JSON before sharing it outside the operator team.
+
 ## TLS and credentials
 
 - Keep the private key and configuration `root:masque` mode `0640`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,10 +14,12 @@
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
 | Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth, CONNECT-IP setup, mixed authentication, and live HTTP/3 TLS reload/rollback |
 | HTTP/2 interop | `cargo test --test http2_connect` | Real TLS/H2 CONNECT variants, multiple Basic accounts, both authentication modes, and credential/TLS reload rollback without dropping an established connection |
+| End-user probe | `cargo test -p masque-probe` | Basic/certificate authentication over H2/H3 with live TCP CONNECT and CONNECT-UDP echo round trips, plus stable result/error handling |
 | Observability assets | `cargo test --test monitoring_assets` | Prometheus metric references and importable Grafana JSON |
 | Service shutdown | `tests/systemd-shutdown.sh` | Real SIGTERM/SIGINT handling and every-shard drain; Linux exercises two shards |
-| Config and host diagnostics | `cargo test --test check_config` | `check-config` accepts what a server accepts; `doctor` remains read-only and unit fixtures classify Linux host evidence |
+| Config and host diagnostics | `cargo test --test check_config` | `check-config` accepts what a server accepts; `doctor` remains read-only; support bundles omit credential/identity sentinels |
 | Config editing | `cargo test --test add_listener` | Listener and Basic-account edits are validated, atomic, and preserve deployed comments and secrets |
+| Client config | `cargo test --test client_config` | Surge output is importable, private, secret-aware, and never overwritten |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
 | Parser fuzzing | `cargo +nightly fuzz run protocol_parsers` | Incremental capsule, datagram, varint, IP, and URI parser safety |
 
@@ -312,11 +314,13 @@ that, and all three were hit while qualifying this feature:
 
 - Update `CHANGELOG.md` and package version.
 - Run formatting, Clippy with warnings denied, and release tests.
-- Build `x86_64-unknown-linux-musl` with the same command used by CI.
+- Build both `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` with
+  the same matrix used by CI.
 - Extract the archive into a temporary directory and inspect permissions and
   paths.
-- Verify `masque-server --help`, `hash-password`, side-effect-free
-  `check-config`, and read-only `doctor` from the packaged binary.
+- Verify `masque-server --help`, `hash-password`, `client-config`,
+  side-effect-free `check-config`, read-only `doctor`, `support-bundle`, and
+  `masque-probe --help` from the packaged binaries.
 - Install on a disposable Linux host and run a client smoke test.
 - Tag only the commit that passed these checks.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,150 @@
+# Troubleshooting
+
+Separate client-path failures from server-host failures before changing tuning
+or firewall rules. `masque-probe` exercises the actual protocol from the client
+network; `check-config`, `doctor`, and `support-bundle` inspect the server
+without changing it.
+
+## Client-side connectivity probe
+
+Release archives install `/usr/local/bin/masque-probe` beside the server. Copy
+that binary to the affected Linux client if necessary, and run it from the same
+network and interface as the application that fails.
+
+For Basic authentication, pass the password on stdin so it never appears in
+the process list:
+
+```sh
+printf '%s' 'client-password' | masque-probe proxy.example.com:8449 \
+  --username client-name --password-stdin
+```
+
+For client-certificate authentication, use the secret enrollment JSON produced
+by `enroll-client`:
+
+```sh
+masque-probe proxy.example.com:4443 --client-config client.json --connect-ip
+```
+
+The default `--transport auto` tries HTTP/3 first. If UDP/QUIC cannot establish
+a session, the report records that failure as a warning and tries HTTP/2 on the
+same numeric port. Use `--transport http3` or `--transport http2` to test one
+path without fallback. HTTP/3 needs an inbound UDP listener; HTTP/2 needs a TCP
+listener.
+
+After the handshake, the default checks perform:
+
+- upstream TCP CONNECT establishment to `example.com:443`;
+- CONNECT-UDP to `1.1.1.1:53` with a real DNS query and matching response; and
+- CONNECT-IP negotiation/address assignment only when `--connect-ip` is set.
+
+Use `--tcp-target` or `--udp-target` when server policy intentionally blocks the
+defaults. `--udp-mode echo` is available for a controlled UDP echo target.
+`--skip-tcp` and `--skip-udp` isolate one protocol without treating the skipped
+check as a failure.
+
+Public Basic endpoints use the platform CA roots and hostname verification by
+default. `--ca-cert` adds a private CA. `--insecure` is only a temporary
+diagnostic and is reported as a warning. Enrollment mode always checks the
+server public key pinned in the enrollment JSON; `--insecure` cannot disable
+that pin.
+
+### Fake-IP DNS and route selection
+
+Some local proxy configurations answer DNS with an address in `198.18.0.0/15`.
+The probe reports `DNS_FAKE_IP_DETECTED`; that address may lead back into the
+proxy rather than to the server. Retain the hostname for TLS and HTTP while
+dialing the real address explicitly:
+
+```sh
+masque-probe proxy.example.com:8449 --resolve 203.0.113.9 \
+  --username client-name --password-stdin
+```
+
+On macOS or Linux, `--interface en0` (replace `en0`) binds the HTTP/3 UDP socket
+to a specific interface. It does not affect the HTTP/2 TCP fallback. Combining
+`--resolve` and `--interface` is useful when a system proxy changes both DNS and
+the default route.
+
+### Machine-readable results
+
+`--json` emits a stable schema with the requested and selected transport, each
+check's status/code/detail/duration, and the overall result. Exit status is zero
+only when a transport was selected and no check failed. Warnings, including a
+successful HTTP/2 fallback, do not fail the run.
+
+```sh
+printf '%s' 'client-password' | masque-probe proxy.example.com:8449 \
+  --username client-name --password-stdin --json >probe.json
+```
+
+Useful result codes include:
+
+| Code | Meaning |
+| --- | --- |
+| `AUTH_REJECTED` | The server returned 407; select the correct Basic listener and credential |
+| `TARGET_POLICY_DENIED` | The configured allow/deny policy rejected the probe target |
+| `PROTOCOL_REJECTED` | The listener does not expose the requested CONNECT protocol |
+| `TARGET_CONNECT_FAILED` | The proxy was reached, but target connection failed (HTTP 502) |
+| `TLS_PIN_MISMATCH` | Enrollment JSON pins a different server key |
+| `DNS_FAKE_IP_DETECTED` | Local DNS returned a synthetic address; retry with `--resolve` |
+| `RESPONSE_TIMEOUT` | Handshake or tunnel succeeded far enough to wait, but no response arrived |
+
+The detailed code distinguishes DNS, UDP socket, TCP connect, TLS, HTTP/2,
+HTTP/3, capsule, and response failures, so retain the complete JSON rather than
+copying only the last line.
+
+## Server-side checks
+
+First validate what the process would load, then inspect CONNECT-IP host
+prerequisites:
+
+```sh
+sudo masque-server --config /etc/masque/masque.toml check-config
+sudo masque-server --config /etc/masque/masque.toml doctor
+sudo systemctl status masque --no-pager
+```
+
+`check-config` parses the TLS identity, credentials, roster, policies, transport
+settings, and address pools without binding sockets or creating a TUN. `doctor`
+adds read-only TUN, forwarding, route, firewall, and optional NAT evidence. It
+does not install a route, modify a sysctl, or change a firewall.
+
+## Server-side support bundle
+
+For a persistent problem, create one attachable report:
+
+```sh
+sudo masque-server --config /etc/masque/masque.toml support-bundle \
+  --out /root/masque-support.json
+```
+
+The command validates the configuration first, creates a new mode-`0600` file,
+syncs it, and refuses to overwrite any existing path. The JSON includes:
+
+- server version, operating system, architecture, kernel, and logical CPUs;
+- resolved listeners, transport, shard count, authentication kind, and only
+  the number of Basic users;
+- enabled protocols, policy-rule counts, bounded tuning fields, and
+  observability address;
+- TLS file existence/size/permissions and certificate validity window;
+- read-only CONNECT-IP diagnostic names and result levels (free-form command
+  output is excluded); and
+- bounded `masque.service` load/active/enabled state when systemd is available.
+
+It deliberately excludes raw configuration, usernames and password hashes,
+client labels and assigned addresses, certificate identity/serial, public and
+private keys, environment variables, logs, and traffic destinations/counters.
+This exclusion is structural rather than a regular-expression pass over secret
+text. Still review the resulting JSON before sharing because listener addresses,
+TUN names, kernel version, and service state are operational metadata.
+
+Logs are not bundled automatically. If a maintainer asks for a short journal
+excerpt, collect and review it separately:
+
+```sh
+sudo journalctl -u masque --since '-10 minutes' --no-pager
+```
+
+Do not publish credentials, password hashes, enrollment files, TLS keys,
+complete production configuration, packet captures, or user traffic.

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -24,8 +24,9 @@ if [ "$(uname -s)" != Linux ]; then
     die "the prebuilt service package supports Linux only"
 fi
 case "$(uname -m)" in
-    x86_64|amd64) ;;
-    *) die "the prebuilt service package supports Linux x86_64 only" ;;
+    x86_64|amd64) ARCH=x86_64 ;;
+    aarch64|arm64) ARCH=aarch64 ;;
+    *) die "the prebuilt service package supports Linux x86_64 and ARM64 only" ;;
 esac
 
 for required_command in curl tar sha256sum awk grep mktemp; do
@@ -65,7 +66,7 @@ case "$RELEASE_TAG" in
 esac
 
 VERSION=${RELEASE_TAG#v}
-ARCHIVE_NAME=masque-v${VERSION}-linux-x86_64.tar.gz
+ARCHIVE_NAME=masque-v${VERSION}-linux-${ARCH}.tar.gz
 CHECKSUM_NAME=$ARCHIVE_NAME.sha256
 DOWNLOAD_BASE=https://github.com/$REPOSITORY/releases/download/$RELEASE_TAG
 
@@ -93,7 +94,7 @@ if tar tzf "$ARCHIVE_PATH" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
 fi
 tar xzf "$ARCHIVE_PATH" -C "$DOWNLOAD_DIR"
 
-PACKAGE_DIR=$DOWNLOAD_DIR/masque-v${VERSION}-linux-x86_64
+PACKAGE_DIR=$DOWNLOAD_DIR/masque-v${VERSION}-linux-${ARCH}
 if [ ! -x "$PACKAGE_DIR/install.sh" ]; then
     die "the release archive does not contain an executable install.sh"
 fi

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -4,13 +4,36 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 TARGET="${TARGET:-x86_64-unknown-linux-musl}"
-VERSION="${VERSION:-$(awk '
+case "$TARGET" in
+    x86_64-unknown-linux-*) TARGET_ARCH=x86_64 ;;
+    aarch64-unknown-linux-*) TARGET_ARCH=aarch64 ;;
+    *)
+        echo "error: unsupported Linux release target: $TARGET" >&2
+        exit 1
+        ;;
+esac
+ARCH="${ARCH:-$TARGET_ARCH}"
+if [ "$ARCH" != "$TARGET_ARCH" ]; then
+    echo "error: ARCH=$ARCH does not match TARGET=$TARGET" >&2
+    exit 1
+fi
+PACKAGE_VERSION=$(awk '
     /^\[package\]$/ { in_package=1; next }
     /^\[/ { in_package=0 }
     in_package && /^version = / { gsub(/[" ]/, "", $3); print $3; exit }
-' Cargo.toml)}"
+' Cargo.toml)
+PROBE_VERSION=$(awk '
+    /^\[package\]$/ { in_package=1; next }
+    /^\[/ { in_package=0 }
+    in_package && /^version = / { gsub(/[" ]/, "", $3); print $3; exit }
+' tools/masque-probe/Cargo.toml)
+[ -n "$PACKAGE_VERSION" ] && [ "$PACKAGE_VERSION" = "$PROBE_VERSION" ] || {
+    echo "error: masque-server and masque-probe package versions must match" >&2
+    exit 1
+}
+VERSION="${VERSION:-$PACKAGE_VERSION}"
 OUTPUT_DIR="${OUTPUT_DIR:-dist}"
-ARCHIVE_NAME="masque-v${VERSION}-linux-x86_64"
+ARCHIVE_NAME="masque-v${VERSION}-linux-${ARCH}"
 STAGING_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/masque-package.XXXXXX")"
 
 cleanup() {
@@ -19,9 +42,11 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if [ "${USE_ZIGBUILD:-0}" = "1" ]; then
-    cargo zigbuild --locked --release --target "$TARGET" --bin masque-server
+    cargo zigbuild --locked --release --target "$TARGET" \
+        -p masque-server -p masque-probe
 else
-    cargo build --locked --release --target "$TARGET" --bin masque-server
+    cargo build --locked --release --target "$TARGET" \
+        -p masque-server -p masque-probe
 fi
 
 install -d \
@@ -31,6 +56,8 @@ install -d \
     "$STAGING_ROOT/$ARCHIVE_NAME/systemd"
 install -m 0755 "target/$TARGET/release/masque-server" \
     "$STAGING_ROOT/$ARCHIVE_NAME/bin/masque-server"
+install -m 0755 "target/$TARGET/release/masque-probe" \
+    "$STAGING_ROOT/$ARCHIVE_NAME/bin/masque-probe"
 install -m 0755 deploy/install.sh "$STAGING_ROOT/$ARCHIVE_NAME/install.sh"
 install -m 0644 deploy/config/masque.toml "$STAGING_ROOT/$ARCHIVE_NAME/config/masque.toml"
 install -m 0644 deploy/systemd/masque.service \
@@ -44,7 +71,10 @@ install -m 0644 CHANGELOG.md "$STAGING_ROOT/$ARCHIVE_NAME/CHANGELOG.md"
 install -m 0644 LICENSE "$STAGING_ROOT/$ARCHIVE_NAME/LICENSE"
 
 mkdir -p "$OUTPUT_DIR"
-tar -C "$STAGING_ROOT" -czf "$OUTPUT_DIR/$ARCHIVE_NAME.tar.gz" "$ARCHIVE_NAME"
+# macOS otherwise records com.apple.* xattrs in PAX headers. They are harmless
+# but make a locally built Linux archive noisy to extract with GNU tar.
+COPYFILE_DISABLE=1 tar --no-xattrs -C "$STAGING_ROOT" -czf \
+    "$OUTPUT_DIR/$ARCHIVE_NAME.tar.gz" "$ARCHIVE_NAME"
 (
     cd "$OUTPUT_DIR"
     sha256sum "$ARCHIVE_NAME.tar.gz" >"$ARCHIVE_NAME.tar.gz.sha256"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -41,7 +41,7 @@ pub(crate) struct SharedBasicAuthenticator {
 /// colon inside the username makes the pair ambiguous. Shared with
 /// Configuration-editing commands also use this check before changing a file,
 /// so an operator sees the error before any Argon2 work or write is attempted.
-pub(crate) fn check_username(username: &str) -> anyhow::Result<()> {
+pub fn check_username(username: &str) -> anyhow::Result<()> {
     if username.is_empty() {
         bail!("auth.username must not be empty when authentication is enabled");
     }

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -41,7 +41,7 @@ use crate::auth;
 use crate::config::{
     self, AuthMode, AuthSection, BasicUser, ListenerSection, ListenerTransport, ServerConfig,
 };
-use crate::enroll::toml_string;
+use crate::enroll::{self, ClientEndpoint, toml_string};
 use crate::server::validate_config;
 
 /// Bytes of entropy in a generated password, matching the installer's.
@@ -67,6 +67,8 @@ pub struct AddListener {
     pub password_hash: Option<String>,
     /// Read the password from standard input and hash it.
     pub password_stdin: bool,
+    /// Optionally emit the client half of this newly created credential.
+    pub client_output: Option<BasicClientOutput>,
     /// Write `enabled = false`, for a listener on a trusted network.
     pub disable_auth: bool,
     /// Do not try to bind the new address before writing it.
@@ -92,6 +94,20 @@ pub struct BasicUserPassword {
     pub username: String,
     pub password_hash: Option<String>,
     pub password_stdin: bool,
+    pub client_output: Option<BasicClientOutput>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BasicClientFormat {
+    Surge,
+}
+
+#[derive(Debug)]
+pub struct BasicClientOutput {
+    pub format: BasicClientFormat,
+    pub endpoint: ClientEndpoint,
+    pub name: Option<String>,
+    pub out: Option<PathBuf>,
 }
 
 /// Append one `[[listeners]]` block to `config_path`.
@@ -157,6 +173,16 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
              enroll the client instead"
         );
     }
+    if request.client_output.is_some() {
+        ensure!(
+            !request.disable_auth && mode == AuthMode::Basic,
+            "client configuration output applies only to an authenticated Basic listener"
+        );
+        ensure!(
+            transport == ListenerTransport::Http3,
+            "Surge MASQUE client output requires an HTTP/3 listener"
+        );
+    }
 
     let shards = match (transport, request.shards) {
         (ListenerTransport::Http2, Some(1) | None) => 1,
@@ -168,7 +194,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         (ListenerTransport::Http3, None) => 1,
     };
 
-    let mut generated_password: Option<Zeroizing<String>> = None;
+    let mut resolved_password: Option<ResolvedUserPassword> = None;
     let auth = if request.disable_auth {
         AuthSection {
             enabled: false,
@@ -195,8 +221,10 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
                     None if interactive => prompt_username()?,
                     None => bail!("--username is required when standard input is not a terminal"),
                 };
-                let (password_hash, generated) = resolve_password(&request, interactive)?;
-                generated_password = generated;
+                let resolved =
+                    resolve_password(&request, interactive, request.client_output.is_some())?;
+                let password_hash = resolved.password_hash.clone();
+                resolved_password = Some(resolved);
                 AuthSection {
                     enabled: true,
                     mode,
@@ -265,7 +293,11 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
     // Deliver the only copy before committing the hash. In particular, a
     // broken pipe or full redirected output must leave the configuration
     // untouched instead of installing a credential the operator never saw.
-    if let Some(password) = generated_password.as_ref() {
+    if let Some(password) = resolved_password
+        .as_ref()
+        .filter(|resolved| resolved.generated)
+        .and_then(|resolved| resolved.plaintext.as_ref())
+    {
         let username = listener
             .auth
             .users
@@ -273,6 +305,19 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
             .map(|user| user.username.as_str())
             .unwrap_or(&listener.auth.username);
         print_generated_password(username, password)?;
+    }
+    if let Some(output) = request.client_output.as_ref() {
+        let username = listener
+            .auth
+            .users
+            .first()
+            .map(|user| user.username.as_str())
+            .unwrap_or(&listener.auth.username);
+        let password = resolved_password
+            .as_ref()
+            .and_then(|resolved| resolved.plaintext.as_ref())
+            .context("client output requires a plaintext password")?;
+        deliver_basic_client_config(output, username, password)?;
     }
 
     write_in_place(config_path, &text, &merged)?;
@@ -402,6 +447,16 @@ fn edit_basic_user(config_path: &Path, edit: UserEdit) -> anyhow::Result<()> {
         )
     })?;
     let listener_index = select_basic_listener(&config, edit.selector())?;
+    let client_output = match &edit {
+        UserEdit::Add(request) => request.client_output.as_ref(),
+        UserEdit::SetPassword(_) | UserEdit::Remove { .. } => None,
+    };
+    if client_output.is_some() {
+        ensure!(
+            config.listeners[listener_index].transport == ListenerTransport::Http3,
+            "Surge MASQUE client output requires an HTTP/3 listener"
+        );
+    }
     let mut expected = config.clone();
     let expected_auth = &mut expected.listeners[listener_index].auth;
     migrate_legacy_basic_user(expected_auth);
@@ -444,13 +499,15 @@ fn edit_basic_user(config_path: &Path, edit: UserEdit) -> anyhow::Result<()> {
         }
     }
 
-    let (replacement_hash, generated_password) = match &edit {
+    let resolved_password = match &edit {
         UserEdit::Add(request) | UserEdit::SetPassword(request) => {
-            let (hash, generated) = resolve_user_password(request)?;
-            (Some(hash), generated)
+            Some(resolve_user_password(request, client_output.is_some())?)
         }
-        UserEdit::Remove { .. } => (None, None),
+        UserEdit::Remove { .. } => None,
     };
+    let replacement_hash = resolved_password
+        .as_ref()
+        .map(|resolved| resolved.password_hash.clone());
 
     match &edit {
         UserEdit::Add(_) => {
@@ -522,8 +579,19 @@ fn edit_basic_user(config_path: &Path, edit: UserEdit) -> anyhow::Result<()> {
 
     // As with add-listener, deliver a generated secret before committing the
     // only usable representation of it (the hash) to disk.
-    if let Some(password) = generated_password.as_ref() {
+    if let Some(password) = resolved_password
+        .as_ref()
+        .filter(|resolved| resolved.generated)
+        .and_then(|resolved| resolved.plaintext.as_ref())
+    {
         print_generated_password(&username, password)?;
+    }
+    if let Some(output) = client_output {
+        let password = resolved_password
+            .as_ref()
+            .and_then(|resolved| resolved.plaintext.as_ref())
+            .context("client output requires a plaintext password")?;
+        deliver_basic_client_config(output, &username, password)?;
     }
     write_in_place(config_path, &text, &merged)?;
 
@@ -545,31 +613,95 @@ fn edit_basic_user(config_path: &Path, edit: UserEdit) -> anyhow::Result<()> {
     Ok(())
 }
 
+struct ResolvedUserPassword {
+    password_hash: String,
+    plaintext: Option<Zeroizing<String>>,
+    generated: bool,
+}
+
 fn resolve_user_password(
     request: &BasicUserPassword,
-) -> anyhow::Result<(String, Option<Zeroizing<String>>)> {
+    retain_plaintext: bool,
+) -> anyhow::Result<ResolvedUserPassword> {
     ensure!(
         !(request.password_hash.is_some() && request.password_stdin),
         "--password-hash conflicts with --password-stdin"
     );
     if let Some(hash) = &request.password_hash {
-        return Ok((hash.clone(), None));
+        ensure!(
+            !retain_plaintext,
+            "--password-hash cannot be combined with client configuration output because the plaintext password is unavailable"
+        );
+        return Ok(ResolvedUserPassword {
+            password_hash: hash.clone(),
+            plaintext: None,
+            generated: false,
+        });
     }
     if request.password_stdin {
         let mut password = Zeroizing::new(String::new());
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut password)?;
         let password = Zeroizing::new(trim_newline(&password).to_owned());
         check_password(&password)?;
-        return Ok((auth::hash_password(password.as_bytes())?, None));
+        let password_hash = auth::hash_password(password.as_bytes())?;
+        return Ok(ResolvedUserPassword {
+            password_hash,
+            plaintext: retain_plaintext.then_some(password),
+            generated: false,
+        });
     }
     if std::io::stdin().is_terminal()
         && let Some(password) = prompt_password(true)?
     {
-        return Ok((auth::hash_password(password.as_bytes())?, None));
+        let password_hash = auth::hash_password(password.as_bytes())?;
+        return Ok(ResolvedUserPassword {
+            password_hash,
+            plaintext: retain_plaintext.then_some(password),
+            generated: false,
+        });
     }
 
     let password = generate_password()?;
-    Ok((auth::hash_password(password.as_bytes())?, Some(password)))
+    Ok(ResolvedUserPassword {
+        password_hash: auth::hash_password(password.as_bytes())?,
+        plaintext: Some(password),
+        generated: true,
+    })
+}
+
+fn deliver_basic_client_config(
+    output: &BasicClientOutput,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<()> {
+    let name = output
+        .name
+        .clone()
+        .unwrap_or_else(|| enroll::default_surge_proxy_name(&output.endpoint));
+    let contents = Zeroizing::new(match output.format {
+        BasicClientFormat::Surge => {
+            enroll::surge_proxy_config(&name, &output.endpoint, username, password)?
+        }
+    });
+    if let Some(path) = &output.out {
+        enroll::write_client_config(path, &contents)?;
+        println!(
+            "Surge client configuration written to {} (contains the plaintext password)",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let stdout = std::io::stdout();
+    let mut writer = stdout.lock();
+    writeln!(
+        writer,
+        "\n# Surge client configuration (contains the plaintext password):"
+    )?;
+    writer.write_all(contents.as_bytes())?;
+    writer
+        .flush()
+        .context("failed to print the client configuration; configuration is unchanged")
 }
 
 fn select_basic_listener(
@@ -830,9 +962,18 @@ fn verify_merge(
 fn resolve_password(
     request: &AddListener,
     interactive: bool,
-) -> anyhow::Result<(String, Option<Zeroizing<String>>)> {
+    retain_plaintext: bool,
+) -> anyhow::Result<ResolvedUserPassword> {
     if let Some(hash) = &request.password_hash {
-        return Ok((hash.clone(), None));
+        ensure!(
+            !retain_plaintext,
+            "--password-hash cannot be combined with client configuration output because the plaintext password is unavailable"
+        );
+        return Ok(ResolvedUserPassword {
+            password_hash: hash.clone(),
+            plaintext: None,
+            generated: false,
+        });
     }
 
     if request.password_stdin {
@@ -840,13 +981,21 @@ fn resolve_password(
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut password)?;
         let password = Zeroizing::new(trim_newline(&password).to_owned());
         check_password(&password)?;
-        return Ok((auth::hash_password(password.as_bytes())?, None));
+        return Ok(ResolvedUserPassword {
+            password_hash: auth::hash_password(password.as_bytes())?,
+            plaintext: retain_plaintext.then_some(password),
+            generated: false,
+        });
     }
 
     if interactive {
         let password = prompt_password(!request.dry_run)?;
         if let Some(password) = password {
-            return Ok((auth::hash_password(password.as_bytes())?, None));
+            return Ok(ResolvedUserPassword {
+                password_hash: auth::hash_password(password.as_bytes())?,
+                plaintext: retain_plaintext.then_some(password),
+                generated: false,
+            });
         }
     }
 
@@ -864,7 +1013,11 @@ fn resolve_password(
     // alternative is a listener that cannot start — but it exists only in this
     // output, so the caller prints it exactly once.
     let password = generate_password()?;
-    Ok((auth::hash_password(password.as_bytes())?, Some(password)))
+    Ok(ResolvedUserPassword {
+        password_hash: auth::hash_password(password.as_bytes())?,
+        plaintext: Some(password),
+        generated: true,
+    })
 }
 
 /// A random password, hex encoded, matching what the installer generates.

--- a/src/enroll.rs
+++ b/src/enroll.rs
@@ -13,6 +13,7 @@ use std::fs::OpenOptions;
 use std::io::Write as _;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::Path;
+use std::str::FromStr as _;
 
 use anyhow::{Context, bail};
 use base64::Engine as _;
@@ -144,6 +145,129 @@ pub fn mihomo_proxy_yaml(
     block.push_str(&format!("    mtu: {mtu}\n"));
     block.push_str("    udp: true\n");
     block
+}
+
+/// Public address placed in a generated client configuration.
+///
+/// Listener addresses such as `[::]:8449` describe where the server binds,
+/// not what a remote client dials, so credential-management commands require
+/// this value explicitly instead of guessing from the server configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientEndpoint {
+    pub host: String,
+    pub port: u16,
+}
+
+impl ClientEndpoint {
+    pub fn parse(value: &str) -> anyhow::Result<Self> {
+        if value.contains('@') {
+            bail!("client endpoint must not contain user information");
+        }
+        let authority = http::uri::Authority::from_str(value)
+            .with_context(|| format!("invalid client endpoint {value:?}"))?;
+        let port = authority
+            .port_u16()
+            .with_context(|| format!("client endpoint {value:?} has no port"))?;
+        if port == 0 {
+            bail!("client endpoint port must be between 1 and 65535");
+        }
+        let host = authority.host();
+        let host = host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(host);
+        if host.is_empty()
+            || host
+                .bytes()
+                .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+        {
+            bail!("client endpoint host is empty or contains whitespace");
+        }
+        if IpAddr::from_str(host).is_err()
+            && !host
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+        {
+            bail!(
+                "client endpoint host must be an IP address or an ASCII DNS name containing only letters, digits, dots, and hyphens"
+            );
+        }
+        Ok(Self {
+            host: host.to_owned(),
+            port,
+        })
+    }
+
+    fn surge_host(&self) -> String {
+        if self.host.contains(':') {
+            format!("[{}]", self.host)
+        } else {
+            self.host.clone()
+        }
+    }
+}
+
+/// A complete Surge `[Proxy]` block for one standard HTTP/3 MASQUE account.
+///
+/// This intentionally takes the plaintext password. The server stores only an
+/// Argon2id hash and cannot export the configuration later, so callers invoke
+/// it while creating or replacing the credential and immediately zeroize the
+/// plaintext afterwards.
+pub fn surge_proxy_config(
+    name: &str,
+    endpoint: &ClientEndpoint,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<String> {
+    if name.is_empty() || name.contains(['\r', '\n', '=']) || name.chars().any(char::is_control) {
+        bail!(
+            "Surge proxy name must be non-empty and contain no '=', newline, or control character"
+        );
+    }
+    if username.is_empty()
+        || username.contains(['\r', '\n'])
+        || username.chars().any(char::is_control)
+    {
+        bail!("Surge username cannot be represented safely in a proxy declaration");
+    }
+    if password.is_empty() || password.chars().any(char::is_control) {
+        bail!("Surge password must be non-empty and contain no control character");
+    }
+
+    Ok(format!(
+        "[Proxy]\n{name} = masque, {}, {}, username={}, password={}\n",
+        endpoint.surge_host(),
+        endpoint.port,
+        surge_value(username),
+        surge_value(password),
+    ))
+}
+
+/// A stable default that remains readable when several server accounts are
+/// imported into the same Surge configuration.
+pub fn default_surge_proxy_name(endpoint: &ClientEndpoint) -> String {
+    format!("[masque] {}:{}", endpoint.surge_host(), endpoint.port)
+}
+
+fn surge_value(value: &str) -> String {
+    if value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'~'))
+    {
+        return value.to_owned();
+    }
+
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => quoted.push_str("\\\""),
+            '\\' => quoted.push_str("\\\\"),
+            other => quoted.push(other),
+        }
+    }
+    quoted.push('"');
+    quoted
 }
 
 /// The `[[clients]]` block to append to the server's config file.
@@ -448,6 +572,39 @@ mod tests {
         );
         assert!(!yaml.contains("ip:"));
         assert!(!yaml.contains("ipv6:"));
+    }
+
+    #[test]
+    fn surge_block_carries_basic_credentials_and_public_endpoint() {
+        let endpoint = ClientEndpoint::parse("proxy.example:8449").unwrap();
+        let block = surge_proxy_config(
+            "phone",
+            &endpoint,
+            "alice",
+            "password with spaces, and commas",
+        )
+        .unwrap();
+        assert_eq!(
+            block,
+            "[Proxy]\nphone = masque, proxy.example, 8449, username=alice, password=\"password with spaces, and commas\"\n"
+        );
+    }
+
+    #[test]
+    fn surge_endpoint_accepts_bracketed_ipv6() {
+        let endpoint = ClientEndpoint::parse("[2001:db8::1]:443").unwrap();
+        assert_eq!(endpoint.host, "2001:db8::1");
+        assert_eq!(
+            default_surge_proxy_name(&endpoint),
+            "[masque] [2001:db8::1]:443"
+        );
+    }
+
+    #[test]
+    fn surge_endpoint_rejects_user_information_and_port_zero() {
+        assert!(ClientEndpoint::parse("user@proxy.example:443").is_err());
+        assert!(ClientEndpoint::parse("proxy.example:0").is_err());
+        assert!(ClientEndpoint::parse("proxy.example,udp-relay=true:443").is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod policy;
 pub mod routing;
 mod scheduler;
 pub mod server;
+pub mod support;
 mod systemd;
 pub mod tun;
 pub mod tunnel;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use masque::config_edit;
 use masque::enroll;
 use masque::host;
 use masque::server::{Server, validate_config};
+use masque::support;
 
 /// MASQUE proxy server (CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 or
 /// HTTP/3).
@@ -55,6 +56,28 @@ enum LogFormat {
 enum Command {
     /// Read a password from standard input and print an Argon2id PHC hash.
     HashPassword,
+    /// Read a Basic password from stdin and emit an importable client configuration.
+    ClientConfig {
+        /// Client configuration syntax.
+        #[arg(value_enum)]
+        format: BasicClientArg,
+
+        /// Public host:port the client dials.
+        #[arg(long)]
+        endpoint: String,
+
+        /// Basic username.
+        #[arg(long)]
+        username: String,
+
+        /// Client-side proxy name.
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Write to a new mode-0600 file instead of stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Validate the configuration without binding sockets or creating a TUN.
     CheckConfig,
     /// Validate the configuration and inspect CONNECT-IP host prerequisites.
@@ -62,6 +85,13 @@ enum Command {
     /// This is read-only. It checks Linux forwarding switches and looks for
     /// TUN, route, firewall, and NAT evidence without changing any of them.
     Doctor,
+    /// Write a private, shareable JSON diagnostic report with credentials,
+    /// key material, raw configuration, logs, and traffic details excluded.
+    SupportBundle {
+        /// Create the report at this path; an existing path is never replaced.
+        #[arg(long, short)]
+        out: PathBuf,
+    },
     /// Generate a client key pair for a listener using client-certificate auth.
     ///
     /// Prints the `[[clients]]` block to add to the server config, and the JSON
@@ -137,13 +167,47 @@ enum Command {
         #[arg(long)]
         password_stdin: bool,
 
+        /// Emit a ready-to-import client configuration while the plaintext
+        /// password is still available.
+        #[arg(
+            long,
+            value_enum,
+            requires = "client_endpoint",
+            conflicts_with_all = ["password_hash", "dry_run"]
+        )]
+        emit_client: Option<BasicClientArg>,
+
+        /// Public host:port the client dials; never inferred from a wildcard bind address.
+        #[arg(long, requires = "emit_client")]
+        client_endpoint: Option<String>,
+
+        /// Proxy name in the generated client configuration.
+        #[arg(long, requires = "emit_client")]
+        client_name: Option<String>,
+
+        /// Write the secret client configuration to a new mode-0600 file.
+        #[arg(long, requires = "emit_client")]
+        client_out: Option<PathBuf>,
+
         /// Write `enabled = false`. Anyone who reaches the socket may use the
         /// proxy, so this is for a listener on a trusted network only.
         ///
         /// Conflicts with `--mode`: a listener that demands nothing has no
         /// authentication mode to pick, and writing one down would describe a
         /// requirement that is not enforced.
-        #[arg(long, conflicts_with_all = ["mode", "username", "password_hash", "password_stdin"])]
+        #[arg(
+            long,
+            conflicts_with_all = [
+                "mode",
+                "username",
+                "password_hash",
+                "password_stdin",
+                "emit_client",
+                "client_endpoint",
+                "client_name",
+                "client_out"
+            ]
+        )]
         disable_auth: bool,
 
         /// Do not try to bind the new address before writing it.
@@ -192,6 +256,28 @@ enum Command {
         /// Read the plaintext password from standard input and hash it.
         #[arg(long)]
         password_stdin: bool,
+
+        /// Emit a ready-to-import client configuration while the plaintext
+        /// password is still available.
+        #[arg(
+            long,
+            value_enum,
+            requires = "client_endpoint",
+            conflicts_with = "password_hash"
+        )]
+        emit_client: Option<BasicClientArg>,
+
+        /// Public host:port the client dials; never inferred from a wildcard bind address.
+        #[arg(long, requires = "emit_client")]
+        client_endpoint: Option<String>,
+
+        /// Proxy name in the generated client configuration.
+        #[arg(long, requires = "emit_client")]
+        client_name: Option<String>,
+
+        /// Write the secret client configuration to a new mode-0600 file.
+        #[arg(long, requires = "emit_client")]
+        client_out: Option<PathBuf>,
     },
     /// Replace one Basic user's password without changing other accounts.
     SetPassword {
@@ -244,6 +330,19 @@ enum AuthModeArg {
 enum TransportArg {
     Http3,
     Http2,
+}
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum BasicClientArg {
+    Surge,
+}
+
+impl From<BasicClientArg> for config_edit::BasicClientFormat {
+    fn from(format: BasicClientArg) -> Self {
+        match format {
+            BasicClientArg::Surge => Self::Surge,
+        }
+    }
 }
 
 impl From<TransportArg> for config::ListenerTransport {
@@ -382,6 +481,43 @@ async fn main() -> anyhow::Result<()> {
         println!("{}", auth::hash_password(password.as_bytes())?);
         return Ok(());
     }
+    if let Some(Command::ClientConfig {
+        format,
+        endpoint,
+        username,
+        name,
+        out,
+    }) = &cli.command
+    {
+        auth::check_username(username)?;
+        let endpoint = enroll::ClientEndpoint::parse(endpoint)?;
+        let password = read_password_from_stdin()?;
+        let name = name
+            .clone()
+            .unwrap_or_else(|| enroll::default_surge_proxy_name(&endpoint));
+        let contents = Zeroizing::new(match format {
+            BasicClientArg::Surge => {
+                enroll::surge_proxy_config(&name, &endpoint, username, &password)?
+            }
+        });
+        match out {
+            Some(path) => {
+                enroll::write_client_config(path, &contents)?;
+                println!(
+                    "Surge client configuration written to {} (contains the plaintext password)",
+                    path.display()
+                );
+            }
+            None => {
+                eprintln!(
+                    "warning: client configuration on stdout contains the plaintext password"
+                );
+                print!("{}", contents.as_str());
+                std::io::stdout().flush()?;
+            }
+        }
+        return Ok(());
+    }
 
     // Logging
     let default_filter = match cli.verbose {
@@ -410,6 +546,7 @@ async fn main() -> anyhow::Result<()> {
         Some(
             Command::CheckConfig
                 | Command::Doctor
+                | Command::SupportBundle { .. }
                 | Command::AddListener { .. }
                 | Command::ListUsers { .. }
                 | Command::AddUser { .. }
@@ -432,12 +569,29 @@ async fn main() -> anyhow::Result<()> {
         username,
         password_hash,
         password_stdin,
+        emit_client,
+        client_endpoint,
+        client_name,
+        client_out,
         disable_auth,
         no_bind_check,
         dry_run,
         yes,
     }) = &cli.command
     {
+        let client_output = match emit_client {
+            Some(format) => Some(config_edit::BasicClientOutput {
+                format: (*format).into(),
+                endpoint: enroll::ClientEndpoint::parse(
+                    client_endpoint
+                        .as_deref()
+                        .expect("clap requires --client-endpoint with --emit-client"),
+                )?,
+                name: client_name.clone(),
+                out: client_out.clone(),
+            }),
+            None => None,
+        };
         return config_edit::add_listener(
             &cli.config,
             config_edit::AddListener {
@@ -448,6 +602,7 @@ async fn main() -> anyhow::Result<()> {
                 username: username.clone(),
                 password_hash: password_hash.clone(),
                 password_stdin: *password_stdin,
+                client_output,
                 disable_auth: *disable_auth,
                 no_bind_check: *no_bind_check,
                 dry_run: *dry_run,
@@ -474,8 +629,25 @@ async fn main() -> anyhow::Result<()> {
         transport,
         password_hash,
         password_stdin,
+        emit_client,
+        client_endpoint,
+        client_name,
+        client_out,
     }) = &cli.command
     {
+        let client_output = match emit_client {
+            Some(format) => Some(config_edit::BasicClientOutput {
+                format: (*format).into(),
+                endpoint: enroll::ClientEndpoint::parse(
+                    client_endpoint
+                        .as_deref()
+                        .expect("clap requires --client-endpoint with --emit-client"),
+                )?,
+                name: client_name.clone(),
+                out: client_out.clone(),
+            }),
+            None => None,
+        };
         return config_edit::add_basic_user(
             &cli.config,
             config_edit::BasicUserPassword {
@@ -486,6 +658,7 @@ async fn main() -> anyhow::Result<()> {
                 username: username.clone(),
                 password_hash: password_hash.clone(),
                 password_stdin: *password_stdin,
+                client_output,
             },
         );
     }
@@ -507,6 +680,7 @@ async fn main() -> anyhow::Result<()> {
                 username: username.clone(),
                 password_hash: password_hash.clone(),
                 password_stdin: *password_stdin,
+                client_output: None,
             },
         );
     }
@@ -620,6 +794,17 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if let Some(Command::SupportBundle { out }) = &cli.command {
+        let listeners = validate_config(&cfg)?;
+        let bundle = support::collect(&cli.config, &cfg, &listeners);
+        support::write(out, &bundle)?;
+        println!(
+            "support bundle written to {} (mode 0600; review before sharing)",
+            out.display()
+        );
+        return Ok(());
+    }
+
     if cfg.ip_proxy.enabled {
         let report = host::diagnose_connect_ip_startup(&cfg.ip_proxy);
         for check in report.checks().iter().filter(|check| {
@@ -653,6 +838,21 @@ async fn main() -> anyhow::Result<()> {
     server.run().await
 }
 
+fn read_password_from_stdin() -> anyhow::Result<Zeroizing<String>> {
+    let mut password = Zeroizing::new(String::new());
+    std::io::stdin().read_to_string(&mut password)?;
+    if password.ends_with('\n') {
+        password.pop();
+        if password.ends_with('\r') {
+            password.pop();
+        }
+    }
+    if password.is_empty() || password.chars().any(char::is_control) {
+        anyhow::bail!("password must be non-empty and contain no control characters");
+    }
+    Ok(password)
+}
+
 #[cfg(test)]
 mod tests {
     use clap::CommandFactory as _;
@@ -665,6 +865,11 @@ mod tests {
             Cli::command().get_version(),
             Some(env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[test]
+    fn cli_definition_is_consistent() {
+        Cli::command().debug_assert();
     }
 
     #[test]
@@ -683,6 +888,11 @@ mod tests {
     #[test]
     fn doctor_subcommand_is_available() {
         assert!(Cli::command().find_subcommand("doctor").is_some());
+    }
+
+    #[test]
+    fn support_bundle_subcommand_is_available() {
+        assert!(Cli::command().find_subcommand("support-bundle").is_some());
     }
 
     #[test]

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,0 +1,440 @@
+//! Shareable, credential-free diagnostics for support requests.
+//!
+//! The bundle is assembled from typed configuration fields. It never copies
+//! the source TOML, logs, environment variables, usernames, password hashes,
+//! client labels, or public/private key material, which makes accidental
+//! disclosure much harder than trying to redact arbitrary text afterwards.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::path::Path;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context as _;
+use boring::x509::X509;
+use serde::Serialize;
+
+use crate::config::{ResolvedListener, ServerConfig};
+use crate::host;
+
+#[derive(Debug, Serialize)]
+pub struct SupportBundle {
+    schema_version: u8,
+    generated_at_unix_seconds: u64,
+    application: ApplicationSummary,
+    host: HostSummary,
+    configuration: ConfigurationSummary,
+    tls: TlsSummary,
+    connect_ip_diagnostics: Vec<DiagnosticSummary>,
+    systemd: SystemdSummary,
+    privacy: PrivacySummary,
+}
+
+#[derive(Debug, Serialize)]
+struct ApplicationSummary {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct HostSummary {
+    os: &'static str,
+    architecture: &'static str,
+    kernel_release: Option<String>,
+    logical_cpus: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigurationSummary {
+    valid: bool,
+    config_file: FileSummary,
+    listeners: Vec<ListenerSummary>,
+    registered_client_count: usize,
+    server: ServerLimitsSummary,
+    protocols: ProtocolSummary,
+    quic: QuicSummary,
+    http2: Http2Summary,
+    observability_listen_addr: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct FileSummary {
+    exists: bool,
+    regular_file: bool,
+    size_bytes: Option<u64>,
+    #[cfg(unix)]
+    mode: Option<String>,
+    #[cfg(unix)]
+    group_or_other_writable: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct ListenerSummary {
+    listen_addr: String,
+    transport: &'static str,
+    shards: usize,
+    authentication: &'static str,
+    basic_user_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ServerLimitsSummary {
+    idle_timeout_secs: u64,
+    max_connections: usize,
+    max_connections_per_ip: usize,
+    max_pending_auth_per_ip: usize,
+    max_tunnels_per_connection: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ProtocolSummary {
+    connect_tcp_enabled: bool,
+    connect_udp_enabled: bool,
+    connect_ip_enabled: bool,
+    tcp_allow_rule_count: usize,
+    tcp_deny_rule_count: usize,
+    udp_allow_rule_count: usize,
+    udp_deny_rule_count: usize,
+    tun_name: Option<String>,
+    tun_mtu: Option<usize>,
+    tun_offload: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct QuicSummary {
+    max_datagram_size: usize,
+    congestion_controller: String,
+    udp_gso: bool,
+    udp_gro: bool,
+    path_mtu_discovery: bool,
+    datagram_receive_queue: usize,
+    datagram_send_queue: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct Http2Summary {
+    initial_stream_window: u32,
+    initial_connection_window: u32,
+    max_concurrent_streams: u32,
+    max_datagram_size: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct TlsSummary {
+    certificate_file: FileSummary,
+    private_key_file: FileSummary,
+    certificate_not_before: Option<String>,
+    certificate_not_after: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DiagnosticSummary {
+    level: &'static str,
+    name: &'static str,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct SystemdSummary {
+    available: bool,
+    load_state: Option<String>,
+    active_state: Option<String>,
+    sub_state: Option<String>,
+    unit_file_state: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PrivacySummary {
+    excluded: [&'static str; 8],
+}
+
+/// Collect a support report from already parsed and validated configuration.
+pub fn collect(
+    config_path: &Path,
+    config: &ServerConfig,
+    listeners: &[ResolvedListener],
+) -> SupportBundle {
+    let generated_at_unix_seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let certificate = read_certificate_window(&config.tls.cert_path);
+    let connect_ip_diagnostics = host::diagnose_connect_ip(&config.ip_proxy)
+        .checks()
+        .iter()
+        .map(|check| DiagnosticSummary {
+            level: check.level.label(),
+            name: check.name,
+        })
+        .collect();
+
+    SupportBundle {
+        schema_version: 1,
+        generated_at_unix_seconds,
+        application: ApplicationSummary {
+            name: "masque-server",
+            version: env!("CARGO_PKG_VERSION"),
+        },
+        host: HostSummary {
+            os: std::env::consts::OS,
+            architecture: std::env::consts::ARCH,
+            kernel_release: command_line("uname", &["-r"]),
+            logical_cpus: std::thread::available_parallelism().ok().map(usize::from),
+        },
+        configuration: ConfigurationSummary {
+            valid: true,
+            config_file: file_summary(config_path),
+            listeners: listeners
+                .iter()
+                .map(|listener| ListenerSummary {
+                    listen_addr: listener.listen_addr.to_string(),
+                    transport: listener.transport.as_str(),
+                    shards: listener.shards,
+                    authentication: auth_label(&listener.auth),
+                    basic_user_count: basic_user_count(&listener.auth),
+                })
+                .collect(),
+            registered_client_count: config.clients.len(),
+            server: ServerLimitsSummary {
+                idle_timeout_secs: config.server.idle_timeout_secs,
+                max_connections: config.server.max_connections,
+                max_connections_per_ip: config.server.max_connections_per_ip,
+                max_pending_auth_per_ip: config.server.max_pending_auth_per_ip,
+                max_tunnels_per_connection: config.server.max_tunnels_per_connection,
+            },
+            protocols: ProtocolSummary {
+                connect_tcp_enabled: config.tcp_proxy.enabled,
+                connect_udp_enabled: config.udp_proxy.enabled,
+                connect_ip_enabled: config.ip_proxy.enabled,
+                tcp_allow_rule_count: config.tcp_proxy.allow_targets.len(),
+                tcp_deny_rule_count: config.tcp_proxy.deny_targets.len(),
+                udp_allow_rule_count: config.udp_proxy.allow_targets.len(),
+                udp_deny_rule_count: config.udp_proxy.deny_targets.len(),
+                tun_name: config
+                    .ip_proxy
+                    .enabled
+                    .then(|| config.ip_proxy.tun_name.clone()),
+                tun_mtu: config.ip_proxy.enabled.then_some(config.ip_proxy.tun_mtu),
+                tun_offload: config
+                    .ip_proxy
+                    .enabled
+                    .then_some(config.ip_proxy.tun_offload),
+            },
+            quic: QuicSummary {
+                max_datagram_size: config.quic.max_datagram_size,
+                congestion_controller: config.quic.cc_algorithm.clone(),
+                udp_gso: config.quic.enable_udp_gso,
+                udp_gro: config.quic.enable_udp_gro,
+                path_mtu_discovery: config.quic.discover_pmtu,
+                datagram_receive_queue: config.quic.dgram_recv_queue_len,
+                datagram_send_queue: config.quic.dgram_send_queue_len,
+            },
+            http2: Http2Summary {
+                initial_stream_window: config.http2.initial_stream_window,
+                initial_connection_window: config.http2.initial_connection_window,
+                max_concurrent_streams: config.http2.max_concurrent_streams,
+                max_datagram_size: config.http2.max_datagram_size,
+            },
+            observability_listen_addr: config
+                .observability
+                .listen_addr
+                .map(|address| address.to_string()),
+        },
+        tls: TlsSummary {
+            certificate_file: file_summary(&config.tls.cert_path),
+            private_key_file: file_summary(&config.tls.key_path),
+            certificate_not_before: certificate
+                .as_ref()
+                .map(|cert| cert.not_before().to_string()),
+            certificate_not_after: certificate
+                .as_ref()
+                .map(|cert| cert.not_after().to_string()),
+        },
+        connect_ip_diagnostics,
+        systemd: systemd_summary(),
+        privacy: PrivacySummary {
+            excluded: [
+                "raw configuration",
+                "usernames and password hashes",
+                "client names and assigned addresses",
+                "certificate subjects and serial numbers",
+                "public and private key material",
+                "environment variables",
+                "logs",
+                "traffic destinations and counters",
+            ],
+        },
+    }
+}
+
+/// Serialize a support report using a stable, human-readable JSON layout.
+pub fn to_json(bundle: &SupportBundle) -> anyhow::Result<String> {
+    let mut json =
+        serde_json::to_string_pretty(bundle).context("failed to serialize support bundle")?;
+    json.push('\n');
+    Ok(json)
+}
+
+/// Create a private support report without replacing an existing path.
+pub fn write(path: &Path, bundle: &SupportBundle) -> anyhow::Result<()> {
+    let json = to_json(bundle)?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path).with_context(|| {
+        format!(
+            "failed to create {} (refusing to overwrite an existing path)",
+            path.display()
+        )
+    })?;
+    file.write_all(json.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync {}", path.display()))
+}
+
+fn auth_label(auth: &crate::config::AuthSection) -> &'static str {
+    if auth.client_cert_enabled() {
+        "client_cert"
+    } else if auth.basic_enabled() {
+        "basic"
+    } else {
+        "disabled"
+    }
+}
+
+fn basic_user_count(auth: &crate::config::AuthSection) -> usize {
+    if !auth.basic_enabled() {
+        0
+    } else if auth.users.is_empty() {
+        usize::from(!auth.username.is_empty())
+    } else {
+        auth.users.len()
+    }
+}
+
+fn read_certificate_window(path: &Path) -> Option<X509> {
+    let pem = fs::read(path).ok()?;
+    X509::stack_from_pem(&pem).ok()?.into_iter().next()
+}
+
+fn file_summary(path: &Path) -> FileSummary {
+    let metadata = fs::metadata(path).ok();
+    #[cfg(unix)]
+    let mode = metadata.as_ref().map(|metadata| {
+        use std::os::unix::fs::PermissionsExt as _;
+        metadata.permissions().mode() & 0o7777
+    });
+    FileSummary {
+        exists: metadata.is_some(),
+        regular_file: metadata.as_ref().is_some_and(std::fs::Metadata::is_file),
+        size_bytes: metadata.as_ref().map(std::fs::Metadata::len),
+        #[cfg(unix)]
+        mode: mode.map(|mode| format!("{mode:04o}")),
+        #[cfg(unix)]
+        group_or_other_writable: mode.map(|mode| mode & 0o022 != 0),
+    }
+}
+
+fn command_line(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn systemd_summary() -> SystemdSummary {
+    let output = Command::new("systemctl")
+        .args([
+            "show",
+            "masque.service",
+            "--no-pager",
+            "--property=LoadState",
+            "--property=ActiveState",
+            "--property=SubState",
+            "--property=UnitFileState",
+        ])
+        .output();
+    let Ok(output) = output else {
+        return SystemdSummary::default();
+    };
+    if !output.status.success() {
+        return SystemdSummary::default();
+    }
+    let mut summary = SystemdSummary {
+        available: true,
+        ..SystemdSummary::default()
+    };
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = (!value.is_empty()).then(|| value.to_owned());
+        match key {
+            "LoadState" => summary.load_state = value,
+            "ActiveState" => summary.active_state = value,
+            "SubState" => summary.sub_state = value,
+            "UnitFileState" => summary.unit_file_state = value,
+            _ => {}
+        }
+    }
+    summary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AuthMode, BasicUser, ListenerTransport};
+
+    #[test]
+    fn serialized_bundle_never_contains_credentials_or_roster_identity() {
+        let mut config = ServerConfig::default();
+        config.ip_proxy.enabled = false;
+        config.clients.push(crate::config::ClientEntry {
+            name: "PRIVATE-CLIENT-LABEL".into(),
+            public_key: "PRIVATE-PUBLIC-KEY".into(),
+            ipv4: Some("10.89.0.99".into()),
+            ipv6: None,
+        });
+        config.listeners[0].auth.enabled = true;
+        config.listeners[0].auth.mode = AuthMode::Basic;
+        config.listeners[0].auth.username.clear();
+        config.listeners[0].auth.password_hash.clear();
+        config.listeners[0].auth.users = vec![BasicUser {
+            username: "PRIVATE-USERNAME".into(),
+            password_hash: "PRIVATE-PASSWORD-HASH".into(),
+        }];
+        let listeners = vec![ResolvedListener {
+            listen_addr: config.listeners[0].listen_addr,
+            transport: ListenerTransport::Http3,
+            shards: 1,
+            auth: config.listeners[0].auth.clone(),
+        }];
+
+        let json = to_json(&collect(
+            Path::new("/path/that/does/not/embed/the/config/name"),
+            &config,
+            &listeners,
+        ))
+        .unwrap();
+        for secret in [
+            "PRIVATE-CLIENT-LABEL",
+            "PRIVATE-PUBLIC-KEY",
+            "PRIVATE-USERNAME",
+            "PRIVATE-PASSWORD-HASH",
+            "10.89.0.99",
+        ] {
+            assert!(!json.contains(secret), "bundle leaked {secret}");
+        }
+        assert!(json.contains("\"basic_user_count\": 1"));
+        assert!(json.contains("\"registered_client_count\": 1"));
+    }
+}

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -279,6 +279,86 @@ fn adds_a_basic_listener_with_a_password_read_from_stdin() {
     );
 }
 
+#[test]
+fn adding_a_basic_listener_can_emit_its_private_surge_configuration() {
+    let fixture = Fixture::new(false);
+    let client_path = fixture._dir.path().join("new-listener.conf");
+    let output = fixture.user_command(
+        "add-listener",
+        &[
+            "--listen-addr",
+            "127.0.0.1:8465",
+            "--mode",
+            "basic",
+            "--username",
+            "phone",
+            "--password-stdin",
+            "--emit-client",
+            "surge",
+            "--client-endpoint",
+            "proxy.example:8465",
+            "--client-name",
+            "phone",
+            "--client-out",
+            client_path.to_str().unwrap(),
+            "--no-bind-check",
+        ],
+        Some(b"listener-secret\n"),
+    );
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(&client_path).unwrap(),
+        "[Proxy]\nphone = masque, proxy.example, 8465, username=phone, password=listener-secret\n"
+    );
+    assert!(!fixture.text().contains("listener-secret"));
+    assert_eq!(
+        fixture.config().listeners[1].auth.users[0].username,
+        "phone"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            std::fs::metadata(client_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+#[test]
+fn surge_output_is_rejected_for_an_http2_listener_without_editing_config() {
+    let fixture = Fixture::new(false);
+    let client_path = fixture._dir.path().join("unused.conf");
+    let output = fixture.user_command(
+        "add-listener",
+        &[
+            "--transport",
+            "http2",
+            "--listen-addr",
+            "127.0.0.1:8465",
+            "--mode",
+            "basic",
+            "--username",
+            "phone",
+            "--password-stdin",
+            "--emit-client",
+            "surge",
+            "--client-endpoint",
+            "proxy.example:8465",
+            "--client-out",
+            client_path.to_str().unwrap(),
+        ],
+        Some(b"listener-secret\n"),
+    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires an HTTP/3 listener"));
+    fixture.assert_unchanged();
+}
+
 /// Without a flag or a terminal there is no password to write, and a Basic
 /// listener with none cannot start. One is generated and printed instead — the
 /// same choice the installer makes.
@@ -677,6 +757,97 @@ fn add_user_migrates_legacy_credentials_and_list_users_redacts_hashes() {
     assert!(stdout.contains("alice"));
     assert!(stdout.contains("bob"));
     assert!(!stdout.contains("argon2"));
+}
+
+#[test]
+fn add_user_can_write_a_private_surge_configuration() {
+    let fixture = Fixture::new(false);
+    let client_path = fixture._dir.path().join("phone.conf");
+    let output = fixture.user_command(
+        "add-user",
+        &[
+            "--username",
+            "bob",
+            "--password-stdin",
+            "--emit-client",
+            "surge",
+            "--client-endpoint",
+            "proxy.example:8449",
+            "--client-name",
+            "phone",
+            "--client-out",
+            client_path.to_str().unwrap(),
+        ],
+        Some(b"bob secret,with comma\n"),
+    );
+    assert!(
+        output.status.success(),
+        "add-user failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("bob secret"));
+    assert_eq!(
+        std::fs::read_to_string(&client_path).unwrap(),
+        "[Proxy]\nphone = masque, proxy.example, 8449, username=bob, password=\"bob secret,with comma\"\n"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            std::fs::metadata(&client_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    let config = fixture.config();
+    let bob = config.listeners[0]
+        .auth
+        .users
+        .iter()
+        .find(|user| user.username == "bob")
+        .unwrap();
+    assert!(
+        Argon2::default()
+            .verify_password(
+                b"bob secret,with comma",
+                &PasswordHash::new(&bob.password_hash).unwrap()
+            )
+            .is_ok()
+    );
+}
+
+#[test]
+fn failed_client_output_leaves_the_account_file_unchanged() {
+    let fixture = Fixture::new(false);
+    let before = fixture.text();
+    let client_path = fixture._dir.path().join("existing.conf");
+    std::fs::write(&client_path, "do not replace").unwrap();
+    let output = fixture.user_command(
+        "add-user",
+        &[
+            "--username",
+            "bob",
+            "--password-stdin",
+            "--emit-client",
+            "surge",
+            "--client-endpoint",
+            "proxy.example:8449",
+            "--client-out",
+            client_path.to_str().unwrap(),
+        ],
+        Some(b"bob-secret\n"),
+    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("refusing to overwrite"));
+    assert_eq!(fixture.text(), before);
+    assert_eq!(
+        std::fs::read_to_string(client_path).unwrap(),
+        "do not replace"
+    );
 }
 
 #[test]

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -197,6 +197,73 @@ fn doctor_is_read_only_and_succeeds_when_connect_ip_is_disabled() {
 }
 
 #[test]
+fn support_bundle_is_private_and_omits_configured_identities() {
+    let dir = TempDir::new();
+    let (cert_path, key_path) = write_server_identity(dir.path());
+    let listen_addr = "127.0.0.1:8449".parse().unwrap();
+    let password_hash = masque::auth::hash_password(b"PRIVATE-PLAINTEXT-PASSWORD").unwrap();
+    let config = config_text(listen_addr, &cert_path, &key_path, "cubic").replace(
+        "[listeners.auth]\nenabled = false",
+        &format!(
+            r#"[listeners.auth]
+enabled = true
+mode = "basic"
+
+[[listeners.auth.users]]
+username = "PRIVATE-USERNAME"
+password_hash = "{password_hash}"
+
+[[clients]]
+name = "PRIVATE-CLIENT-LABEL"
+public_key = "PRIVATE-PUBLIC-KEY""#
+        ),
+    );
+    let config_path = dir.path().join("masque.toml");
+    let bundle_path = dir.path().join("support.json");
+    std::fs::write(&config_path, config).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("support-bundle")
+        .arg("--out")
+        .arg(&bundle_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "support-bundle failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bundle = std::fs::read_to_string(&bundle_path).unwrap();
+    assert!(bundle.contains("\"schema_version\": 1"));
+    assert!(bundle.contains("\"authentication\": \"basic\""));
+    assert!(bundle.contains("\"basic_user_count\": 1"));
+    assert!(bundle.contains("\"registered_client_count\": 1"));
+    for private in [
+        "PRIVATE-PLAINTEXT-PASSWORD",
+        "PRIVATE-USERNAME",
+        "PRIVATE-CLIENT-LABEL",
+        "PRIVATE-PUBLIC-KEY",
+        &password_hash,
+        config_path.to_str().unwrap(),
+        cert_path.to_str().unwrap(),
+        key_path.to_str().unwrap(),
+    ] {
+        assert!(!bundle.contains(private), "support bundle leaked {private}");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            std::fs::metadata(bundle_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+#[test]
 fn json_log_format_emits_machine_parseable_events() {
     let dir = TempDir::new();
     let (cert_path, key_path) = write_server_identity(dir.path());

--- a/tests/client_config.rs
+++ b/tests/client_config.rs
@@ -1,0 +1,108 @@
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn run(args: &[&str], password: &[u8]) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("client-config")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(password).unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn unused_path(name: &str) -> PathBuf {
+    static SEQUENCE: AtomicU32 = AtomicU32::new(0);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "masque-client-config-{}-{nonce}-{}-{name}",
+        std::process::id(),
+        SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+#[test]
+fn client_config_writes_a_private_importable_surge_file() {
+    let path = unused_path("surge.conf");
+    let output = run(
+        &[
+            "surge",
+            "--endpoint",
+            "proxy.example:8449",
+            "--username",
+            "alice",
+            "--name",
+            "phone",
+            "--out",
+            path.to_str().unwrap(),
+        ],
+        b"secret, with spaces\n",
+    );
+    assert!(
+        output.status.success(),
+        "client-config failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("secret"));
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "[Proxy]\nphone = masque, proxy.example, 8449, username=alice, password=\"secret, with spaces\"\n"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn client_config_refuses_to_replace_an_existing_file() {
+    let path = unused_path("existing.conf");
+    std::fs::write(&path, "keep me").unwrap();
+    let output = run(
+        &[
+            "surge",
+            "--endpoint",
+            "proxy.example:8449",
+            "--username",
+            "alice",
+            "--out",
+            path.to_str().unwrap(),
+        ],
+        b"secret\n",
+    );
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("refusing to overwrite"));
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "keep me");
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn client_config_stdout_is_explicitly_marked_as_secret() {
+    let output = run(
+        &[
+            "surge",
+            "--endpoint",
+            "[2001:db8::1]:443",
+            "--username",
+            "alice",
+        ],
+        b"secret\n",
+    );
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("password=secret"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("plaintext password"));
+}

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -20,14 +20,17 @@ die() {
 
 CANDIDATE=${MASQUE_TEST_PACKAGE_BIN:-}
 [ -x "$CANDIDATE" ] || die "MASQUE_TEST_PACKAGE_BIN must name an executable"
+CANDIDATE_PROBE=${MASQUE_TEST_PACKAGE_PROBE:-}
+[ -x "$CANDIDATE_PROBE" ] || die "MASQUE_TEST_PACKAGE_PROBE must name an executable"
 
 BIN_PATH=/usr/local/bin/masque-server
+PROBE_PATH=/usr/local/bin/masque-probe
 CONFIG_PATH=/etc/masque/masque.toml
 UNIT_PATH=/etc/systemd/system/masque.service
 MONITORING_DIR=/usr/local/share/masque-server/monitoring
 PROMETHEUS_RULES_PATH=$MONITORING_DIR/prometheus-rules.yml
 GRAFANA_DASHBOARD_PATH=$MONITORING_DIR/grafana-dashboard.json
-for protected_path in "$BIN_PATH" "$CONFIG_PATH" "$UNIT_PATH" \
+for protected_path in "$BIN_PATH" "$PROBE_PATH" "$CONFIG_PATH" "$UNIT_PATH" \
     "$PROMETHEUS_RULES_PATH" "$GRAFANA_DASHBOARD_PATH"; do
     [ ! -e "$protected_path" ] || die "runner is not clean: $protected_path already exists"
 done
@@ -40,6 +43,7 @@ cleanup() {
     set +e
     rm -f -- \
         "$BIN_PATH" \
+        "$PROBE_PATH" \
         "$CONFIG_PATH" \
         /etc/masque/.masque.toml.lock \
         "$UNIT_PATH" \
@@ -61,6 +65,7 @@ MOCK_STATE=$TEST_TMP/restart-count
 install -d "$PACKAGE_DIR/bin" "$PACKAGE_DIR/config" "$PACKAGE_DIR/monitoring" \
     "$PACKAGE_DIR/systemd" "$MOCK_BIN"
 install -m 0755 "$CANDIDATE" "$PACKAGE_DIR/bin/masque-server"
+install -m 0755 "$CANDIDATE_PROBE" "$PACKAGE_DIR/bin/masque-probe"
 install -m 0755 deploy/install.sh "$PACKAGE_DIR/install.sh"
 install -m 0644 deploy/config/masque.toml "$PACKAGE_DIR/config/masque.toml"
 install -m 0644 deploy/systemd/masque.service "$PACKAGE_DIR/systemd/masque.service"
@@ -139,6 +144,11 @@ write_old_installation() {
 echo old-masque-server
 EOF
     chmod 0755 "$BIN_PATH"
+    cat >"$PROBE_PATH" <<'EOF'
+#!/usr/bin/env sh
+echo old-masque-probe
+EOF
+    chmod 0755 "$PROBE_PATH"
     printf '%s\n' 'old systemd unit' >"$UNIT_PATH"
     chmod 0644 "$UNIT_PATH"
     install -d "$MONITORING_DIR"
@@ -170,6 +180,7 @@ assert_upgrade_output_is_summary_only() {
 # both authentication modes. This runs first, while the runner still has no
 # configuration; the upgrade cases below overwrite everything it leaves behind.
 DUAL_CLIENT_JSON=$TEST_TMP/dual-client.json
+DUAL_SURGE_CONFIG=$TEST_TMP/dual-surge.conf
 MASQUE_AUTH_MODE=dual \
     MASQUE_AUTH_USERNAME=proxy-user \
     MASQUE_AUTH_PASSWORD=a-strong-password \
@@ -178,6 +189,9 @@ MASQUE_AUTH_MODE=dual \
     MASQUE_CLIENT_NAME=laptop \
     MASQUE_CLIENT_ENDPOINT=203.0.113.9:8450 \
     MASQUE_CLIENT_CONFIG_OUT="$DUAL_CLIENT_JSON" \
+    MASQUE_BASIC_CLIENT_ENDPOINT=proxy.example:8449 \
+    MASQUE_BASIC_CLIENT_NAME=dual-proxy \
+    MASQUE_BASIC_CLIENT_CONFIG_OUT="$DUAL_SURGE_CONFIG" \
     MASQUE_START_SERVICE=0 \
     "$PACKAGE_DIR/install.sh" >"$TEST_TMP/dual.log" 2>&1 ||
     die "fresh dual installation failed; see $TEST_TMP/dual.log"
@@ -202,6 +216,12 @@ grep -q '^\[server\]$' "$CONFIG_PATH" ||
 grep -q '^\[\[clients\]\]$' "$CONFIG_PATH" ||
     die "dual mode did not enroll the first certificate client"
 [ -s "$DUAL_CLIENT_JSON" ] || die "dual mode did not write the client JSON"
+[ -s "$DUAL_SURGE_CONFIG" ] || die "dual mode did not write the Surge configuration"
+grep -q '^dual-proxy = masque, proxy.example, 8449, username=proxy-user, password=a-strong-password$' \
+    "$DUAL_SURGE_CONFIG" || die "the generated Surge configuration is not importable"
+[ "$(stat -c '%a' "$DUAL_SURGE_CONFIG")" = 600 ] ||
+    die "the generated Surge configuration is not mode 0600"
+[ -x "$PROBE_PATH" ] || die "the diagnostic probe was not installed"
 
 # The server itself must agree about what those listeners are.
 "$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/dual-check.log" 2>&1 ||
@@ -260,6 +280,7 @@ rm -f -- "$CONFIG_PATH" "$(dirname "$CONFIG_PATH")/.masque.toml.lock"
 write_old_installation
 write_config not-a-controller
 old_binary_sha=$(sha256sum "$BIN_PATH" | awk '{print $1}')
+old_probe_sha=$(sha256sum "$PROBE_PATH" | awk '{print $1}')
 old_unit_sha=$(sha256sum "$UNIT_PATH" | awk '{print $1}')
 old_rules_sha=$(sha256sum "$PROMETHEUS_RULES_PATH" | awk '{print $1}')
 old_dashboard_sha=$(sha256sum "$GRAFANA_DASHBOARD_PATH" | awk '{print $1}')
@@ -268,6 +289,7 @@ if MASQUE_START_SERVICE=0 "$PACKAGE_DIR/install.sh" >"$TEST_TMP/preflight.log" 2
     die "incompatible configuration unexpectedly passed"
 fi
 assert_sha_unchanged "$BIN_PATH" "$old_binary_sha"
+assert_sha_unchanged "$PROBE_PATH" "$old_probe_sha"
 assert_sha_unchanged "$UNIT_PATH" "$old_unit_sha"
 assert_sha_unchanged "$PROMETHEUS_RULES_PATH" "$old_rules_sha"
 assert_sha_unchanged "$GRAFANA_DASHBOARD_PATH" "$old_dashboard_sha"
@@ -283,7 +305,9 @@ assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
 assert_upgrade_output_is_summary_only "$TEST_TMP/staged.log"
 candidate_sha=$(sha256sum "$CANDIDATE" | awk '{print $1}')
+candidate_probe_sha=$(sha256sum "$CANDIDATE_PROBE" | awk '{print $1}')
 assert_sha_unchanged "$BIN_PATH" "$candidate_sha"
+assert_sha_unchanged "$PROBE_PATH" "$candidate_probe_sha"
 
 # A successful activation restarts once and preserves operator-managed files.
 write_old_installation
@@ -293,6 +317,7 @@ MOCK_ACTIVE=1 MOCK_ENABLED=1 MASQUE_START_SERVICE=1 \
 [ "$(sed -n '1p' "$MOCK_STATE")" -eq 1 ] ||
     die "successful activation did not restart the service exactly once"
 assert_sha_unchanged "$BIN_PATH" "$candidate_sha"
+assert_sha_unchanged "$PROBE_PATH" "$candidate_probe_sha"
 assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
 assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
@@ -303,6 +328,7 @@ grep -q 'Service:        started or restarted' "$TEST_TMP/activated.log" ||
 # A failed activation restores every release-managed file and the prior service state.
 write_old_installation
 old_binary_sha=$(sha256sum "$BIN_PATH" | awk '{print $1}')
+old_probe_sha=$(sha256sum "$PROBE_PATH" | awk '{print $1}')
 old_unit_sha=$(sha256sum "$UNIT_PATH" | awk '{print $1}')
 old_rules_sha=$(sha256sum "$PROMETHEUS_RULES_PATH" | awk '{print $1}')
 old_dashboard_sha=$(sha256sum "$GRAFANA_DASHBOARD_PATH" | awk '{print $1}')
@@ -313,13 +339,14 @@ if MOCK_ACTIVE=1 MOCK_ENABLED=1 MOCK_FAIL_FIRST_RESTART=1 \
     die "failed activation unexpectedly reported success"
 fi
 assert_sha_unchanged "$BIN_PATH" "$old_binary_sha"
+assert_sha_unchanged "$PROBE_PATH" "$old_probe_sha"
 assert_sha_unchanged "$UNIT_PATH" "$old_unit_sha"
 assert_sha_unchanged "$PROMETHEUS_RULES_PATH" "$old_rules_sha"
 assert_sha_unchanged "$GRAFANA_DASHBOARD_PATH" "$old_dashboard_sha"
 assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
 assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
-grep -q 'Previous binary, systemd unit, monitoring assets, and service state restored' \
+grep -q 'Previous binaries, systemd unit, monitoring assets, and service state restored' \
     "$TEST_TMP/rollback.log" || die "rollback confirmation was not printed"
 
 echo "installer upgrade preflight, preservation, and rollback passed"

--- a/tests/monitoring_assets.rs
+++ b/tests/monitoring_assets.rs
@@ -55,4 +55,5 @@ fn release_packager_includes_both_monitoring_assets() {
     let script = std::fs::read_to_string(root.join("scripts/package-linux.sh")).unwrap();
     assert!(script.contains("monitoring/prometheus-rules.yml"));
     assert!(script.contains("monitoring/grafana-dashboard.json"));
+    assert!(script.contains("bin/masque-probe"));
 }

--- a/tools/masque-probe/Cargo.toml
+++ b/tools/masque-probe/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "masque-probe"
+version = "0.10.0"
+edition = "2024"
+rust-version = "1.88"
+description = "End-to-end connectivity diagnostics for MASQUE proxies"
+license = "MIT"
+repository = "https://github.com/Vincent-bin/masque-server"
+publish = false
+
+[[bin]]
+name = "masque-probe"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+base64 = "0.22.1"
+boring = "4.3"
+bytes = "1"
+clap = { version = "4", features = ["derive"] }
+h2 = "0.4.18"
+http = "1"
+masque = { package = "masque-server", path = "../.." }
+quiche = "0.29.3"
+ring = "0.17"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-boring = "4.19"
+zeroize = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/tools/masque-probe/src/credentials.rs
+++ b/tools/masque-probe/src/credentials.rs
@@ -1,0 +1,92 @@
+use std::io::Read as _;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use zeroize::Zeroizing;
+
+use crate::identity::ClientIdentity;
+use crate::report::ProbeFailure;
+
+pub enum Credentials {
+    None,
+    Basic(BasicCredentials),
+    ClientCertificate(ClientIdentity),
+}
+
+pub struct BasicCredentials {
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+}
+
+impl BasicCredentials {
+    pub fn from_stdin(username: String) -> Result<Self, ProbeFailure> {
+        if username.is_empty() || username.contains(':') || username.chars().any(char::is_control) {
+            return Err(ProbeFailure::new(
+                "INVALID_CREDENTIALS",
+                "Basic username must be non-empty and contain no colon or control character",
+            ));
+        }
+
+        let mut password = Zeroizing::new(String::new());
+        std::io::stdin()
+            .read_to_string(&mut password)
+            .map_err(|error| {
+                ProbeFailure::new(
+                    "INVALID_CREDENTIALS",
+                    format!("could not read password from stdin: {error}"),
+                )
+            })?;
+        if password.ends_with('\n') {
+            password.pop();
+            if password.ends_with('\r') {
+                password.pop();
+            }
+        }
+        if password.is_empty() || password.chars().any(char::is_control) {
+            return Err(ProbeFailure::new(
+                "INVALID_CREDENTIALS",
+                "Basic password must be non-empty and contain no control character",
+            ));
+        }
+
+        Ok(Self {
+            username: Zeroizing::new(username),
+            password,
+        })
+    }
+
+    pub fn authorization(&self) -> Zeroizing<String> {
+        let mut joined = Zeroizing::new(String::with_capacity(
+            self.username.len() + self.password.len() + 1,
+        ));
+        joined.push_str(&self.username);
+        joined.push(':');
+        joined.push_str(&self.password);
+        let encoded = STANDARD.encode(joined.as_bytes());
+        Zeroizing::new(format!("Basic {encoded}"))
+    }
+}
+
+impl Credentials {
+    pub fn authorization(&self) -> Option<Zeroizing<String>> {
+        match self {
+            Self::Basic(credentials) => Some(credentials.authorization()),
+            Self::None | Self::ClientCertificate(_) => None,
+        }
+    }
+
+    pub fn client_identity(&self) -> Option<&ClientIdentity> {
+        match self {
+            Self::ClientCertificate(identity) => Some(identity),
+            Self::None | Self::Basic(_) => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Basic(_) => "basic",
+            Self::ClientCertificate(_) => "client_cert",
+        }
+    }
+}

--- a/tools/masque-probe/src/endpoint.rs
+++ b/tools/masque-probe/src/endpoint.rs
@@ -1,0 +1,115 @@
+use std::collections::HashSet;
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use crate::report::ProbeFailure;
+
+#[derive(Debug, Clone)]
+pub struct Authority {
+    pub original: String,
+    pub host: String,
+    pub port: u16,
+}
+
+impl Authority {
+    pub fn parse(value: &str, what: &'static str) -> Result<Self, ProbeFailure> {
+        if value.contains('@') {
+            return Err(ProbeFailure::new(
+                "INVALID_ENDPOINT",
+                format!("invalid {what}: user information is not allowed"),
+            ));
+        }
+        let parsed = masque::uri::parse_connect_authority(value).map_err(|error| {
+            ProbeFailure::new(
+                "INVALID_ENDPOINT",
+                format!("invalid {what} {value:?}: {error}"),
+            )
+        })?;
+        if parsed.port == 0 {
+            return Err(ProbeFailure::new(
+                "INVALID_ENDPOINT",
+                format!("invalid {what}: port must be between 1 and 65535"),
+            ));
+        }
+        Ok(Self {
+            original: value.to_owned(),
+            host: parsed.host,
+            port: parsed.port,
+        })
+    }
+
+    pub fn resolve(&self) -> Result<Vec<SocketAddr>, ProbeFailure> {
+        let mut seen = HashSet::new();
+        let addresses = (self.host.as_str(), self.port)
+            .to_socket_addrs()
+            .map_err(|error| {
+                ProbeFailure::new(
+                    "DNS_ERROR",
+                    format!("could not resolve {}: {error}", self.original),
+                )
+            })?
+            .filter(|address| seen.insert(*address))
+            .take(8)
+            .collect::<Vec<_>>();
+        if addresses.is_empty() {
+            return Err(ProbeFailure::new(
+                "DNS_ERROR",
+                format!("{} resolved to no addresses", self.original),
+            ));
+        }
+        Ok(addresses)
+    }
+}
+
+pub fn validate_server_name(value: &str) -> Result<(), ProbeFailure> {
+    if value.is_empty()
+        || value
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+        || value.contains(['/', '@', ':'])
+    {
+        return Err(ProbeFailure::new(
+            "INVALID_SERVER_NAME",
+            "--server-name must be one DNS name without a port",
+        ));
+    }
+    Ok(())
+}
+
+pub fn encode_path_segment(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_dns_and_ipv6_authorities() {
+        let dns = Authority::parse("proxy.example:8449", "endpoint").unwrap();
+        assert_eq!(dns.host, "proxy.example");
+        assert_eq!(dns.port, 8449);
+
+        let ipv6 = Authority::parse("[2001:db8::1]:443", "endpoint").unwrap();
+        assert_eq!(ipv6.host, "2001:db8::1");
+        assert_eq!(ipv6.port, 443);
+    }
+
+    #[test]
+    fn rejects_user_information_and_port_zero() {
+        assert!(Authority::parse("user@proxy.example:443", "endpoint").is_err());
+        assert!(Authority::parse("proxy.example:0", "endpoint").is_err());
+    }
+
+    #[test]
+    fn percent_encodes_ipv6_for_connect_udp_path() {
+        assert_eq!(encode_path_segment("2001:db8::1"), "2001%3Adb8%3A%3A1");
+    }
+}

--- a/tools/masque-probe/src/http2.rs
+++ b/tools/masque-probe/src/http2.rs
@@ -1,0 +1,563 @@
+use std::future::poll_fn;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::Duration;
+
+use bytes::{Buf as _, Bytes};
+use h2::client::SendRequest;
+use http::{Method, Request};
+use masque::capsule::CapsuleFrame;
+use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
+use tokio::net::TcpStream;
+use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
+
+use crate::credentials::Credentials;
+use crate::endpoint::{Authority, encode_path_segment};
+use crate::protocol::{ensure_success_status, udp_probe_payload, validate_udp_probe_response};
+use crate::report::ProbeFailure;
+
+const INITIAL_STREAM_WINDOW: u32 = 4 * 1024 * 1024;
+const INITIAL_CONNECTION_WINDOW: u32 = 8 * 1024 * 1024;
+
+pub struct Session {
+    runtime: Runtime,
+    connection: Connection,
+}
+
+impl Session {
+    #[allow(clippy::too_many_arguments)]
+    pub fn connect(
+        addresses: &[SocketAddr],
+        endpoint: &Authority,
+        server_name: &str,
+        credentials: &Credentials,
+        insecure: bool,
+        ca_cert: Option<&Path>,
+        timeout: Duration,
+    ) -> Result<(Self, SocketAddr), ProbeFailure> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                ProbeFailure::new("HTTP2_RUNTIME_ERROR", format!("create runtime: {error}"))
+            })?;
+        let (connection, peer) = runtime.block_on(Connection::connect(
+            addresses,
+            endpoint,
+            server_name,
+            credentials,
+            insecure,
+            ca_cert,
+            timeout,
+        ))?;
+        Ok((
+            Self {
+                runtime,
+                connection,
+            },
+            peer,
+        ))
+    }
+
+    pub fn probe_tcp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+    ) -> Result<String, ProbeFailure> {
+        let Self {
+            runtime,
+            connection,
+        } = self;
+        runtime.block_on(connection.probe_tcp(target, credentials))
+    }
+
+    pub fn probe_udp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+        dns: bool,
+    ) -> Result<String, ProbeFailure> {
+        let Self {
+            runtime,
+            connection,
+        } = self;
+        runtime.block_on(connection.probe_udp(target, credentials, dns))
+    }
+
+    pub fn probe_connect_ip(&mut self, credentials: &Credentials) -> Result<String, ProbeFailure> {
+        let Self {
+            runtime,
+            connection,
+        } = self;
+        runtime.block_on(connection.probe_connect_ip(credentials))
+    }
+}
+
+struct Connection {
+    sender: SendRequest<Bytes>,
+    driver: JoinHandle<Result<(), h2::Error>>,
+    authority: String,
+    timeout: Duration,
+}
+
+impl Connection {
+    #[allow(clippy::too_many_arguments)]
+    async fn connect(
+        addresses: &[SocketAddr],
+        endpoint: &Authority,
+        server_name: &str,
+        credentials: &Credentials,
+        insecure: bool,
+        ca_cert: Option<&Path>,
+        timeout: Duration,
+    ) -> Result<(Self, SocketAddr), ProbeFailure> {
+        let mut failures = Vec::new();
+        for &peer in addresses {
+            match Self::connect_one(
+                peer,
+                endpoint,
+                server_name,
+                credentials,
+                insecure,
+                ca_cert,
+                timeout,
+            )
+            .await
+            {
+                Ok(connection) => return Ok((connection, peer)),
+                Err(failure) => failures.push(format!("{peer}: {}", failure.detail)),
+            }
+        }
+        Err(ProbeFailure::new(
+            "HTTP2_HANDSHAKE_FAILED",
+            format!("all resolved addresses failed: {}", failures.join("; ")),
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn connect_one(
+        peer: SocketAddr,
+        endpoint: &Authority,
+        server_name: &str,
+        credentials: &Credentials,
+        insecure: bool,
+        ca_cert: Option<&Path>,
+        timeout: Duration,
+    ) -> Result<Self, ProbeFailure> {
+        let tcp = tokio::time::timeout(timeout, TcpStream::connect(peer))
+            .await
+            .map_err(|_| {
+                ProbeFailure::new(
+                    "TCP_BLOCKED_OR_TIMEOUT",
+                    format!("TCP connection to {peer} timed out"),
+                )
+            })?
+            .map_err(|error| {
+                ProbeFailure::new(
+                    "TCP_CONNECT_ERROR",
+                    format!("TCP connection to {peer} failed: {error}"),
+                )
+            })?;
+        tcp.set_nodelay(true).map_err(|error| {
+            ProbeFailure::new("TCP_CONNECT_ERROR", format!("set TCP_NODELAY: {error}"))
+        })?;
+
+        let mut connector =
+            boring::ssl::SslConnector::builder(boring::ssl::SslMethod::tls_client()).map_err(
+                |error| {
+                    ProbeFailure::new("TLS_CONFIG_ERROR", format!("create TLS connector: {error}"))
+                },
+            )?;
+        connector
+            .set_alpn_protos(b"\x02h2")
+            .map_err(|error| ProbeFailure::new("TLS_CONFIG_ERROR", error.to_string()))?;
+        if let Some(identity) = credentials.client_identity() {
+            identity.configure_context(&mut connector)?;
+        } else {
+            connector.set_verify(if insecure {
+                boring::ssl::SslVerifyMode::NONE
+            } else {
+                boring::ssl::SslVerifyMode::PEER
+            });
+            if let Some(path) = ca_cert {
+                connector.set_ca_file(path).map_err(|error| {
+                    ProbeFailure::new(
+                        "TLS_CONFIG_ERROR",
+                        format!("load CA certificate {}: {error}", path.display()),
+                    )
+                })?;
+            }
+        }
+        let configuration = connector.build().configure().map_err(|error| {
+            ProbeFailure::new("TLS_CONFIG_ERROR", format!("configure TLS: {error}"))
+        })?;
+        let tls = tokio::time::timeout(
+            timeout,
+            tokio_boring::connect(configuration, server_name, tcp),
+        )
+        .await
+        .map_err(|_| {
+            ProbeFailure::new(
+                "TLS_HANDSHAKE_TIMEOUT",
+                format!("TLS handshake with {peer} timed out"),
+            )
+        })?
+        .map_err(|error| {
+            ProbeFailure::new(
+                "TLS_HANDSHAKE_FAILED",
+                format!("TLS handshake with {peer} failed: {error}"),
+            )
+        })?;
+        if tls.ssl().selected_alpn_protocol() != Some(b"h2") {
+            return Err(ProbeFailure::new(
+                "HTTP2_ALPN_MISSING",
+                "server did not negotiate the h2 ALPN",
+            ));
+        }
+        if let Some(identity) = credentials.client_identity() {
+            let certificate = tls.ssl().peer_certificate().ok_or_else(|| {
+                ProbeFailure::new("TLS_PIN_MISMATCH", "server sent no leaf certificate")
+            })?;
+            let der = certificate.to_der().map_err(|error| {
+                ProbeFailure::new(
+                    "TLS_PIN_MISMATCH",
+                    format!("encode server certificate: {error}"),
+                )
+            })?;
+            identity.verify_peer_certificate(&der)?;
+        }
+
+        let mut builder = h2::client::Builder::new();
+        builder
+            .initial_window_size(INITIAL_STREAM_WINDOW)
+            .initial_connection_window_size(INITIAL_CONNECTION_WINDOW)
+            .max_send_buffer_size(1024 * 1024)
+            .data_frame_budget(64 * 1024);
+        let (sender, h2_connection) = builder.handshake(tls).await.map_err(|error| {
+            ProbeFailure::new(
+                "HTTP2_HANDSHAKE_FAILED",
+                format!("start HTTP/2 connection: {error}"),
+            )
+        })?;
+        let driver = tokio::spawn(h2_connection);
+        let sender = sender.ready().await.map_err(|error| {
+            ProbeFailure::new(
+                "HTTP2_HANDSHAKE_FAILED",
+                format!("HTTP/2 sender not ready: {error}"),
+            )
+        })?;
+        let deadline = tokio::time::Instant::now() + timeout;
+        while !sender.is_extended_connect_protocol_enabled() {
+            if driver.is_finished() {
+                return Err(ProbeFailure::new(
+                    "HTTP2_SETTINGS_MISSING",
+                    "HTTP/2 connection ended before server SETTINGS arrived",
+                ));
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(ProbeFailure::new(
+                    "HTTP2_SETTINGS_MISSING",
+                    "server did not advertise Extended CONNECT",
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        Ok(Self {
+            sender,
+            driver,
+            authority: endpoint.original.clone(),
+            timeout,
+        })
+    }
+
+    async fn ready_sender(&self) -> Result<SendRequest<Bytes>, ProbeFailure> {
+        self.sender.clone().ready().await.map_err(|error| {
+            ProbeFailure::new(
+                "HTTP2_CONNECTION_CLOSED",
+                format!("HTTP/2 connection is not ready: {error}"),
+            )
+        })
+    }
+
+    async fn probe_tcp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+    ) -> Result<String, ProbeFailure> {
+        let uri = http::Uri::builder()
+            .authority(target.original.as_str())
+            .build()
+            .map_err(|error| {
+                ProbeFailure::new(
+                    "INVALID_TARGET",
+                    format!("build CONNECT authority: {error}"),
+                )
+            })?;
+        let mut request = Request::builder()
+            .method(Method::CONNECT)
+            .uri(uri)
+            .body(())
+            .map_err(|error| ProbeFailure::new("HTTP2_REQUEST_ERROR", error.to_string()))?;
+        append_auth(&mut request, credentials)?;
+        let mut sender = self.ready_sender().await?;
+        let (response, _) = sender.send_request(request, false).map_err(|error| {
+            ProbeFailure::new("HTTP2_REQUEST_ERROR", format!("send CONNECT: {error}"))
+        })?;
+        let response = response_with_timeout(response, self.timeout).await?;
+        ensure_success_status(response.status().as_u16(), &target.original)?;
+        Ok(format!("CONNECT to {} returned HTTP 200", target.original))
+    }
+
+    async fn probe_udp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+        dns: bool,
+    ) -> Result<String, ProbeFailure> {
+        let path = format!(
+            "/.well-known/masque/udp/{}/{}/",
+            encode_path_segment(&target.host),
+            target.port
+        );
+        let uri = format!("https://{}{}", self.authority, path)
+            .parse::<http::Uri>()
+            .map_err(|error| {
+                ProbeFailure::new("INVALID_TARGET", format!("build CONNECT-UDP URI: {error}"))
+            })?;
+        let mut request = Request::builder()
+            .method(Method::CONNECT)
+            .uri(uri)
+            .header("capsule-protocol", "?1")
+            .body(())
+            .map_err(|error| ProbeFailure::new("HTTP2_REQUEST_ERROR", error.to_string()))?;
+        request
+            .extensions_mut()
+            .insert(h2::ext::Protocol::from_static("connect-udp"));
+        append_auth(&mut request, credentials)?;
+        let mut sender = self.ready_sender().await?;
+        let (response, mut request_body) =
+            sender.send_request(request, false).map_err(|error| {
+                ProbeFailure::new("HTTP2_REQUEST_ERROR", format!("send CONNECT-UDP: {error}"))
+            })?;
+        let response = response_with_timeout(response, self.timeout).await?;
+        ensure_success_status(response.status().as_u16(), &target.original)?;
+        if response.headers().get("capsule-protocol") != Some(&http::HeaderValue::from_static("?1"))
+        {
+            return Err(ProbeFailure::new(
+                "CAPSULE_PROTOCOL_MISSING",
+                "CONNECT-UDP response omitted Capsule-Protocol: ?1",
+            ));
+        }
+        let mut response_body = response.into_body();
+        let request = udp_probe_payload(dns);
+        let mut capsule = Vec::with_capacity(request.len() + 16);
+        masque::capsule::encoder::encode_datagram_context_zero(&request, &mut capsule);
+        send_data_all(&mut request_body, Bytes::from(capsule), false).await?;
+        let payload = recv_datagram_payload(&mut response_body, self.timeout).await?;
+        validate_udp_probe_response(&payload, &request, dns)?;
+        Ok(format!(
+            "CONNECT-UDP to {} returned a matching {} response",
+            target.original,
+            if dns { "DNS" } else { "echo" }
+        ))
+    }
+
+    async fn probe_connect_ip(
+        &mut self,
+        credentials: &Credentials,
+    ) -> Result<String, ProbeFailure> {
+        let uri = format!("https://{}/.well-known/masque/ip/", self.authority)
+            .parse::<http::Uri>()
+            .map_err(|error| {
+                ProbeFailure::new("INVALID_ENDPOINT", format!("build CONNECT-IP URI: {error}"))
+            })?;
+        let mut request = Request::builder()
+            .method(Method::CONNECT)
+            .uri(uri)
+            .header("capsule-protocol", "?1")
+            .body(())
+            .map_err(|error| ProbeFailure::new("HTTP2_REQUEST_ERROR", error.to_string()))?;
+        request
+            .extensions_mut()
+            .insert(h2::ext::Protocol::from_static("connect-ip"));
+        append_auth(&mut request, credentials)?;
+        let mut sender = self.ready_sender().await?;
+        let (response, _) = sender.send_request(request, false).map_err(|error| {
+            ProbeFailure::new("HTTP2_REQUEST_ERROR", format!("send CONNECT-IP: {error}"))
+        })?;
+        let response = response_with_timeout(response, self.timeout).await?;
+        ensure_success_status(response.status().as_u16(), "CONNECT-IP")?;
+        let addresses = recv_assigned_addresses(response.into_body(), self.timeout).await?;
+        Ok(format!(
+            "CONNECT-IP assigned {addresses} address(es); run server-side doctor to verify forwarding/NAT"
+        ))
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.driver.abort();
+    }
+}
+
+fn append_auth(request: &mut Request<()>, credentials: &Credentials) -> Result<(), ProbeFailure> {
+    if let Some(value) = credentials.authorization() {
+        let value = http::HeaderValue::from_str(&value).map_err(|error| {
+            ProbeFailure::new(
+                "INVALID_CREDENTIALS",
+                format!("build Proxy-Authorization header: {error}"),
+            )
+        })?;
+        request
+            .headers_mut()
+            .insert(http::header::PROXY_AUTHORIZATION, value);
+    }
+    Ok(())
+}
+
+async fn response_with_timeout(
+    response: h2::client::ResponseFuture,
+    timeout: Duration,
+) -> Result<http::Response<h2::RecvStream>, ProbeFailure> {
+    tokio::time::timeout(timeout, response)
+        .await
+        .map_err(|_| ProbeFailure::new("RESPONSE_TIMEOUT", "CONNECT response timed out"))?
+        .map_err(|error| {
+            ProbeFailure::new(
+                "HTTP2_RESPONSE_ERROR",
+                format!("CONNECT response failed: {error}"),
+            )
+        })
+}
+
+async fn send_data_all(
+    stream: &mut h2::SendStream<Bytes>,
+    mut data: Bytes,
+    end_stream: bool,
+) -> Result<(), ProbeFailure> {
+    while data.has_remaining() {
+        stream.reserve_capacity(data.remaining());
+        let capacity = poll_fn(|context| stream.poll_capacity(context))
+            .await
+            .ok_or_else(|| {
+                ProbeFailure::new(
+                    "HTTP2_STREAM_CLOSED",
+                    "request stream closed while waiting for flow-control capacity",
+                )
+            })?
+            .map_err(|error| {
+                ProbeFailure::new("HTTP2_STREAM_CLOSED", format!("flow control: {error}"))
+            })?;
+        let length = capacity.min(data.remaining());
+        let chunk = data.split_to(length);
+        stream
+            .send_data(chunk, end_stream && data.is_empty())
+            .map_err(|error| {
+                ProbeFailure::new("HTTP2_STREAM_CLOSED", format!("send capsule: {error}"))
+            })?;
+    }
+    Ok(())
+}
+
+async fn recv_datagram_payload(
+    stream: &mut h2::RecvStream,
+    timeout: Duration,
+) -> Result<Vec<u8>, ProbeFailure> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut decoder = CapsuleDecoder::new();
+    loop {
+        let chunk = tokio::time::timeout_at(deadline, stream.data())
+            .await
+            .map_err(|_| {
+                ProbeFailure::new(
+                    "UDP_RESPONSE_TIMEOUT",
+                    "CONNECT-UDP opened, but no DNS response capsule arrived",
+                )
+            })?
+            .ok_or_else(|| {
+                ProbeFailure::new(
+                    "HTTP2_STREAM_CLOSED",
+                    "CONNECT-UDP response stream ended before a DNS response",
+                )
+            })?
+            .map_err(|error| {
+                ProbeFailure::new("HTTP2_STREAM_CLOSED", format!("read capsule: {error}"))
+            })?;
+        stream
+            .flow_control()
+            .release_capacity(chunk.len())
+            .map_err(|error| ProbeFailure::new("HTTP2_FLOW_CONTROL_ERROR", error.to_string()))?;
+        let frames = match decoder.decode(&chunk) {
+            Ok(frames) => frames,
+            Err(DecodeError::Incomplete) => continue,
+            Err(error) => {
+                return Err(ProbeFailure::new(
+                    "CAPSULE_ERROR",
+                    format!("decode DATAGRAM capsule: {error:?}"),
+                ));
+            }
+        };
+        for frame in frames {
+            let CapsuleFrame::Datagram(value) = frame else {
+                continue;
+            };
+            let (context, length) = masque::varint::decode(&value).map_err(|_| {
+                ProbeFailure::new("CAPSULE_ERROR", "DATAGRAM capsule has no Context ID")
+            })?;
+            if context == 0 {
+                return Ok(value[length..].to_vec());
+            }
+        }
+    }
+}
+
+async fn recv_assigned_addresses(
+    mut stream: h2::RecvStream,
+    timeout: Duration,
+) -> Result<usize, ProbeFailure> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut decoder = CapsuleDecoder::new();
+    loop {
+        let chunk = tokio::time::timeout_at(deadline, stream.data())
+            .await
+            .map_err(|_| {
+                ProbeFailure::new(
+                    "CAPSULE_TIMEOUT",
+                    "timed out waiting for CONNECT-IP ADDRESS_ASSIGN",
+                )
+            })?
+            .ok_or_else(|| {
+                ProbeFailure::new(
+                    "HTTP2_STREAM_CLOSED",
+                    "CONNECT-IP stream ended before ADDRESS_ASSIGN",
+                )
+            })?
+            .map_err(|error| {
+                ProbeFailure::new("HTTP2_STREAM_CLOSED", format!("read capsule: {error}"))
+            })?;
+        stream
+            .flow_control()
+            .release_capacity(chunk.len())
+            .map_err(|error| ProbeFailure::new("HTTP2_FLOW_CONTROL_ERROR", error.to_string()))?;
+        let frames = match decoder.decode(&chunk) {
+            Ok(frames) => frames,
+            Err(DecodeError::Incomplete) => continue,
+            Err(error) => {
+                return Err(ProbeFailure::new(
+                    "CAPSULE_ERROR",
+                    format!("decode CONNECT-IP capsule: {error:?}"),
+                ));
+            }
+        };
+        for frame in frames {
+            if let CapsuleFrame::AddressAssign(addresses) = frame
+                && !addresses.is_empty()
+            {
+                return Ok(addresses.len());
+            }
+        }
+    }
+}

--- a/tools/masque-probe/src/http3.rs
+++ b/tools/masque-probe/src/http3.rs
@@ -1,0 +1,753 @@
+use std::net::{SocketAddr, UdpSocket};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use boring::ssl::{SslContextBuilder, SslMethod};
+use masque::capsule::CapsuleFrame;
+use masque::capsule::decoder::{CapsuleDecoder, DecodeError};
+use quiche::h3::NameValue as _;
+use ring::rand::SecureRandom as _;
+
+use crate::credentials::Credentials;
+use crate::endpoint::{Authority, encode_path_segment};
+use crate::protocol::{ensure_success_status, udp_probe_payload, validate_udp_probe_response};
+use crate::report::ProbeFailure;
+
+const MAX_DATAGRAM_SIZE: usize = 65_535;
+
+pub struct Session {
+    socket: UdpSocket,
+    quic: quiche::Connection,
+    h3: quiche::h3::Connection,
+    peer: SocketAddr,
+    local: SocketAddr,
+    authority: String,
+    timeout: Duration,
+}
+
+impl Session {
+    #[allow(clippy::too_many_arguments)]
+    pub fn connect(
+        addresses: &[SocketAddr],
+        endpoint: &Authority,
+        server_name: &str,
+        credentials: &Credentials,
+        insecure: bool,
+        ca_cert: Option<&Path>,
+        interface: Option<&str>,
+        timeout: Duration,
+    ) -> Result<(Self, SocketAddr), ProbeFailure> {
+        let mut failures = Vec::new();
+        for &peer in addresses {
+            match Self::connect_one(
+                peer,
+                endpoint,
+                server_name,
+                credentials,
+                insecure,
+                ca_cert,
+                interface,
+                timeout,
+            ) {
+                Ok(session) => return Ok((session, peer)),
+                Err(failure) => failures.push(format!("{peer}: {}", failure.detail)),
+            }
+        }
+        Err(ProbeFailure::new(
+            "HTTP3_HANDSHAKE_FAILED",
+            format!("all resolved addresses failed: {}", failures.join("; ")),
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn connect_one(
+        peer: SocketAddr,
+        endpoint: &Authority,
+        server_name: &str,
+        credentials: &Credentials,
+        insecure: bool,
+        ca_cert: Option<&Path>,
+        interface: Option<&str>,
+        timeout: Duration,
+    ) -> Result<Self, ProbeFailure> {
+        let bind = if peer.is_ipv4() {
+            "0.0.0.0:0"
+        } else {
+            "[::]:0"
+        };
+        let socket = UdpSocket::bind(bind).map_err(|error| {
+            ProbeFailure::new("UDP_SOCKET_ERROR", format!("bind {bind}: {error}"))
+        })?;
+        if let Some(interface) = interface {
+            bind_socket_to_interface(&socket, peer, interface)?;
+        }
+        socket.connect(peer).map_err(|error| {
+            ProbeFailure::new(
+                "UDP_SOCKET_ERROR",
+                format!("connect UDP to {peer}: {error}"),
+            )
+        })?;
+        let local = socket.local_addr().map_err(|error| {
+            ProbeFailure::new(
+                "UDP_SOCKET_ERROR",
+                format!("read local UDP address: {error}"),
+            )
+        })?;
+
+        let mut config = build_config(credentials, insecure, ca_cert)?;
+        let mut scid = [0_u8; quiche::MAX_CONN_ID_LEN];
+        ring::rand::SystemRandom::new()
+            .fill(&mut scid)
+            .map_err(|_| ProbeFailure::new("RNG_ERROR", "system random generator failed"))?;
+        let connection_id = quiche::ConnectionId::from_ref(&scid);
+        let quic = quiche::connect(Some(server_name), &connection_id, local, peer, &mut config)
+            .map_err(|error| {
+                ProbeFailure::new("QUIC_ERROR", format!("create QUIC connection: {error}"))
+            })?;
+
+        let mut pending = PendingSession {
+            socket,
+            quic,
+            peer,
+            local,
+            timeout,
+        };
+        pending.handshake()?;
+
+        if let Some(identity) = credentials.client_identity() {
+            let peer_certificate = pending.quic.peer_cert().ok_or_else(|| {
+                ProbeFailure::new("TLS_PIN_MISMATCH", "server sent no leaf certificate")
+            })?;
+            identity.verify_peer_certificate(peer_certificate)?;
+        }
+
+        let mut h3_config = quiche::h3::Config::new().map_err(|error| {
+            ProbeFailure::new("HTTP3_ERROR", format!("create HTTP/3 config: {error}"))
+        })?;
+        h3_config.enable_extended_connect(true);
+        let h3 = quiche::h3::Connection::with_transport(&mut pending.quic, &h3_config)
+            .map_err(|error| ProbeFailure::new("HTTP3_ERROR", format!("start HTTP/3: {error}")))?;
+        let mut session = Self {
+            socket: pending.socket,
+            quic: pending.quic,
+            h3,
+            peer,
+            local,
+            authority: endpoint.original.clone(),
+            timeout,
+        };
+        session.wait_for_capabilities()?;
+        Ok(session)
+    }
+
+    pub fn probe_tcp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+    ) -> Result<String, ProbeFailure> {
+        let mut headers = vec![
+            quiche::h3::Header::new(b":method", b"CONNECT"),
+            quiche::h3::Header::new(b":authority", target.original.as_bytes()),
+        ];
+        append_auth(&mut headers, credentials);
+        let stream = self.send_request(&headers)?;
+        let status = self.poll_status(stream)?;
+        ensure_success_status(status, &target.original)?;
+        Ok(format!("CONNECT to {} returned HTTP 200", target.original))
+    }
+
+    pub fn probe_udp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+        dns: bool,
+    ) -> Result<String, ProbeFailure> {
+        let path = format!(
+            "/.well-known/masque/udp/{}/{}/",
+            encode_path_segment(&target.host),
+            target.port
+        );
+        let mut headers = vec![
+            quiche::h3::Header::new(b":method", b"CONNECT"),
+            quiche::h3::Header::new(b":protocol", b"connect-udp"),
+            quiche::h3::Header::new(b":scheme", b"https"),
+            quiche::h3::Header::new(b":authority", self.authority.as_bytes()),
+            quiche::h3::Header::new(b":path", path.as_bytes()),
+            quiche::h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        append_auth(&mut headers, credentials);
+        let stream = self.send_request(&headers)?;
+        let status = self.poll_status(stream)?;
+        ensure_success_status(status, &target.original)?;
+
+        let request = udp_probe_payload(dns);
+        let datagram = masque::datagram::encode_payload(stream, &request).map_err(|error| {
+            ProbeFailure::new(
+                "HTTP_DATAGRAM_ERROR",
+                format!("encode DNS datagram: {error}"),
+            )
+        })?;
+        self.quic.dgram_send(&datagram).map_err(|error| {
+            ProbeFailure::new(
+                "HTTP_DATAGRAM_ERROR",
+                format!("queue DNS datagram: {error}"),
+            )
+        })?;
+        self.flush()?;
+        let response = self.recv_datagram(stream)?;
+        validate_udp_probe_response(&response, &request, dns)?;
+        Ok(format!(
+            "CONNECT-UDP to {} returned a matching {} response",
+            target.original,
+            if dns { "DNS" } else { "echo" }
+        ))
+    }
+
+    pub fn probe_connect_ip(&mut self, credentials: &Credentials) -> Result<String, ProbeFailure> {
+        let mut headers = vec![
+            quiche::h3::Header::new(b":method", b"CONNECT"),
+            quiche::h3::Header::new(b":protocol", b"connect-ip"),
+            quiche::h3::Header::new(b":scheme", b"https"),
+            quiche::h3::Header::new(b":authority", self.authority.as_bytes()),
+            quiche::h3::Header::new(b":path", b"/.well-known/masque/ip/"),
+            quiche::h3::Header::new(b"capsule-protocol", b"?1"),
+        ];
+        append_auth(&mut headers, credentials);
+        let stream = self.send_request(&headers)?;
+        let status = self.poll_status(stream)?;
+        ensure_success_status(status, "CONNECT-IP")?;
+        let frames = self.recv_capsules(stream)?;
+        let assigned = frames.iter().find_map(|frame| match frame {
+            CapsuleFrame::AddressAssign(addresses) if !addresses.is_empty() => Some(addresses),
+            _ => None,
+        });
+        let Some(addresses) = assigned else {
+            return Err(ProbeFailure::new(
+                "CONNECT_IP_NO_ADDRESS",
+                "CONNECT-IP returned 200 but no ADDRESS_ASSIGN capsule",
+            ));
+        };
+        Ok(format!(
+            "CONNECT-IP assigned {} address(es); run server-side doctor to verify forwarding/NAT",
+            addresses.len()
+        ))
+    }
+
+    fn wait_for_capabilities(&mut self) -> Result<(), ProbeFailure> {
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            if self.h3.extended_connect_enabled_by_peer()
+                && self.h3.dgram_enabled_by_peer(&self.quic)
+            {
+                return Ok(());
+            }
+            self.poll_events(None)?;
+            if Instant::now() >= deadline {
+                return Err(ProbeFailure::new(
+                    "HTTP3_SETTINGS_MISSING",
+                    "server did not advertise Extended CONNECT and HTTP Datagrams",
+                ));
+            }
+            self.drive(deadline)?;
+        }
+    }
+
+    fn send_request(&mut self, headers: &[quiche::h3::Header]) -> Result<u64, ProbeFailure> {
+        let stream = self
+            .h3
+            .send_request(&mut self.quic, headers, false)
+            .map_err(|error| {
+                ProbeFailure::new("HTTP3_REQUEST_ERROR", format!("send CONNECT: {error}"))
+            })?;
+        self.flush()?;
+        Ok(stream)
+    }
+
+    fn poll_status(&mut self, expected_stream: u64) -> Result<u16, ProbeFailure> {
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            if let Some(status) = self.poll_events(Some(expected_stream))? {
+                return Ok(status);
+            }
+            if Instant::now() >= deadline {
+                return Err(ProbeFailure::new(
+                    "RESPONSE_TIMEOUT",
+                    "timed out waiting for CONNECT response headers",
+                ));
+            }
+            self.drive(deadline)?;
+        }
+    }
+
+    fn poll_events(&mut self, expected_stream: Option<u64>) -> Result<Option<u16>, ProbeFailure> {
+        loop {
+            match self.h3.poll(&mut self.quic) {
+                Ok((stream, quiche::h3::Event::Headers { list, .. }))
+                    if expected_stream.is_none_or(|expected| expected == stream) =>
+                {
+                    let status = list
+                        .iter()
+                        .find(|header| header.name() == b":status")
+                        .ok_or_else(|| {
+                            ProbeFailure::new(
+                                "HTTP3_PROTOCOL_ERROR",
+                                "response has no :status header",
+                            )
+                        })?;
+                    let value = std::str::from_utf8(status.value())
+                        .ok()
+                        .and_then(|value| value.parse::<u16>().ok())
+                        .ok_or_else(|| {
+                            ProbeFailure::new(
+                                "HTTP3_PROTOCOL_ERROR",
+                                "response has an invalid :status header",
+                            )
+                        })?;
+                    return Ok(Some(value));
+                }
+                Ok(_) => continue,
+                Err(quiche::h3::Error::Done) => return Ok(None),
+                Err(error) => {
+                    return Err(ProbeFailure::new(
+                        "HTTP3_PROTOCOL_ERROR",
+                        format!("poll HTTP/3: {error}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn recv_datagram(&mut self, expected_stream: u64) -> Result<Vec<u8>, ProbeFailure> {
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            let mut buffer = [0_u8; MAX_DATAGRAM_SIZE];
+            match self.quic.dgram_recv(&mut buffer) {
+                Ok(length) => {
+                    let datagram =
+                        masque::datagram::decode(&buffer[..length]).map_err(|error| {
+                            ProbeFailure::new(
+                                "HTTP_DATAGRAM_ERROR",
+                                format!("decode response datagram: {error}"),
+                            )
+                        })?;
+                    if datagram.stream_id == expected_stream && datagram.context_id == 0 {
+                        return Ok(datagram.payload);
+                    }
+                }
+                Err(quiche::Error::Done) => {}
+                Err(error) => {
+                    return Err(ProbeFailure::new(
+                        "HTTP_DATAGRAM_ERROR",
+                        format!("receive response datagram: {error}"),
+                    ));
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(ProbeFailure::new(
+                    "UDP_RESPONSE_TIMEOUT",
+                    "CONNECT-UDP opened, but no DNS response datagram arrived",
+                ));
+            }
+            self.drive(deadline)?;
+        }
+    }
+
+    fn recv_capsules(&mut self, stream: u64) -> Result<Vec<CapsuleFrame>, ProbeFailure> {
+        let deadline = Instant::now() + self.timeout;
+        let mut decoder = CapsuleDecoder::new();
+        let mut frames = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            self.poll_events(None)?;
+            loop {
+                match self.h3.recv_body(&mut self.quic, stream, &mut buffer) {
+                    Ok(length) => match decoder.decode(&buffer[..length]) {
+                        Ok(mut decoded) => frames.append(&mut decoded),
+                        Err(DecodeError::Incomplete) => {}
+                        Err(error) => {
+                            return Err(ProbeFailure::new(
+                                "CAPSULE_ERROR",
+                                format!("decode CONNECT-IP capsule: {error:?}"),
+                            ));
+                        }
+                    },
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(error) => {
+                        return Err(ProbeFailure::new(
+                            "CAPSULE_ERROR",
+                            format!("read CONNECT-IP capsule: {error}"),
+                        ));
+                    }
+                }
+            }
+            if frames
+                .iter()
+                .any(|frame| matches!(frame, CapsuleFrame::AddressAssign(_)))
+            {
+                return Ok(frames);
+            }
+            if Instant::now() >= deadline {
+                return Err(ProbeFailure::new(
+                    "CAPSULE_TIMEOUT",
+                    "timed out waiting for CONNECT-IP ADDRESS_ASSIGN",
+                ));
+            }
+            self.drive(deadline)?;
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), ProbeFailure> {
+        let mut output = [0_u8; MAX_DATAGRAM_SIZE];
+        loop {
+            match self.quic.send(&mut output) {
+                Ok((length, info)) => {
+                    let delay = info.at.saturating_duration_since(Instant::now());
+                    if !delay.is_zero() {
+                        std::thread::sleep(delay.min(Duration::from_millis(10)));
+                    }
+                    self.socket.send(&output[..length]).map_err(|error| {
+                        ProbeFailure::new("UDP_SEND_ERROR", format!("send QUIC packet: {error}"))
+                    })?;
+                }
+                Err(quiche::Error::Done) => return Ok(()),
+                Err(error) => {
+                    return Err(ProbeFailure::new(
+                        "QUIC_ERROR",
+                        format!("serialize QUIC packet: {error}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn drive(&mut self, deadline: Instant) -> Result<(), ProbeFailure> {
+        self.flush()?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let timeout = self
+            .quic
+            .timeout()
+            .unwrap_or(Duration::from_millis(50))
+            .min(remaining)
+            .max(Duration::from_millis(1));
+        self.socket
+            .set_read_timeout(Some(timeout))
+            .map_err(|error| {
+                ProbeFailure::new("UDP_SOCKET_ERROR", format!("set receive timeout: {error}"))
+            })?;
+        let mut input = [0_u8; MAX_DATAGRAM_SIZE];
+        match self.socket.recv(&mut input) {
+            Ok(length) => {
+                let info = quiche::RecvInfo {
+                    from: self.peer,
+                    to: self.local,
+                };
+                match self.quic.recv(&mut input[..length], info) {
+                    Ok(_) | Err(quiche::Error::Done) => {}
+                    Err(error) => {
+                        return Err(ProbeFailure::new(
+                            "QUIC_ERROR",
+                            format!("parse QUIC packet: {error}"),
+                        ));
+                    }
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                self.quic.on_timeout();
+            }
+            Err(error) => {
+                return Err(ProbeFailure::new(
+                    "UDP_RECEIVE_ERROR",
+                    format!("receive QUIC packet: {error}"),
+                ));
+            }
+        }
+        if self.quic.is_closed() {
+            return Err(ProbeFailure::new(
+                "QUIC_CONNECTION_CLOSED",
+                quic_close_detail(&self.quic),
+            ));
+        }
+        self.flush()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn bind_socket_to_interface(
+    socket: &UdpSocket,
+    peer: SocketAddr,
+    interface: &str,
+) -> Result<(), ProbeFailure> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd as _;
+
+    let interface = CString::new(interface).map_err(|_| {
+        ProbeFailure::new(
+            "INVALID_INTERFACE",
+            "interface name contains an embedded NUL",
+        )
+    })?;
+    // SAFETY: `interface` is live and NUL terminated for the duration of the call.
+    let index = unsafe { libc::if_nametoindex(interface.as_ptr()) };
+    if index == 0 {
+        return Err(ProbeFailure::new(
+            "INVALID_INTERFACE",
+            "network interface does not exist",
+        ));
+    }
+    let (level, option) = if peer.is_ipv4() {
+        (libc::IPPROTO_IP, libc::IP_BOUND_IF)
+    } else {
+        (libc::IPPROTO_IPV6, libc::IPV6_BOUND_IF)
+    };
+    // SAFETY: the socket fd and pointer to the `c_uint` option are valid.
+    let result = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            level,
+            option,
+            (&index as *const libc::c_uint).cast(),
+            std::mem::size_of_val(&index) as libc::socklen_t,
+        )
+    };
+    if result != 0 {
+        return Err(ProbeFailure::new(
+            "INTERFACE_BIND_FAILED",
+            format!(
+                "could not bind UDP socket to interface {:?}: {}",
+                interface,
+                std::io::Error::last_os_error()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn bind_socket_to_interface(
+    socket: &UdpSocket,
+    _peer: SocketAddr,
+    interface: &str,
+) -> Result<(), ProbeFailure> {
+    use std::os::fd::AsRawFd as _;
+
+    if interface.is_empty() || interface.as_bytes().contains(&0) {
+        return Err(ProbeFailure::new(
+            "INVALID_INTERFACE",
+            "interface name is empty or contains an embedded NUL",
+        ));
+    }
+    let mut name = interface.as_bytes().to_vec();
+    name.push(0);
+    // SAFETY: the socket fd and interface byte string are valid for this call.
+    let result = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_BINDTODEVICE,
+            name.as_ptr().cast(),
+            name.len() as libc::socklen_t,
+        )
+    };
+    if result != 0 {
+        return Err(ProbeFailure::new(
+            "INTERFACE_BIND_FAILED",
+            format!(
+                "could not bind UDP socket to interface {interface:?}: {}; this may require CAP_NET_RAW/root",
+                std::io::Error::last_os_error()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn bind_socket_to_interface(
+    _socket: &UdpSocket,
+    _peer: SocketAddr,
+    _interface: &str,
+) -> Result<(), ProbeFailure> {
+    Err(ProbeFailure::new(
+        "INTERFACE_UNSUPPORTED",
+        "--interface is supported only on Linux and macOS",
+    ))
+}
+
+struct PendingSession {
+    socket: UdpSocket,
+    quic: quiche::Connection,
+    peer: SocketAddr,
+    local: SocketAddr,
+    timeout: Duration,
+}
+
+impl PendingSession {
+    fn handshake(&mut self) -> Result<(), ProbeFailure> {
+        let deadline = Instant::now() + self.timeout;
+        let mut output = [0_u8; MAX_DATAGRAM_SIZE];
+        let mut input = [0_u8; MAX_DATAGRAM_SIZE];
+        loop {
+            loop {
+                match self.quic.send(&mut output) {
+                    Ok((length, _)) => {
+                        self.socket.send(&output[..length]).map_err(|error| {
+                            ProbeFailure::new(
+                                "UDP_SEND_ERROR",
+                                format!("send QUIC handshake: {error}"),
+                            )
+                        })?;
+                    }
+                    Err(quiche::Error::Done) => break,
+                    Err(error) => {
+                        return Err(ProbeFailure::new(
+                            "QUIC_ERROR",
+                            format!("serialize QUIC handshake: {error}"),
+                        ));
+                    }
+                }
+            }
+            if self.quic.is_established() {
+                return Ok(());
+            }
+            if self.quic.is_closed() {
+                return Err(ProbeFailure::new(
+                    "TLS_OR_QUIC_REJECTED",
+                    quic_close_detail(&self.quic),
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(ProbeFailure::new(
+                    "UDP_BLOCKED_OR_TIMEOUT",
+                    "QUIC handshake timed out; UDP may be blocked or the server may not be listening",
+                ));
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let timeout = self
+                .quic
+                .timeout()
+                .unwrap_or(Duration::from_millis(50))
+                .min(remaining)
+                .max(Duration::from_millis(1));
+            self.socket
+                .set_read_timeout(Some(timeout))
+                .map_err(|error| {
+                    ProbeFailure::new("UDP_SOCKET_ERROR", format!("set receive timeout: {error}"))
+                })?;
+            match self.socket.recv(&mut input) {
+                Ok(length) => {
+                    let info = quiche::RecvInfo {
+                        from: self.peer,
+                        to: self.local,
+                    };
+                    match self.quic.recv(&mut input[..length], info) {
+                        Ok(_) | Err(quiche::Error::Done) => {}
+                        Err(error) => {
+                            return Err(ProbeFailure::new(
+                                "QUIC_ERROR",
+                                format!("parse QUIC handshake: {error}"),
+                            ));
+                        }
+                    }
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    self.quic.on_timeout();
+                }
+                Err(error) => {
+                    return Err(ProbeFailure::new(
+                        "UDP_RECEIVE_ERROR",
+                        format!("receive QUIC handshake: {error}"),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn build_config(
+    credentials: &Credentials,
+    insecure: bool,
+    ca_cert: Option<&Path>,
+) -> Result<quiche::Config, ProbeFailure> {
+    let mut config = if let Some(identity) = credentials.client_identity() {
+        let mut builder = SslContextBuilder::new(SslMethod::tls()).map_err(|error| {
+            ProbeFailure::new("TLS_CONFIG_ERROR", format!("create TLS context: {error}"))
+        })?;
+        identity.configure_context(&mut builder)?;
+        quiche::Config::with_boring_ssl_ctx_builder(quiche::PROTOCOL_VERSION, builder).map_err(
+            |error| ProbeFailure::new("TLS_CONFIG_ERROR", format!("create QUIC config: {error}")),
+        )?
+    } else {
+        let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|error| {
+            ProbeFailure::new("TLS_CONFIG_ERROR", format!("create QUIC config: {error}"))
+        })?;
+        config.verify_peer(!insecure);
+        if let Some(path) = ca_cert {
+            let path = path.to_str().ok_or_else(|| {
+                ProbeFailure::new("TLS_CONFIG_ERROR", "--ca-cert path is not valid UTF-8")
+            })?;
+            config
+                .load_verify_locations_from_file(path)
+                .map_err(|error| {
+                    ProbeFailure::new(
+                        "TLS_CONFIG_ERROR",
+                        format!("load CA certificate {path}: {error}"),
+                    )
+                })?;
+        }
+        config
+    };
+
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|error| ProbeFailure::new("HTTP3_ERROR", error.to_string()))?;
+    config.set_max_idle_timeout(15_000);
+    config.set_max_recv_udp_payload_size(1350);
+    config.set_max_send_udp_payload_size(1350);
+    config.set_initial_max_data(4 * 1024 * 1024);
+    config.set_initial_max_stream_data_bidi_local(1024 * 1024);
+    config.set_initial_max_stream_data_bidi_remote(1024 * 1024);
+    config.set_initial_max_stream_data_uni(256 * 1024);
+    config.set_initial_max_streams_bidi(16);
+    config.set_initial_max_streams_uni(16);
+    config.enable_dgram(true, 128, 128);
+    Ok(config)
+}
+
+fn append_auth(headers: &mut Vec<quiche::h3::Header>, credentials: &Credentials) {
+    if let Some(value) = credentials.authorization() {
+        headers.push(quiche::h3::Header::new(
+            b"proxy-authorization",
+            value.as_bytes(),
+        ));
+    }
+}
+
+fn quic_close_detail(connection: &quiche::Connection) -> String {
+    if let Some(error) = connection.peer_error() {
+        return format!(
+            "peer closed QUIC (application={}, code={}, reason={})",
+            error.is_app,
+            error.error_code,
+            String::from_utf8_lossy(&error.reason)
+        );
+    }
+    if let Some(error) = connection.local_error() {
+        return format!(
+            "local QUIC close (application={}, code={}, reason={})",
+            error.is_app,
+            error.error_code,
+            String::from_utf8_lossy(&error.reason)
+        );
+    }
+    "QUIC connection closed without an error reason".into()
+}

--- a/tools/masque-probe/src/identity.rs
+++ b/tools/masque-probe/src/identity.rs
@@ -1,0 +1,162 @@
+use std::path::Path;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::asn1::Asn1Time;
+use boring::bn::BigNum;
+use boring::ec::EcKey;
+use boring::hash::MessageDigest;
+use boring::pkey::{PKey, Private, Public};
+use boring::x509::{X509, X509Builder};
+use serde::Deserialize;
+use zeroize::{Zeroize as _, Zeroizing};
+
+use crate::report::ProbeFailure;
+
+pub struct ClientIdentity {
+    key: PKey<Private>,
+    certificate: X509,
+    pinned_server_key: PKey<Public>,
+}
+
+#[derive(Deserialize)]
+struct EnrollmentJson {
+    private_key: String,
+    endpoint_pub_key: String,
+}
+
+impl ClientIdentity {
+    pub fn from_enrollment(path: &Path) -> Result<Self, ProbeFailure> {
+        let text = Zeroizing::new(std::fs::read_to_string(path).map_err(|error| {
+            ProbeFailure::new(
+                "CLIENT_CONFIG_ERROR",
+                format!("could not read {}: {error}", path.display()),
+            )
+        })?);
+        let mut raw: EnrollmentJson = serde_json::from_str(&text).map_err(|error| {
+            ProbeFailure::new(
+                "CLIENT_CONFIG_ERROR",
+                format!("{} is not an enrollment JSON file: {error}", path.display()),
+            )
+        })?;
+
+        let result = (|| {
+            let mut private_der =
+                Zeroizing::new(STANDARD.decode(&raw.private_key).map_err(|error| {
+                    ProbeFailure::new(
+                        "CLIENT_CONFIG_ERROR",
+                        format!("private_key is not base64 DER: {error}"),
+                    )
+                })?);
+            let ec_key = EcKey::private_key_from_der(&private_der).map_err(|error| {
+                ProbeFailure::new(
+                    "CLIENT_CONFIG_ERROR",
+                    format!("private_key is not a SEC1 EC key: {error}"),
+                )
+            })?;
+            private_der.zeroize();
+            let key = PKey::from_ec_key(ec_key).map_err(|error| {
+                ProbeFailure::new(
+                    "CLIENT_CONFIG_ERROR",
+                    format!("could not load client key: {error}"),
+                )
+            })?;
+            let pinned_server_key = PKey::public_key_from_pem(raw.endpoint_pub_key.as_bytes())
+                .map_err(|error| {
+                    ProbeFailure::new(
+                        "CLIENT_CONFIG_ERROR",
+                        format!("endpoint_pub_key is not a PEM public key: {error}"),
+                    )
+                })?;
+            let certificate = self_signed_certificate(&key)?;
+            Ok(Self {
+                key,
+                certificate,
+                pinned_server_key,
+            })
+        })();
+
+        raw.private_key.zeroize();
+        raw.endpoint_pub_key.zeroize();
+        result
+    }
+
+    pub fn configure_context(
+        &self,
+        builder: &mut boring::ssl::SslContextBuilder,
+    ) -> Result<(), ProbeFailure> {
+        builder.set_verify(boring::ssl::SslVerifyMode::NONE);
+        builder
+            .set_certificate(&self.certificate)
+            .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+        builder
+            .set_private_key(&self.key)
+            .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+        builder
+            .check_private_key()
+            .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+        Ok(())
+    }
+
+    pub fn verify_peer_certificate(&self, der: &[u8]) -> Result<(), ProbeFailure> {
+        let certificate = X509::from_der(der).map_err(|error| {
+            ProbeFailure::new(
+                "TLS_PIN_MISMATCH",
+                format!("server certificate is not valid DER: {error}"),
+            )
+        })?;
+        let key = certificate.public_key().map_err(|error| {
+            ProbeFailure::new(
+                "TLS_PIN_MISMATCH",
+                format!("server certificate has no public key: {error}"),
+            )
+        })?;
+        if !key.public_eq(&self.pinned_server_key) {
+            return Err(ProbeFailure::new(
+                "TLS_PIN_MISMATCH",
+                "server certificate public key does not match endpoint_pub_key",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn self_signed_certificate(key: &PKey<Private>) -> Result<X509, ProbeFailure> {
+    let mut builder = X509Builder::new()
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    builder
+        .set_version(2)
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    let serial = BigNum::from_u32(0)
+        .and_then(|value| value.to_asn1_integer())
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    builder
+        .set_serial_number(&serial)
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    let not_before = Asn1Time::days_from_now(0)
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    let not_after = Asn1Time::days_from_now(1)
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    builder
+        .set_not_before(&not_before)
+        .and_then(|_| builder.set_not_after(&not_after))
+        .and_then(|_| builder.set_pubkey(key))
+        .and_then(|_| builder.sign(key, MessageDigest::sha256()))
+        .map_err(|error| ProbeFailure::new("CLIENT_CERT_ERROR", error.to_string()))?;
+    Ok(builder.build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boring::ec::{EcGroup, EcKey};
+    use boring::nid::Nid;
+
+    #[test]
+    fn generated_certificate_contains_the_enrolled_key() {
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let key = PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
+        let certificate = self_signed_certificate(&key).unwrap();
+        assert!(certificate.public_key().unwrap().public_eq(&key));
+    }
+}

--- a/tools/masque-probe/src/main.rs
+++ b/tools/masque-probe/src/main.rs
@@ -1,0 +1,523 @@
+mod credentials;
+mod endpoint;
+mod http2;
+mod http3;
+mod identity;
+mod protocol;
+mod report;
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use clap::{Parser, ValueEnum};
+
+use credentials::{BasicCredentials, Credentials};
+use endpoint::Authority;
+use identity::ClientIdentity;
+use report::{CheckResult, ProbeFailure, ProbeReport};
+
+#[derive(Parser)]
+#[command(
+    name = "masque-probe",
+    version,
+    about = "Diagnose a MASQUE endpoint from the client network"
+)]
+struct Cli {
+    /// Public endpoint in host:port form, for example proxy.example.com:8449.
+    endpoint: String,
+
+    /// HTTP transport to test. Auto tries HTTP/3 first, then HTTP/2 on the same port.
+    #[arg(long, value_enum, default_value_t = Transport::Auto)]
+    transport: Transport,
+
+    /// TLS DNS name. Defaults to the endpoint hostname for Basic auth and to
+    /// the usque-compatible SNI for a certificate enrollment.
+    #[arg(long)]
+    server_name: Option<String>,
+
+    /// Connect to this IP while retaining the endpoint hostname for TLS and HTTP.
+    /// Useful when a local proxy returns synthetic DNS addresses.
+    #[arg(long)]
+    resolve: Option<std::net::IpAddr>,
+
+    /// Bind the HTTP/3 UDP socket to this network interface (for example en0).
+    #[arg(long)]
+    interface: Option<String>,
+
+    /// Basic username. The password is deliberately never accepted as an argument.
+    #[arg(long, requires = "password_stdin", conflicts_with = "client_config")]
+    username: Option<String>,
+
+    /// Read the Basic password from stdin.
+    #[arg(long, requires = "username", conflicts_with = "client_config")]
+    password_stdin: bool,
+
+    /// Enrollment JSON containing private_key and endpoint_pub_key.
+    #[arg(long, conflicts_with_all = ["username", "password_stdin", "insecure", "ca_cert"])]
+    client_config: Option<PathBuf>,
+
+    /// TCP target used to verify standard CONNECT.
+    #[arg(long, default_value = "example.com:443", conflicts_with = "skip_tcp")]
+    tcp_target: String,
+
+    /// Skip the standard CONNECT target check.
+    #[arg(long)]
+    skip_tcp: bool,
+
+    /// DNS server used to verify CONNECT-UDP with a real query.
+    #[arg(long, default_value = "1.1.1.1:53", conflicts_with = "skip_udp")]
+    udp_target: String,
+
+    /// UDP validation payload: a DNS query, or a byte-for-byte echo payload.
+    #[arg(long, value_enum, default_value_t = UdpMode::Dns)]
+    udp_mode: UdpMode,
+
+    /// Skip the CONNECT-UDP target check.
+    #[arg(long)]
+    skip_udp: bool,
+
+    /// Also check CONNECT-IP negotiation and address assignment.
+    #[arg(long)]
+    connect_ip: bool,
+
+    /// Per-stage timeout in seconds.
+    #[arg(
+        long,
+        default_value_t = 8,
+        value_parser = clap::value_parser!(u64).range(1..=60)
+    )]
+    timeout: u64,
+
+    /// Trust this PEM CA file in addition to the platform roots.
+    #[arg(long, conflicts_with = "insecure")]
+    ca_cert: Option<PathBuf>,
+
+    /// Disable public CA and hostname verification. Never disables enrollment-key pinning.
+    #[arg(long)]
+    insecure: bool,
+
+    /// Emit one stable JSON report instead of human-readable output.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Transport {
+    Auto,
+    Http3,
+    Http2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum UdpMode {
+    Dns,
+    Echo,
+}
+
+impl Transport {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Http3 => "http3",
+            Self::Http2 => "http2",
+        }
+    }
+}
+
+enum ActiveSession {
+    Http3(Box<http3::Session>),
+    Http2(http2::Session),
+}
+
+impl ActiveSession {
+    fn probe_tcp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+    ) -> Result<String, ProbeFailure> {
+        match self {
+            Self::Http3(session) => session.probe_tcp(target, credentials),
+            Self::Http2(session) => session.probe_tcp(target, credentials),
+        }
+    }
+
+    fn probe_udp(
+        &mut self,
+        target: &Authority,
+        credentials: &Credentials,
+        udp_mode: UdpMode,
+    ) -> Result<String, ProbeFailure> {
+        match self {
+            Self::Http3(session) => {
+                session.probe_udp(target, credentials, udp_mode == UdpMode::Dns)
+            }
+            Self::Http2(session) => {
+                session.probe_udp(target, credentials, udp_mode == UdpMode::Dns)
+            }
+        }
+    }
+
+    fn probe_connect_ip(&mut self, credentials: &Credentials) -> Result<String, ProbeFailure> {
+        match self {
+            Self::Http3(session) => session.probe_connect_ip(credentials),
+            Self::Http2(session) => session.probe_connect_ip(credentials),
+        }
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut report = run_probe(&cli);
+    report.finish();
+
+    if cli.json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("failed to serialize probe report: {error}");
+                std::process::exit(2);
+            }
+        }
+    } else {
+        report.print_human();
+    }
+    if !report.success {
+        std::process::exit(1);
+    }
+}
+
+fn run_probe(cli: &Cli) -> ProbeReport {
+    let mut report = ProbeReport::new(cli.endpoint.clone(), cli.transport.as_str());
+    let endpoint = match Authority::parse(&cli.endpoint, "MASQUE endpoint") {
+        Ok(endpoint) => endpoint,
+        Err(failure) => {
+            report
+                .checks
+                .push(CheckResult::fail("endpoint", failure, Instant::now()));
+            return report;
+        }
+    };
+
+    let credentials_started = Instant::now();
+    let credentials = match load_credentials(cli) {
+        Ok(credentials) => credentials,
+        Err(failure) => {
+            report.checks.push(CheckResult::fail(
+                "credentials",
+                failure,
+                credentials_started,
+            ));
+            return report;
+        }
+    };
+    report.checks.push(CheckResult::pass(
+        "credentials",
+        "CREDENTIALS_READY",
+        format!("authentication mode: {}", credentials.label()),
+        credentials_started,
+    ));
+
+    let server_name = cli.server_name.clone().unwrap_or_else(|| {
+        if credentials.client_identity().is_some() {
+            "consumer-masque.cloudflareclient.com".into()
+        } else {
+            endpoint.host.clone()
+        }
+    });
+    if credentials.client_identity().is_none()
+        && let Err(failure) = endpoint::validate_server_name(&server_name)
+    {
+        report.checks.push(CheckResult::fail(
+            "tls_server_name",
+            failure,
+            Instant::now(),
+        ));
+        return report;
+    }
+
+    if cli.insecure {
+        report.checks.push(CheckResult::warning(
+            "tls_verification",
+            "TLS_VERIFICATION_DISABLED",
+            "certificate-chain and hostname verification are disabled for this probe",
+            Instant::now(),
+        ));
+    }
+
+    let dns_started = Instant::now();
+    let addresses = match cli.resolve {
+        Some(address) => {
+            let address = std::net::SocketAddr::new(address, endpoint.port);
+            report.checks.push(CheckResult::pass(
+                "dns",
+                "DNS_BYPASSED",
+                format!(
+                    "using {address} from --resolve while retaining {}",
+                    endpoint.host
+                ),
+                dns_started,
+            ));
+            vec![address]
+        }
+        None => match endpoint.resolve() {
+            Ok(addresses) => {
+                let detail = format!(
+                    "{} resolved to {}",
+                    endpoint.host,
+                    addresses
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                if addresses
+                    .iter()
+                    .any(|address| is_benchmarking_ip(address.ip()))
+                {
+                    report.checks.push(CheckResult::warning(
+                    "dns",
+                    "DNS_FAKE_IP_DETECTED",
+                    format!(
+                        "{detail}; 198.18.0.0/15 is commonly used by fake-IP DNS, use --resolve with the real server IP if direct probing fails"
+                    ),
+                    dns_started,
+                ));
+                } else {
+                    report.checks.push(CheckResult::pass(
+                        "dns",
+                        "DNS_RESOLVED",
+                        detail,
+                        dns_started,
+                    ));
+                }
+                addresses
+            }
+            Err(failure) => {
+                report
+                    .checks
+                    .push(CheckResult::fail("dns", failure, dns_started));
+                return report;
+            }
+        },
+    };
+
+    let timeout = Duration::from_secs(cli.timeout);
+    let mut session = match connect_transport(
+        cli,
+        &endpoint,
+        &addresses,
+        &server_name,
+        &credentials,
+        timeout,
+        &mut report,
+    ) {
+        Some(session) => session,
+        None => return report,
+    };
+
+    if cli.skip_tcp {
+        report.checks.push(CheckResult::skipped(
+            "connect_tcp",
+            "disabled by --skip-tcp",
+        ));
+    } else {
+        run_target_check(
+            "connect_tcp",
+            &cli.tcp_target,
+            &credentials,
+            &mut report,
+            |target, credentials| session.probe_tcp(target, credentials),
+        );
+    }
+
+    if cli.skip_udp {
+        report.checks.push(CheckResult::skipped(
+            "connect_udp",
+            "disabled by --skip-udp",
+        ));
+    } else {
+        run_target_check(
+            "connect_udp",
+            &cli.udp_target,
+            &credentials,
+            &mut report,
+            |target, credentials| session.probe_udp(target, credentials, cli.udp_mode),
+        );
+    }
+
+    if cli.connect_ip {
+        let started = Instant::now();
+        match session.probe_connect_ip(&credentials) {
+            Ok(detail) => report.checks.push(CheckResult::pass(
+                "connect_ip",
+                "CONNECT_IP_READY",
+                detail,
+                started,
+            )),
+            Err(failure) => report
+                .checks
+                .push(CheckResult::fail("connect_ip", failure, started)),
+        }
+    } else {
+        report.checks.push(CheckResult::skipped(
+            "connect_ip",
+            "not requested; pass --connect-ip to check negotiation",
+        ));
+    }
+
+    report
+}
+
+fn load_credentials(cli: &Cli) -> Result<Credentials, ProbeFailure> {
+    if let Some(path) = &cli.client_config {
+        return ClientIdentity::from_enrollment(path).map(Credentials::ClientCertificate);
+    }
+    if let Some(username) = &cli.username {
+        return BasicCredentials::from_stdin(username.clone()).map(Credentials::Basic);
+    }
+    Ok(Credentials::None)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn connect_transport(
+    cli: &Cli,
+    endpoint: &Authority,
+    addresses: &[std::net::SocketAddr],
+    server_name: &str,
+    credentials: &Credentials,
+    timeout: Duration,
+    report: &mut ProbeReport,
+) -> Option<ActiveSession> {
+    if matches!(cli.transport, Transport::Auto | Transport::Http3) {
+        let started = Instant::now();
+        match http3::Session::connect(
+            addresses,
+            endpoint,
+            server_name,
+            credentials,
+            cli.insecure,
+            cli.ca_cert.as_deref(),
+            cli.interface.as_deref(),
+            timeout,
+        ) {
+            Ok((session, peer)) => {
+                report.selected_transport = Some("http3".into());
+                report.checks.push(CheckResult::pass(
+                    "http3_handshake",
+                    "HTTP3_READY",
+                    format!(
+                        "QUIC, TLS, h3 ALPN, Extended CONNECT and HTTP Datagrams ready via {peer}"
+                    ),
+                    started,
+                ));
+                return Some(ActiveSession::Http3(Box::new(session)));
+            }
+            Err(failure) if cli.transport == Transport::Auto => {
+                report.checks.push(CheckResult::warning(
+                    "http3_handshake",
+                    failure.code,
+                    format!("{}; trying HTTP/2 fallback", failure.detail),
+                    started,
+                ));
+            }
+            Err(failure) => {
+                report
+                    .checks
+                    .push(CheckResult::fail("http3_handshake", failure, started));
+                return None;
+            }
+        }
+    }
+
+    let started = Instant::now();
+    match http2::Session::connect(
+        addresses,
+        endpoint,
+        server_name,
+        credentials,
+        cli.insecure,
+        cli.ca_cert.as_deref(),
+        timeout,
+    ) {
+        Ok((session, peer)) => {
+            report.selected_transport = Some("http2".into());
+            report.checks.push(CheckResult::pass(
+                "http2_handshake",
+                "HTTP2_READY",
+                format!("TCP, TLS, h2 ALPN and Extended CONNECT ready via {peer}"),
+                started,
+            ));
+            Some(ActiveSession::Http2(session))
+        }
+        Err(failure) => {
+            report
+                .checks
+                .push(CheckResult::fail("http2_handshake", failure, started));
+            None
+        }
+    }
+}
+
+fn is_benchmarking_ip(address: std::net::IpAddr) -> bool {
+    match address {
+        std::net::IpAddr::V4(address) => {
+            let octets = address.octets();
+            octets[0] == 198 && matches!(octets[1], 18 | 19)
+        }
+        std::net::IpAddr::V6(_) => false,
+    }
+}
+
+fn run_target_check(
+    name: &str,
+    value: &str,
+    credentials: &Credentials,
+    report: &mut ProbeReport,
+    mut run: impl FnMut(&Authority, &Credentials) -> Result<String, ProbeFailure>,
+) {
+    let started = Instant::now();
+    let target = match Authority::parse(value, "probe target") {
+        Ok(target) => target,
+        Err(failure) => {
+            report
+                .checks
+                .push(CheckResult::fail(name, failure, started));
+            return;
+        }
+    };
+    match run(&target, credentials) {
+        Ok(detail) => report
+            .checks
+            .push(CheckResult::pass(name, "ROUND_TRIP_OK", detail, started)),
+        Err(failure) => report
+            .checks
+            .push(CheckResult::fail(name, failure, started)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory as _;
+
+    use super::*;
+
+    #[test]
+    fn cli_definition_is_consistent() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn default_targets_are_public_and_well_formed() {
+        let cli = Cli::parse_from(["masque-probe", "proxy.example:443"]);
+        assert!(Authority::parse(&cli.tcp_target, "target").is_ok());
+        assert!(Authority::parse(&cli.udp_target, "target").is_ok());
+        assert_eq!(cli.transport, Transport::Auto);
+    }
+
+    #[test]
+    fn recognizes_the_rfc_2544_range_used_by_fake_ip_dns() {
+        assert!(is_benchmarking_ip("198.18.0.1".parse().unwrap()));
+        assert!(is_benchmarking_ip("198.19.255.254".parse().unwrap()));
+        assert!(!is_benchmarking_ip("198.20.0.1".parse().unwrap()));
+    }
+}

--- a/tools/masque-probe/src/protocol.rs
+++ b/tools/masque-probe/src/protocol.rs
@@ -1,0 +1,109 @@
+use crate::report::ProbeFailure;
+
+pub fn ensure_success_status(status: u16, target: &str) -> Result<(), ProbeFailure> {
+    match status {
+        200 => Ok(()),
+        407 => Err(ProbeFailure::new(
+            "AUTH_REJECTED",
+            "server returned HTTP 407; credentials are missing or invalid",
+        )),
+        403 => Err(ProbeFailure::new(
+            "TARGET_POLICY_DENIED",
+            format!("server policy denied target {target} with HTTP 403"),
+        )),
+        404 => Err(ProbeFailure::new(
+            "PROTOCOL_REJECTED",
+            "server returned HTTP 404 for the requested CONNECT protocol",
+        )),
+        502 => Err(ProbeFailure::new(
+            "TARGET_CONNECT_FAILED",
+            format!("proxy was reached, but it could not connect to target {target} (HTTP 502)"),
+        )),
+        status => Err(ProbeFailure::new(
+            "CONNECT_REJECTED",
+            format!("server rejected CONNECT with HTTP {status}"),
+        )),
+    }
+}
+
+pub fn dns_query() -> Vec<u8> {
+    let mut query = vec![
+        0x4d, 0x51, // ID
+        0x01, 0x00, // recursion desired
+        0x00, 0x01, // one question
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    for label in ["example", "com"] {
+        query.push(label.len() as u8);
+        query.extend_from_slice(label.as_bytes());
+    }
+    query.extend_from_slice(&[0, 0, 1, 0, 1]); // root, A, IN
+    query
+}
+
+pub fn validate_dns_response(response: &[u8]) -> Result<(), ProbeFailure> {
+    if response.len() < 12 || response[..2] != [0x4d, 0x51] || response[2] & 0x80 == 0 {
+        return Err(ProbeFailure::new(
+            "UDP_RESPONSE_INVALID",
+            "received UDP payload is not the matching DNS response",
+        ));
+    }
+    Ok(())
+}
+
+pub fn udp_probe_payload(dns: bool) -> Vec<u8> {
+    if dns {
+        dns_query()
+    } else {
+        b"masque-probe-connect-udp-echo".to_vec()
+    }
+}
+
+pub fn validate_udp_probe_response(
+    response: &[u8],
+    request: &[u8],
+    dns: bool,
+) -> Result<(), ProbeFailure> {
+    if dns {
+        validate_dns_response(response)
+    } else if response == request {
+        Ok(())
+    } else {
+        Err(ProbeFailure::new(
+            "UDP_RESPONSE_INVALID",
+            "echo target returned a payload that does not match the request",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dns_query_and_response_validation_use_a_stable_id() {
+        let query = dns_query();
+        assert_eq!(&query[..2], &[0x4d, 0x51]);
+        let mut response = query;
+        response[2] |= 0x80;
+        assert!(validate_dns_response(&response).is_ok());
+        response[0] = 0;
+        assert!(validate_dns_response(&response).is_err());
+    }
+
+    #[test]
+    fn status_codes_have_actionable_categories() {
+        assert_eq!(
+            ensure_success_status(407, "example.com:443")
+                .unwrap_err()
+                .code,
+            "AUTH_REJECTED"
+        );
+        assert_eq!(
+            ensure_success_status(502, "example.com:443")
+                .unwrap_err()
+                .code,
+            "TARGET_CONNECT_FAILED"
+        );
+    }
+}

--- a/tools/masque-probe/src/report.rs
+++ b/tools/masque-probe/src/report.rs
@@ -1,0 +1,177 @@
+use std::time::Instant;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckStatus {
+    Pass,
+    Warning,
+    Fail,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    pub code: String,
+    pub detail: String,
+    pub duration_ms: u128,
+}
+
+impl CheckResult {
+    pub fn pass(name: &str, code: &str, detail: impl Into<String>, started: Instant) -> Self {
+        Self::new(name, CheckStatus::Pass, code, detail, started)
+    }
+
+    pub fn warning(name: &str, code: &str, detail: impl Into<String>, started: Instant) -> Self {
+        Self::new(name, CheckStatus::Warning, code, detail, started)
+    }
+
+    pub fn fail(name: &str, failure: ProbeFailure, started: Instant) -> Self {
+        Self::new(
+            name,
+            CheckStatus::Fail,
+            failure.code,
+            failure.detail,
+            started,
+        )
+    }
+
+    pub fn skipped(name: &str, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.to_owned(),
+            status: CheckStatus::Skipped,
+            code: "SKIPPED".into(),
+            detail: detail.into(),
+            duration_ms: 0,
+        }
+    }
+
+    fn new(
+        name: &str,
+        status: CheckStatus,
+        code: &str,
+        detail: impl Into<String>,
+        started: Instant,
+    ) -> Self {
+        Self {
+            name: name.to_owned(),
+            status,
+            code: code.to_owned(),
+            detail: detail.into(),
+            duration_ms: started.elapsed().as_millis(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ProbeFailure {
+    pub code: &'static str,
+    pub detail: String,
+}
+
+impl ProbeFailure {
+    pub fn new(code: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            code,
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProbeReport {
+    pub schema_version: u8,
+    pub probe_version: &'static str,
+    pub endpoint: String,
+    pub requested_transport: String,
+    pub selected_transport: Option<String>,
+    pub success: bool,
+    pub checks: Vec<CheckResult>,
+}
+
+impl ProbeReport {
+    pub fn new(endpoint: String, transport: &str) -> Self {
+        Self {
+            schema_version: 1,
+            probe_version: env!("CARGO_PKG_VERSION"),
+            endpoint,
+            requested_transport: transport.to_owned(),
+            selected_transport: None,
+            success: false,
+            checks: Vec::new(),
+        }
+    }
+
+    pub fn finish(&mut self) {
+        self.success = self.selected_transport.is_some()
+            && self
+                .checks
+                .iter()
+                .all(|check| check.status != CheckStatus::Fail);
+    }
+
+    pub fn print_human(&self) {
+        println!("MASQUE connectivity probe");
+        println!("  endpoint:  {}", self.endpoint);
+        println!(
+            "  transport: {}",
+            self.selected_transport
+                .as_deref()
+                .unwrap_or(&self.requested_transport)
+        );
+        println!();
+        for check in &self.checks {
+            let status = match check.status {
+                CheckStatus::Pass => "PASS",
+                CheckStatus::Warning => "WARN",
+                CheckStatus::Fail => "FAIL",
+                CheckStatus::Skipped => "SKIP",
+            };
+            println!(
+                "[{status}] {:<20} {:<28} {} ({} ms)",
+                check.name, check.code, check.detail, check.duration_ms
+            );
+        }
+        println!();
+        println!("result: {}", if self.success { "PASS" } else { "FAIL" });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warnings_and_skips_do_not_fail_a_selected_transport() {
+        let now = Instant::now();
+        let mut report = ProbeReport::new("proxy.example:443".into(), "auto");
+        report.selected_transport = Some("http2".into());
+        report.checks.push(CheckResult::warning(
+            "http3",
+            "UDP_BLOCKED",
+            "falling back",
+            now,
+        ));
+        report
+            .checks
+            .push(CheckResult::skipped("connect_ip", "not requested"));
+        report.finish();
+        assert!(report.success);
+    }
+
+    #[test]
+    fn any_failed_check_fails_the_report() {
+        let mut report = ProbeReport::new("proxy.example:443".into(), "http3");
+        report.selected_transport = Some("http3".into());
+        report.checks.push(CheckResult::fail(
+            "auth",
+            ProbeFailure::new("AUTH_REJECTED", "HTTP 407"),
+            Instant::now(),
+        ));
+        report.finish();
+        assert!(!report.success);
+    }
+}

--- a/tools/masque-probe/tests/basic_probe.rs
+++ b/tools/masque-probe/tests/basic_probe.rs
@@ -1,0 +1,313 @@
+use std::io::Write as _;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use boring::asn1::Asn1Time;
+use boring::bn::BigNum;
+use boring::ec::{EcGroup, EcKey};
+use boring::hash::MessageDigest;
+use boring::nid::Nid;
+use boring::pkey::PKey;
+use boring::x509::{X509Builder, X509NameBuilder};
+use masque::config::{AuthMode, BasicUser, ClientEntry, ListenerTransport, ServerConfig};
+use masque::server::Server;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, UdpSocket};
+
+struct TempTls {
+    directory: PathBuf,
+    cert: PathBuf,
+    key: PathBuf,
+}
+
+impl TempTls {
+    fn new() -> Self {
+        let directory = std::env::temp_dir().join(format!(
+            "masque-probe-it-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let cert = directory.join("server.crt");
+        let key = directory.join("server.key");
+
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+        let key_pair = PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
+        let mut name = X509NameBuilder::new().unwrap();
+        name.append_entry_by_text("CN", "localhost").unwrap();
+        let name = name.build();
+        let mut certificate = X509Builder::new().unwrap();
+        certificate.set_version(2).unwrap();
+        certificate
+            .set_serial_number(&BigNum::from_u32(1).unwrap().to_asn1_integer().unwrap())
+            .unwrap();
+        certificate.set_subject_name(&name).unwrap();
+        certificate.set_issuer_name(&name).unwrap();
+        certificate
+            .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        certificate
+            .set_not_after(&Asn1Time::days_from_now(1).unwrap())
+            .unwrap();
+        certificate.set_pubkey(&key_pair).unwrap();
+        certificate
+            .sign(&key_pair, MessageDigest::sha256())
+            .unwrap();
+        std::fs::write(&cert, certificate.build().to_pem().unwrap()).unwrap();
+        std::fs::write(
+            &key,
+            key_pair.ec_key().unwrap().private_key_to_pem().unwrap(),
+        )
+        .unwrap();
+
+        Self {
+            directory,
+            cert,
+            key,
+        }
+    }
+}
+
+impl Drop for TempTls {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.cert).ok();
+        std::fs::remove_file(&self.key).ok();
+        std::fs::remove_dir(&self.directory).ok();
+    }
+}
+
+async fn spawn_echo() -> (
+    SocketAddr,
+    tokio::task::JoinHandle<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let tcp = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let address = tcp.local_addr().unwrap();
+    let udp = UdpSocket::bind(address).await.unwrap();
+
+    let tcp_task = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = tcp.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                let mut buffer = [0_u8; 4096];
+                loop {
+                    let Ok(length) = stream.read(&mut buffer).await else {
+                        return;
+                    };
+                    if length == 0 || stream.write_all(&buffer[..length]).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+    let udp_task = tokio::spawn(async move {
+        let mut buffer = [0_u8; 65_535];
+        loop {
+            let Ok((length, peer)) = udp.recv_from(&mut buffer).await else {
+                return;
+            };
+            if udp.send_to(&buffer[..length], peer).await.is_err() {
+                return;
+            }
+        }
+    });
+    (address, tcp_task, udp_task)
+}
+
+async fn spawn_server(
+    tls: &TempTls,
+    transport: ListenerTransport,
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let mut config = ServerConfig::default();
+    config.tls.cert_path = tls.cert.clone();
+    config.tls.key_path = tls.key.clone();
+    config.listeners[0].listen_addr = "127.0.0.1:0".parse().unwrap();
+    config.listeners[0].transport = transport;
+    config.listeners[0].auth.username.clear();
+    config.listeners[0].auth.password_hash.clear();
+    config.listeners[0].auth.users = vec![BasicUser {
+        username: "probe-user".into(),
+        password_hash: masque::auth::hash_password(b"probe-password").unwrap(),
+    }];
+    config.tcp_proxy.enabled = true;
+    config.tcp_proxy.allow_targets = vec!["127.0.0.0/8".into()];
+    config.tcp_proxy.deny_targets.clear();
+    config.udp_proxy.enabled = true;
+    config.udp_proxy.allow_targets = vec!["127.0.0.0/8".into()];
+    config.udp_proxy.deny_targets.clear();
+    config.ip_proxy.enabled = false;
+
+    let mut server = Server::bind(config).await.unwrap();
+    let address = server.listen_addrs()[0];
+    let task = tokio::spawn(async move {
+        server.run().await.unwrap();
+    });
+    (address, task)
+}
+
+async fn spawn_certificate_server(
+    tls: &TempTls,
+    transport: ListenerTransport,
+    public_key: String,
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let mut config = ServerConfig::default();
+    config.tls.cert_path = tls.cert.clone();
+    config.tls.key_path = tls.key.clone();
+    config.listeners[0].listen_addr = "127.0.0.1:0".parse().unwrap();
+    config.listeners[0].transport = transport;
+    config.listeners[0].auth.mode = AuthMode::ClientCert;
+    config.listeners[0].auth.username.clear();
+    config.listeners[0].auth.password_hash.clear();
+    config.listeners[0].auth.users.clear();
+    config.clients = vec![ClientEntry {
+        name: "probe-client".into(),
+        public_key,
+        ipv4: None,
+        ipv6: None,
+    }];
+    config.tcp_proxy.enabled = true;
+    config.tcp_proxy.allow_targets = vec!["127.0.0.0/8".into()];
+    config.tcp_proxy.deny_targets.clear();
+    config.udp_proxy.enabled = true;
+    config.udp_proxy.allow_targets = vec!["127.0.0.0/8".into()];
+    config.udp_proxy.deny_targets.clear();
+    config.ip_proxy.enabled = false;
+
+    let mut server = Server::bind(config).await.unwrap();
+    let address = server.listen_addrs()[0];
+    let task = tokio::spawn(async move {
+        server.run().await.unwrap();
+    });
+    (address, task)
+}
+
+fn run_probe(endpoint: SocketAddr, target: SocketAddr, transport: &str) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_masque-probe"))
+        .args([
+            &endpoint.to_string(),
+            "--transport",
+            transport,
+            "--username",
+            "probe-user",
+            "--password-stdin",
+            "--insecure",
+            "--tcp-target",
+            &target.to_string(),
+            "--udp-target",
+            &target.to_string(),
+            "--udp-mode",
+            "echo",
+            "--json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"probe-password")
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn assert_probe_passed(output: std::process::Output, transport: &str) {
+    assert!(
+        output.status.success(),
+        "probe failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["success"], true);
+    assert_eq!(report["selected_transport"], transport);
+    let checks = report["checks"].as_array().unwrap();
+    for name in ["connect_tcp", "connect_udp"] {
+        let check = checks.iter().find(|check| check["name"] == name).unwrap();
+        assert_eq!(check["status"], "pass");
+    }
+}
+
+fn run_certificate_probe(
+    endpoint: SocketAddr,
+    target: SocketAddr,
+    transport: &str,
+    client_config: &Path,
+) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_masque-probe"))
+        .args([
+            &endpoint.to_string(),
+            "--transport",
+            transport,
+            "--client-config",
+            client_config.to_str().unwrap(),
+            "--tcp-target",
+            &target.to_string(),
+            "--udp-target",
+            &target.to_string(),
+            "--udp-mode",
+            "echo",
+            "--json",
+        ])
+        .output()
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn released_probe_checks_basic_http2_and_http3_end_to_end() {
+    let tls = TempTls::new();
+    let (target, tcp_echo, udp_echo) = spawn_echo().await;
+
+    for (transport, configured) in [
+        ("http3", ListenerTransport::Http3),
+        ("http2", ListenerTransport::Http2),
+    ] {
+        let (endpoint, server) = spawn_server(&tls, configured).await;
+        let output = tokio::task::block_in_place(|| run_probe(endpoint, target, transport));
+        assert_probe_passed(output, transport);
+        server.abort();
+    }
+
+    tcp_echo.abort();
+    udp_echo.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn released_probe_checks_certificate_http2_and_http3_end_to_end() {
+    let tls = TempTls::new();
+    let pair = masque::enroll::generate_client_key().unwrap();
+    let server_key = masque::enroll::server_public_key_pem(&tls.cert).unwrap();
+    let enrollment_path = tls.directory.join("client.json");
+    let enrollment = masque::enroll::client_config_json(
+        &pair.private_key_b64,
+        &server_key,
+        Ipv4Addr::LOCALHOST.into(),
+        None,
+        None,
+    );
+    std::fs::write(&enrollment_path, enrollment).unwrap();
+    let (target, tcp_echo, udp_echo) = spawn_echo().await;
+
+    for (transport, configured) in [
+        ("http3", ListenerTransport::Http3),
+        ("http2", ListenerTransport::Http2),
+    ] {
+        let (endpoint, server) =
+            spawn_certificate_server(&tls, configured, pair.public_key_b64.clone()).await;
+        let output = tokio::task::block_in_place(|| {
+            run_certificate_probe(endpoint, target, transport, &enrollment_path)
+        });
+        assert_probe_passed(output, transport);
+        server.abort();
+    }
+
+    tcp_echo.abort();
+    udp_echo.abort();
+    std::fs::remove_file(enrollment_path).unwrap();
+}


### PR DESCRIPTION
## Summary

- ship `masque-probe` for Basic and certificate-authenticated HTTP/3/HTTP/2 CONNECT diagnostics
- generate private Surge configurations while Basic plaintext credentials are available
- add a structurally redacted `support-bundle` command and troubleshooting guide
- publish and transactionally install static Linux x86_64 and ARM64 server/probe archives

## Validation

- `cargo test --workspace --locked`
- `cargo test --workspace --release --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --locked`
- ShellCheck, release metadata, workflow YAML, and diff validation
- static x86_64 and AArch64 package builds, checksums, layouts, modes, and ELF architecture inspection
- x86_64 Linux runtime smoke for the packaged commands
