### PR TITLE
Fix ShellCheck compatibility before v0.10.0

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -746,8 +746,9 @@ if ! CANDIDATE_PROBE_VERSION_OUTPUT=$("$CANDIDATE_PROBE" --version); then
 fi
 CANDIDATE_VERSION=$(printf '%s\n' "$CANDIDATE_VERSION_OUTPUT" | awk '{print $NF}')
 CANDIDATE_PROBE_VERSION=$(printf '%s\n' "$CANDIDATE_PROBE_VERSION_OUTPUT" | awk '{print $NF}')
-[ -n "$CANDIDATE_VERSION" ] && [ -n "$CANDIDATE_PROBE_VERSION" ] || die \
-    "could not read the packaged binary versions"
+if [ -z "$CANDIDATE_VERSION" ] || [ -z "$CANDIDATE_PROBE_VERSION" ]; then
+    die "could not read the packaged binary versions"
+fi
 [ "$CANDIDATE_VERSION" = "$CANDIDATE_PROBE_VERSION" ] || die \
     "packaged binary versions differ: server $CANDIDATE_VERSION, probe $CANDIDATE_PROBE_VERSION"
 parse_start_requested

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -27,10 +27,10 @@ PROBE_VERSION=$(awk '
     /^\[/ { in_package=0 }
     in_package && /^version = / { gsub(/[" ]/, "", $3); print $3; exit }
 ' tools/masque-probe/Cargo.toml)
-[ -n "$PACKAGE_VERSION" ] && [ "$PACKAGE_VERSION" = "$PROBE_VERSION" ] || {
+if [ -z "$PACKAGE_VERSION" ] || [ "$PACKAGE_VERSION" != "$PROBE_VERSION" ]; then
     echo "error: masque-server and masque-probe package versions must match" >&2
     exit 1
-}
+fi
 VERSION="${VERSION:-$PACKAGE_VERSION}"
 OUTPUT_DIR="${OUTPUT_DIR:-dist}"
 ARCHIVE_NAME="masque-v${VERSION}-linux-${ARCH}"


### PR DESCRIPTION
## Summary

- replace two `A && B || C` validation expressions with explicit `if` blocks
- preserve the same packaged-version checks while satisfying ShellCheck 0.9 on the Ubuntu runner

## Validation

- `sh -n deploy/install.sh scripts/package-linux.sh`
- `shellcheck deploy/install.sh scripts/package-linux.sh`
- release metadata and `v0.10.0` validation
