### PR TITLE
test: fix macOS stdin race before v0.10.1

### DIFF
--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -168,8 +168,16 @@ impl Fixture {
             .stderr(Stdio::piped());
         if let Some(input) = stdin {
             let mut child = command.stdin(Stdio::piped()).spawn().unwrap();
-            child.stdin.take().unwrap().write_all(input).unwrap();
-            child.wait_with_output().unwrap()
+            let write_result = child.stdin.take().unwrap().write_all(input);
+            let output = child.wait_with_output().unwrap();
+            if let Err(error) = write_result {
+                assert_eq!(
+                    error.kind(),
+                    std::io::ErrorKind::BrokenPipe,
+                    "failed to write command input: {error}"
+                );
+            }
+            output
         } else {
             command.output().unwrap()
         }


### PR DESCRIPTION
## Summary

- tolerate an expected broken pipe when a rejected config edit exits before reading password stdin
- preserve all output and exit-status assertions, so real command failures remain visible

## Why

The duplicate-user case intentionally rejects before reading a password. On the macOS runner the child can close stdin before the test writes, making the test helper panic even though the command behaves correctly.

## Validation

- cargo test --locked --test add_listener
- duplicate-user regression repeated 25 times
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
