### PR TITLE
Fix scheduled E2E Docker workspace build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,19 +17,22 @@ WORKDIR /build
 # sources and replaced by the real one below.
 COPY Cargo.toml Cargo.lock ./
 COPY tools/masque-e2e/Cargo.toml tools/masque-e2e/Cargo.toml
-RUN mkdir -p src benches tools/masque-e2e/src \
+COPY tools/masque-probe/Cargo.toml tools/masque-probe/Cargo.toml
+RUN mkdir -p src benches tools/masque-e2e/src tools/masque-probe/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/core.rs \
     && echo "fn main() {}" > tools/masque-e2e/src/main.rs \
+    && echo "fn main() {}" > tools/masque-probe/src/main.rs \
     && cargo build --release -p masque-server 2>/dev/null || true \
     && rm -f target/release/masque-server target/release/deps/masque_server-* \
-    && rm -rf src tools/masque-e2e/src
+    && rm -rf src tools/masque-e2e/src tools/masque-probe/src
 
 # Copy real source and build.
 COPY src/ src/
 COPY benches/ benches/
 COPY tools/masque-e2e/ tools/masque-e2e/
+COPY tools/masque-probe/ tools/masque-probe/
 RUN touch src/main.rs src/lib.rs && cargo build --release -p masque-server --bin masque-server
 
 # Stage 2: minimal runtime

--- a/tests/docker_workspace.rs
+++ b/tests/docker_workspace.rs
@@ -1,0 +1,36 @@
+use std::path::Path;
+
+#[test]
+fn docker_build_contexts_include_every_workspace_tool() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = std::fs::read_to_string(root.join("Cargo.toml")).unwrap();
+    let manifest: toml::Value = toml::from_str(&manifest).unwrap();
+    let members = manifest["workspace"]["members"].as_array().unwrap();
+
+    for dockerfile_path in ["Dockerfile", "tests/e2e/client.Dockerfile"] {
+        let dockerfile = std::fs::read_to_string(root.join(dockerfile_path)).unwrap();
+        let (dependency_stage, source_stage) = dockerfile
+            .split_once("# Copy real source and build.")
+            .unwrap();
+
+        for member in members.iter().filter_map(toml::Value::as_str) {
+            if member == "." {
+                continue;
+            }
+
+            let manifest_copy = format!("COPY {member}/Cargo.toml {member}/Cargo.toml");
+            assert!(
+                dependency_stage
+                    .lines()
+                    .any(|line| line.trim() == manifest_copy),
+                "{dockerfile_path} does not copy the {member} manifest before building"
+            );
+
+            let source_copy = format!("COPY {member}/ {member}/");
+            assert!(
+                source_stage.lines().any(|line| line.trim() == source_copy),
+                "{dockerfile_path} does not copy the {member} sources before building"
+            );
+        }
+    }
+}

--- a/tests/e2e/client.Dockerfile
+++ b/tests/e2e/client.Dockerfile
@@ -12,19 +12,22 @@ WORKDIR /build
 # builds the selected package, so the root benchmark needs a stub here too.
 COPY Cargo.toml Cargo.lock ./
 COPY tools/masque-e2e/Cargo.toml tools/masque-e2e/Cargo.toml
-RUN mkdir -p src benches tools/masque-e2e/src \
+COPY tools/masque-probe/Cargo.toml tools/masque-probe/Cargo.toml
+RUN mkdir -p src benches tools/masque-e2e/src tools/masque-probe/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/core.rs \
     && echo "fn main() {}" > tools/masque-e2e/src/main.rs \
+    && echo "fn main() {}" > tools/masque-probe/src/main.rs \
     && cargo build --release -p masque-e2e 2>/dev/null || true \
     && rm -f target/release/masque-e2e target/release/deps/masque* \
-    && rm -rf src benches tools/masque-e2e/src
+    && rm -rf src benches tools/masque-e2e/src tools/masque-probe/src
 
 # Copy real source and build.
 COPY src/ src/
 COPY benches/ benches/
 COPY tools/masque-e2e/ tools/masque-e2e/
+COPY tools/masque-probe/ tools/masque-probe/
 RUN touch src/main.rs src/lib.rs tools/masque-e2e/src/main.rs \
     && cargo build --release -p masque-e2e
 


### PR DESCRIPTION
## Summary

- include `masque-probe` manifests and sources in both E2E Docker build contexts
- create a probe target stub during dependency caching
- add a regression test that keeps Docker build contexts aligned with Cargo workspace members

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Fixes the Scheduled verification failure at the Docker CONNECT-IP E2E build step.