### PR TITLE
feat: harden protocol safety and resource limits for v0.11.0

### DIFF
--- a/.github/workflows/scheduled-verification.yml
+++ b/.github/workflows/scheduled-verification.yml
@@ -16,6 +16,94 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
+  dependency-security:
+    name: Dependency vulnerabilities and policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal
+          rustup default 1.97.1
+
+      - name: Restore security tool cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+            ~/.cargo/bin/cargo-deny
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: security-tools-${{ runner.os }}-audit-0.22.2-deny-0.20.2
+
+      - name: Install pinned security tools
+        run: |
+          if ! cargo audit --version 2>/dev/null | grep -Fq '0.22.2'; then
+            cargo install cargo-audit --version 0.22.2 --locked
+          fi
+          if ! cargo deny --version 2>/dev/null | grep -Fq '0.20.2'; then
+            cargo install cargo-deny --version 0.20.2 --locked
+          fi
+
+      - name: Audit RustSec advisories
+        run: cargo audit
+
+      - name: Enforce licenses and dependency sources
+        run: cargo deny --workspace --locked check licenses sources bans
+
+  linux-asan:
+    name: Linux GNU ASan and resource bounds
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      ASAN_OPTIONS: detect_leaks=0:halt_on_error=1:abort_on_error=1
+      RUSTFLAGS: -Zsanitizer=address -Cforce-frame-pointers=yes
+      RUSTDOCFLAGS: -Zsanitizer=address -Cforce-frame-pointers=yes
+      MASQUE_RESOURCE_RSS_DELTA_MIB: "512"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install nightly Rust with instrumented standard library support
+        run: rustup toolchain install nightly --profile minimal --component rust-src
+
+      - name: Install native tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang cmake openssl
+
+      - name: Restore Cargo cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: asan-${{ runner.os }}-nightly-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            asan-${{ runner.os }}-nightly-
+
+      - name: Exercise unsafe QUIC and target UDP packet paths
+        run: >-
+          cargo +nightly test -Zbuild-std
+          --target x86_64-unknown-linux-gnu --locked --lib net::
+
+      - name: Verify session tickets reject HTTP/3 Early Data
+        run: >-
+          cargo +nightly test -Zbuild-std
+          --target x86_64-unknown-linux-gnu --locked
+          --test client_cert_connect_ip
+          session_tickets_never_enable_zero_rtt_connect_requests
+
+      - name: Pressure authentication, streams, datagrams, and half-open peers
+        run: >-
+          cargo +nightly test -Zbuild-std
+          --target x86_64-unknown-linux-gnu --locked
+          --test resource_exhaustion -- --ignored --nocapture
+
   linux-network:
     name: Linux E2E and transport smoke
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.11.0 - 2026-09-01
+
+### Added
+
+- Weekly security verification runs pinned `cargo-audit` and `cargo-deny`
+  versions for RustSec vulnerabilities, license policy, duplicate versions, and
+  non-registry dependency sources.
+- Linux GNU AddressSanitizer exercises the QUIC and target-UDP syscall paths,
+  the real HTTP/3 session-ticket regression, and an isolated resource-pressure
+  suite covering wrong passwords, half-open TLS peers, excess streams, and
+  sustained DATAGRAM capsules.
+- Prometheus exports process-lifetime high-water marks for active connections,
+  tunnels, pending authentication, and concurrent Argon2 work.
+
+### Changed
+
+- TLS 1.3 Early Data is explicitly disabled in BoringSSL and guarded again at
+  HTTP/3 initialization, so CONNECT, CONNECT-UDP, and CONNECT-IP cannot execute
+  before the full handshake. A real resumed session verifies the ticket never
+  advertises 0-RTT while ordinary resumption remains available.
+- Configuration validation now caps connection/tunnel counts, QUIC/H2 streams
+  and flow-control windows, header/send buffers, and QUIC DATAGRAM queues at
+  auditable hard limits.
+- Workspace lint policy denies unsafe operations outside explicit `unsafe`
+  blocks and undocumented unsafe blocks. Target UDP batching exposes safe
+  wrappers; only the private raw-syscall boundary remains unsafe.
+
 ## 0.10.1 - 2026-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-probe"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,15 @@
 members = [".", "tools/masque-e2e", "tools/masque-probe"]
 resolver = "3"
 
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 [package]
 name = "masque-server"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"
@@ -15,6 +21,9 @@ keywords = ["masque", "http2", "http3", "quic", "proxy"]
 categories = ["network-programming", "command-line-utilities"]
 publish = false
 default-run = "masque-server"
+
+[lints]
+workspace = true
 
 [lib]
 name = "masque"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+# Dependency policy enforced by the scheduled security audit.
+
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "aarch64-apple-darwin",
+]
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = false
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# Workspace path dependencies are private and resolved entirely from this
+# checkout. They deliberately omit a version so a release bump cannot leave
+# the local tools pointing at the previous package version.
+allow-wildcard-paths = true
+highlight = "simplest-path"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,10 +88,10 @@ max_tunnels_per_connection = 100
 | Key | Meaning |
 | --- | --- |
 | `idle_timeout_secs` | Inactive tunnel lifetime |
-| `max_connections` | Per-HTTP/3-shard or per-HTTP/2-listener connection cap |
-| `max_connections_per_ip` | Process-wide live H2 + H3 connections from one source IP |
+| `max_connections` | Per-HTTP/3-shard or per-HTTP/2-listener connection cap; `1..1000000` |
+| `max_connections_per_ip` | Process-wide live H2 + H3 connections from one source IP; `1..65536` |
 | `max_pending_auth_per_ip` | Process-wide running + queued Basic/Argon2 checks from one source; `1..256` |
-| `max_tunnels_per_connection` | CONNECT streams retained per connection |
+| `max_tunnels_per_connection` | CONNECT streams retained per connection; `1..4096` |
 
 This section contains process-wide connection limits only. Socket addresses and
 shard counts belong to [`[[listeners]]`](#listeners).
@@ -650,11 +650,11 @@ These values apply only to listeners with `transport = "http2"`:
 
 | Key | Meaning |
 | --- | --- |
-| `initial_stream_window` | Initial request-stream receive credit |
-| `initial_connection_window` | Initial aggregate receive credit per connection |
-| `max_concurrent_streams` | Concurrent request streams advertised per connection |
-| `max_header_list_size` | Maximum decoded request header list size |
-| `max_send_buffer_size` | Maximum response bytes buffered per stream by the H2 implementation |
+| `initial_stream_window` | Initial request-stream receive credit; `1..16777216` |
+| `initial_connection_window` | Initial aggregate receive credit per connection; `1..67108864` |
+| `max_concurrent_streams` | Concurrent request streams advertised per connection; `1..4096` |
+| `max_header_list_size` | Maximum decoded request header list size; `1..1048576` |
+| `max_send_buffer_size` | Maximum response bytes buffered per stream by the H2 implementation; `1..16777216` |
 | `data_frame_budget` | Connection-level allowance for queued small DATA-frame overhead; `1..16777216`. Packetized CONNECT-IP needs more than h2's generic HTTP default, but raising it increases the memory an abusive connection can consume. |
 | `max_datagram_size` | Maximum UDP payload or IP packet carried in one DATAGRAM capsule; `1..65527` |
 
@@ -689,6 +689,11 @@ Important relationships:
 
 - `initial_max_data` must not exceed `max_connection_window`.
 - `initial_max_stream_data` must not exceed `max_stream_window`.
+- `initial_max_streams_bidi` is limited to 4096.
+- `max_connection_window` is limited to 1 GiB and `max_stream_window` to
+  256 MiB.
+- Both `dgram_*_queue_len` values must be `1..4096`; queue depth is measured in
+  whole datagrams, so increasing it raises per-connection memory directly.
 - Path-MTU discovery cannot probe beyond `max_datagram_size`; raising only
   `discover_pmtu` has no benefit.
 - UDP GSO is opt-in because some virtual egress paths advertise it but drop

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -96,6 +96,7 @@ All metric names start with `masque_`.
 | `masque_event_loop_lag_seconds` | gauge | `listener`, `transport`, `auth`, `shard` | Latest one-second heartbeat scheduling delay |
 | `masque_event_loop_lag_max_seconds` | gauge | `listener`, `transport`, `auth`, `shard` | Largest heartbeat delay since startup |
 | `masque_connections_active` | gauge | `listener`, `transport`, `auth` | Live HTTP transport connections |
+| `masque_connections_active_max` | gauge | `listener`, `transport`, `auth` | Largest live connection count since process start |
 | `masque_connections_accepted_total` | counter | `listener`, `transport`, `auth` | Accepted connection objects |
 | `masque_connections_rejected_total` | counter | `listener`, `transport`, `auth`, `reason` | Connections rejected at a resource limit |
 | `masque_quic_retries_total` | counter | `listener`, `transport`, `auth`, `result` | Retry packets sent or invalid Retry tokens received |
@@ -111,9 +112,12 @@ All metric names start with `masque_`.
 | `masque_tcp_relay_events_total` | counter | `listener`, `transport`, `auth` | Target TCP events consumed by HTTP/3 shards |
 | `masque_tcp_relay_bytes_total` | counter | `listener`, `transport`, `auth` | Target TCP response bytes handed to HTTP/3 shards |
 | `masque_tunnels_active` | gauge | `listener`, `transport`, `auth`, `protocol` | Live `tcp`, `udp`, or `ip` tunnels |
+| `masque_tunnels_active_max` | gauge | `listener`, `transport`, `auth`, `protocol` | Largest live tunnel count since process start |
 | `masque_auth_attempts_total` | counter | `listener`, `transport`, `auth`, `result` | Successful, failed, or load-shed verification |
 | `masque_auth_pending` | gauge | `listener`, `transport`, `auth` | Admitted Basic checks not yet completed |
+| `masque_auth_pending_max` | gauge | `listener`, `transport`, `auth` | Largest pending Basic-check count since process start |
 | `masque_auth_running` | gauge | `listener`, `transport`, `auth` | Argon2 jobs currently executing |
+| `masque_auth_running_max` | gauge | `listener`, `transport`, `auth` | Largest concurrent Argon2 count since process start |
 | `masque_packets_dropped_total` | counter | `listener`, `transport`, `auth`, `reason` | Drops at bounded shard, datagram, or TUN queues |
 | `masque_tls_reloads_total` | counter | `result` | Successful and rejected SIGHUP TLS identity reloads |
 | `masque_roster_reloads_total` | counter | `result` | Successful and rejected active client-roster reloads |

--- a/docs/security.md
+++ b/docs/security.md
@@ -93,6 +93,18 @@ connection IDs.
 Do not respond to overload by making queues arbitrarily deep; this can turn
 packet loss into seconds of latency and make memory exhaustion easier.
 
+Configuration validation also applies hard ceilings to attacker-controlled
+protocol credit: connection and tunnel counts, H2/H3 stream counts, receive
+windows, H2 header/send buffers, and both QUIC DATAGRAM queues. This prevents a
+mistyped deployment value from silently removing the runtime bounds.
+Process-lifetime `*_max` metrics make the actual connection, tunnel, and
+authentication high-water marks observable after a burst has ended.
+
+The scheduled Linux pressure test runs the daemon as a separate process and
+floods wrong passwords, half-open TLS sockets, excess streams, and DATAGRAM
+capsules. It checks authentication and tunnel high-water marks, CPU ticks,
+resident-memory growth, and `/proc/<pid>/fd` against the configured ceilings.
+
 `masque-server support-bundle` is deliberately a metadata-only diagnostic. It
 does not copy the configuration, logs, environment, usernames, password hashes,
 client labels or keys, certificate identities, target addresses, or traffic
@@ -121,6 +133,12 @@ Each successful reload advances the TLS session ID context. Session tickets
 from the previous identity or roster therefore cannot bypass certificate
 rotation or client revocation: BoringSSL falls back to a full handshake and
 issues tickets in the new context.
+
+TLS 1.3 Early Data is unconditionally disabled. CONNECT, CONNECT-UDP, and
+CONNECT-IP create externally visible network effects and are not replay-safe;
+they are accepted only after the peer's Finished message. Session resumption
+still works, but a ticket issued by this server never authorizes 0-RTT. The H3
+application gate independently rejects an Early Data state as defense in depth.
 
 The right server certificate depends on the authentication mode, because the
 two modes establish server identity in completely different ways.
@@ -197,11 +215,32 @@ than permission to install a broad ACCEPT or MASQUERADE rule automatically.
 
 ## Unsafe and syscall code
 
+The complete production unsafe inventory is intentionally small:
+
+| Module | Unsafe boundary | Invariant checked in review |
+| --- | --- | --- |
+| `src/net/quic.rs` | socket setup, `recvmmsg`/`sendmmsg`, sockaddr and ancillary-data layouts | Counts are clamped to fixed arrays; raw pointers refer to live per-call storage; address/control lengths are checked before typed reads |
+| `src/net/target_udp.rs` | `recvmmsg`/`sendmmsg` and UDP GSO ancillary data | Public batching wrappers are safe; only the private syscall receives raw interior pointers; payload and result counts are clamped |
+| `src/server/tls.rs` | two BoringSSL context/connection setters | Pointers come from live safe wrappers; BoringSSL copies bounded context bytes or changes one context flag without retaining ownership |
+| `src/config_edit.rs` | terminal attributes, ownership, and advisory file locks | Every descriptor is owned and live; initialized `termios` is restored by an RAII guard |
+
 Linux batching constructs `mmsghdr`, `iovec`, socket-address, and control
 message arrays that contain raw pointers. They are rebuilt per syscall, point
-only to live storage, are zero-initialized for ABI padding, and never escape
-the call. Any change to these layouts requires Linux musl and GNU tests plus
-boundary tests for control buffers and datagram truncation.
+only to live storage, and never escape the call. `unsafe_op_in_unsafe_fn` and
+Clippy's `undocumented_unsafe_blocks` are denied workspace-wide. The weekly
+Linux GNU ASan job directly exercises both packet modules; any layout change
+still requires GNU and musl tests plus control-buffer and truncation boundaries.
+The development-only E2E and probe tools use a few reviewed `setsockopt` and
+`if_nametoindex` calls; the same workspace lint policy applies to them.
+
+## Dependency security
+
+The weekly security workflow uses pinned `cargo-audit` and `cargo-deny`
+versions. Known RustSec vulnerabilities fail the audit, while informational
+warnings such as an unmaintained transitive crate remain visible. `deny.toml`
+restricts licenses and dependency registries/sources while reporting duplicate
+transitive versions. Workspace path dependencies are the sole wildcard
+exception because they are private code resolved from the same checkout.
 
 ## Reporting
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,8 @@
 | Client config | `cargo test --test client_config` | Surge output is importable, private, secret-aware, and never overwritten |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
 | Parser fuzzing | `cargo +nightly fuzz run protocol_parsers` | Incremental capsule, datagram, varint, IP, and URI parser safety |
+| Dependency security | `cargo audit && cargo deny --workspace --locked check licenses sources bans` | RustSec, license, duplicate-version, and source policy |
+| Linux GNU ASan | Scheduled `linux-asan` job | Unsafe QUIC/target UDP FFI, 0-RTT ticket regression, and resource-pressure suite |
 
 ## Local tests
 
@@ -114,13 +116,21 @@ See [Performance](performance.md) for methodology and reporting requirements.
 ## Scheduled verification
 
 The weekly and manually dispatchable `Scheduled verification` workflow keeps
-the expensive checks off ordinary commits. It runs the Docker CONNECT-IP E2E,
-an HTTP/2 + HTTP/3 smoke test with QUIC Retry forced on, and a bounded parser
-fuzz session. A longer local parser run is:
+the expensive checks off ordinary commits. It runs dependency policy/security
+audits, Linux GNU ASan over the unsafe packet paths, an isolated resource
+pressure test, the real 0-RTT ticket regression, Docker CONNECT-IP E2E, an
+HTTP/2 + HTTP/3 smoke test with QUIC Retry forced on, and a bounded parser fuzz
+session. A longer local parser run is:
 
 ```sh
 cargo +nightly install cargo-fuzz --version 0.13.2 --locked
 cargo +nightly fuzz run protocol_parsers -- -max_total_time=3600
+```
+
+Run the Linux pressure suite without ASan with:
+
+```sh
+cargo test --test resource_exhaustion -- --ignored --nocapture
 ```
 
 ## Linux-specific checks

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -349,6 +349,12 @@ impl ListenerMetrics {
         );
         render_value(
             out,
+            "masque_connections_active_max",
+            label,
+            self.sum(|shard| &shard.connections_active_max),
+        );
+        render_value(
+            out,
             "masque_connections_accepted_total",
             label,
             self.sum(|shard| &shard.connections_accepted),
@@ -424,6 +430,16 @@ impl ListenerMetrics {
                 "masque_tunnels_active{{{label},protocol=\"{protocol}\"}} {value}"
             )
             .unwrap();
+            let maximum = self
+                .shards
+                .iter()
+                .map(|shard| shard.tunnels_active_max[index].load(RELAXED))
+                .sum::<u64>();
+            writeln!(
+                out,
+                "masque_tunnels_active_max{{{label},protocol=\"{protocol}\"}} {maximum}"
+            )
+            .unwrap();
         }
         for (result, field) in [
             (
@@ -448,9 +464,21 @@ impl ListenerMetrics {
         );
         render_value(
             out,
+            "masque_auth_pending_max",
+            label,
+            self.sum(|shard| &shard.auth_pending_max),
+        );
+        render_value(
+            out,
             "masque_auth_running",
             label,
             self.sum(|shard| &shard.auth_running),
+        );
+        render_value(
+            out,
+            "masque_auth_running_max",
+            label,
+            self.sum(|shard| &shard.auth_running_max),
         );
         for (reason, field) in [
             (
@@ -487,6 +515,7 @@ pub(crate) struct ShardMetrics {
     quic_udp_gso_enabled: AtomicBool,
     quic_udp_gro_enabled: AtomicBool,
     connections_active: AtomicU64,
+    connections_active_max: AtomicU64,
     connections_accepted: AtomicU64,
     connections_rejected_limit: AtomicU64,
     connections_rejected_source_limit: AtomicU64,
@@ -502,11 +531,14 @@ pub(crate) struct ShardMetrics {
     tcp_relay_events: AtomicU64,
     tcp_relay_bytes: AtomicU64,
     tunnels_active: [AtomicU64; 3],
+    tunnels_active_max: [AtomicU64; 3],
     auth_success: AtomicU64,
     auth_failure: AtomicU64,
     auth_overloaded: AtomicU64,
     auth_pending: AtomicU64,
+    auth_pending_max: AtomicU64,
     auth_running: AtomicU64,
+    auth_running_max: AtomicU64,
     dropped_shard_queue: AtomicU64,
     dropped_datagram_queue: AtomicU64,
     dropped_tun_queue: AtomicU64,
@@ -522,6 +554,7 @@ impl ShardMetrics {
             quic_udp_gso_enabled: AtomicBool::new(udp_gso),
             quic_udp_gro_enabled: AtomicBool::new(udp_gro),
             connections_active: AtomicU64::new(0),
+            connections_active_max: AtomicU64::new(0),
             connections_accepted: AtomicU64::new(0),
             connections_rejected_limit: AtomicU64::new(0),
             connections_rejected_source_limit: AtomicU64::new(0),
@@ -537,11 +570,14 @@ impl ShardMetrics {
             tcp_relay_events: AtomicU64::new(0),
             tcp_relay_bytes: AtomicU64::new(0),
             tunnels_active: std::array::from_fn(|_| AtomicU64::new(0)),
+            tunnels_active_max: std::array::from_fn(|_| AtomicU64::new(0)),
             auth_success: AtomicU64::new(0),
             auth_failure: AtomicU64::new(0),
             auth_overloaded: AtomicU64::new(0),
             auth_pending: AtomicU64::new(0),
+            auth_pending_max: AtomicU64::new(0),
             auth_running: AtomicU64::new(0),
+            auth_running_max: AtomicU64::new(0),
             dropped_shard_queue: AtomicU64::new(0),
             dropped_datagram_queue: AtomicU64::new(0),
             dropped_tun_queue: AtomicU64::new(0),
@@ -582,7 +618,7 @@ impl ShardMetrics {
             return;
         }
         self.connections_accepted.fetch_add(1, RELAXED);
-        self.connections_active.fetch_add(1, RELAXED);
+        increment_with_high_water(&self.connections_active, &self.connections_active_max);
     }
 
     pub(crate) fn connection_closed(&self) {
@@ -652,12 +688,19 @@ impl ShardMetrics {
         if !self.enabled {
             return;
         }
-        for ((metric, old), new) in self.tunnels_active.iter().zip(previous).zip(current) {
+        for (((metric, maximum), old), new) in self
+            .tunnels_active
+            .iter()
+            .zip(&self.tunnels_active_max)
+            .zip(previous)
+            .zip(current)
+        {
             if new >= old {
                 metric.fetch_add((new - old) as u64, RELAXED);
             } else {
                 subtract(metric, (old - new) as u64);
             }
+            maximum.fetch_max(new as u64, RELAXED);
         }
     }
 
@@ -665,7 +708,10 @@ impl ShardMetrics {
     /// streams run as Tokio tasks rather than inside a shard-owned map.
     pub(crate) fn tunnel_opened(&self, protocol_index: usize) {
         if self.enabled {
-            self.tunnels_active[protocol_index].fetch_add(1, RELAXED);
+            increment_with_high_water(
+                &self.tunnels_active[protocol_index],
+                &self.tunnels_active_max[protocol_index],
+            );
         }
     }
 
@@ -746,10 +792,13 @@ impl GaugeGuard {
         let active = metrics.enabled;
         if active {
             match gauge {
-                Gauge::AuthPending => &metrics.auth_pending,
-                Gauge::AuthRunning => &metrics.auth_running,
+                Gauge::AuthPending => {
+                    increment_with_high_water(&metrics.auth_pending, &metrics.auth_pending_max)
+                }
+                Gauge::AuthRunning => {
+                    increment_with_high_water(&metrics.auth_running, &metrics.auth_running_max)
+                }
             }
-            .fetch_add(1, RELAXED);
         }
         Self {
             metrics,
@@ -778,6 +827,11 @@ fn subtract(metric: &AtomicU64, amount: u64) {
             Some(current.saturating_sub(amount))
         })
         .ok();
+}
+
+fn increment_with_high_water(current: &AtomicU64, maximum: &AtomicU64) {
+    let next = current.fetch_add(1, RELAXED).saturating_add(1);
+    maximum.fetch_max(next, RELAXED);
 }
 
 fn render_value(out: &mut String, name: &str, label: &str, value: u64) {
@@ -824,6 +878,11 @@ fn render_listener_headers(out: &mut String) {
         (
             "masque_connections_active",
             "Currently active HTTP transport connections.",
+            "gauge",
+        ),
+        (
+            "masque_connections_active_max",
+            "Largest active HTTP transport connection count since process start.",
             "gauge",
         ),
         (
@@ -892,6 +951,11 @@ fn render_listener_headers(out: &mut String) {
             "gauge",
         ),
         (
+            "masque_tunnels_active_max",
+            "Largest active CONNECT tunnel count by protocol since process start.",
+            "gauge",
+        ),
+        (
             "masque_auth_attempts_total",
             "Completed or load-shed authentication attempts.",
             "counter",
@@ -902,8 +966,18 @@ fn render_listener_headers(out: &mut String) {
             "gauge",
         ),
         (
+            "masque_auth_pending_max",
+            "Largest pending Basic authentication count since process start.",
+            "gauge",
+        ),
+        (
             "masque_auth_running",
             "Argon2 password verifications currently executing.",
+            "gauge",
+        ),
+        (
+            "masque_auth_running_max",
+            "Largest concurrent Argon2 verification count since process start.",
             "gauge",
         ),
         (
@@ -971,6 +1045,11 @@ mod tests {
                 "masque_connections_active{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 2"
             )
         );
+        assert!(
+            rendered.contains(
+                "masque_connections_active_max{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 2"
+            )
+        );
         assert!(rendered.contains(
             "masque_quic_receive_bytes_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 4800"
         ));
@@ -996,6 +1075,9 @@ mod tests {
         ));
         assert!(rendered.contains(
             "masque_tunnels_active{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",protocol=\"udp\"} 2"
+        ));
+        assert!(rendered.contains(
+            "masque_tunnels_active_max{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",protocol=\"udp\"} 2"
         ));
         assert!(rendered.contains(
             "masque_event_loop_lag_seconds{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",shard=\"0\"} 0.025000"
@@ -1032,6 +1114,8 @@ mod tests {
         }
         assert_eq!(listener.auth_pending.load(RELAXED), 0);
         assert_eq!(listener.auth_running.load(RELAXED), 0);
+        assert_eq!(listener.auth_pending_max.load(RELAXED), 1);
+        assert_eq!(listener.auth_running_max.load(RELAXED), 1);
     }
 
     #[test]

--- a/src/net/quic.rs
+++ b/src/net/quic.rs
@@ -132,11 +132,8 @@ impl RecvPacketBatch {
             return Err(io::Error::last_os_error());
         }
 
-        for (message, slot) in messages
-            .iter()
-            .zip(self.slots.iter_mut())
-            .take(result as usize)
-        {
+        let received = (result as usize).min(count);
+        for (message, slot) in messages.iter().zip(self.slots.iter_mut()).take(received) {
             if message.msg_hdr.msg_flags & libc::MSG_TRUNC != 0 {
                 continue;
             }
@@ -148,7 +145,7 @@ impl RecvPacketBatch {
                 .unwrap_or(slot.len);
         }
 
-        Ok(result as usize)
+        Ok(received)
     }
 }
 
@@ -600,10 +597,14 @@ fn gro_segment_size(header: &libc::msghdr) -> Option<usize> {
     // CMSG_FIRSTHDR validates that it contains at least a cmsghdr.
     unsafe {
         let control = libc::CMSG_FIRSTHDR(header);
+        let required = libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as usize;
+        let control_len = header.msg_controllen as usize;
         if control.is_null()
+            || control_len < required
             || (*control).cmsg_level != libc::IPPROTO_UDP
             || (*control).cmsg_type != libc::UDP_GRO
-            || (*control).cmsg_len < libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as _
+            || ((*control).cmsg_len as usize) < required
+            || ((*control).cmsg_len as usize) > control_len
         {
             return None;
         }
@@ -766,7 +767,7 @@ fn send_mmsg(
     if result < 0 {
         Err(io::Error::last_os_error())
     } else {
-        Ok(result as usize)
+        Ok((result as usize).min(count))
     }
 }
 
@@ -893,6 +894,44 @@ mod tests {
         // SAFETY: The argument is a small constant payload length.
         let required = unsafe { libc::CMSG_SPACE(std::mem::size_of::<u16>() as _) as usize };
         assert!(std::mem::size_of::<ControlBuffer>() >= required);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn gro_control_message_requires_a_bounded_u16_payload() {
+        use std::os::raw::c_void;
+
+        let mut control = ControlBuffer::default();
+        let control_header = control.as_mut_ptr().cast::<libc::cmsghdr>();
+        // SAFETY: `control` is aligned and large enough for this header and
+        // u16 payload, as checked by the preceding test.
+        unsafe {
+            (*control_header).cmsg_level = libc::IPPROTO_UDP;
+            (*control_header).cmsg_type = libc::UDP_GRO;
+            (*control_header).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as _;
+            libc::CMSG_DATA(control_header).cast::<u16>().write(1_200);
+        }
+
+        // SAFETY: Zero is a valid initial representation for msghdr; the
+        // control pointer and length are filled before inspection.
+        let mut message: libc::msghdr = unsafe { std::mem::zeroed() };
+        message.msg_control = control.as_mut_ptr().cast::<c_void>();
+        // SAFETY: The argument is a small constant payload length.
+        let required = unsafe { libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as usize };
+        message.msg_controllen = required as _;
+        assert_eq!(gro_segment_size(&message), Some(1_200));
+
+        // A kernel- or ABI-supplied cmsg length may never authorize a read
+        // beyond the actual control buffer described by msghdr.
+        // SAFETY: Only the initialized cmsghdr field is changed.
+        unsafe { (*control_header).cmsg_len = (required + 1) as _ };
+        assert_eq!(gro_segment_size(&message), None);
+
+        // Restore the header, then truncate the outer buffer description.
+        // SAFETY: Only the initialized cmsghdr field is changed.
+        unsafe { (*control_header).cmsg_len = required as _ };
+        message.msg_controllen = (required - 1) as _;
+        assert_eq!(gro_segment_size(&message), None);
     }
 
     #[cfg(target_os = "linux")]

--- a/src/net/quic.rs
+++ b/src/net/quic.rs
@@ -598,7 +598,7 @@ fn gro_segment_size(header: &libc::msghdr) -> Option<usize> {
     unsafe {
         let control = libc::CMSG_FIRSTHDR(header);
         let required = libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as usize;
-        let control_len = header.msg_controllen as usize;
+        let control_len = header.msg_controllen;
         if control.is_null()
             || control_len < required
             || (*control).cmsg_level != libc::IPPROTO_UDP

--- a/src/net/target_udp.rs
+++ b/src/net/target_udp.rs
@@ -225,14 +225,11 @@ impl TargetRecvBatch {
 
 /// Read up to a batch of datagrams from a connected socket in one syscall.
 ///
-/// # Safety
-///
-/// `fd` must be a live, connected, nonblocking UDP socket.
+/// The caller should pass a connected, nonblocking UDP socket. An invalid or
+/// incompatible descriptor is reported by the kernel; all userspace pointers
+/// passed to it are constructed and retained inside this function.
 #[cfg(target_os = "linux")]
-pub unsafe fn recv_mmsg(
-    fd: std::os::fd::RawFd,
-    batch: &mut TargetRecvBatch,
-) -> std::io::Result<usize> {
+pub fn recv_mmsg(fd: std::os::fd::RawFd, batch: &mut TargetRecvBatch) -> std::io::Result<usize> {
     use std::os::raw::c_void;
 
     // Rebuilt per call because these hold raw pointers into `batch`.
@@ -285,6 +282,7 @@ unsafe fn raw_send_mmsg(
     headers: &mut [libc::mmsghdr; TARGET_BATCH_SIZE],
     count: usize,
 ) -> std::io::Result<usize> {
+    let count = count.min(TARGET_BATCH_SIZE);
     // SAFETY: The caller keeps every buffer referenced by `headers` alive for
     // this nonblocking call. Issued as a raw syscall because musl's `sendmmsg`
     // wrapper degrades into a loop of `sendmsg`.
@@ -305,7 +303,7 @@ unsafe fn raw_send_mmsg(
 }
 
 #[cfg(target_os = "linux")]
-unsafe fn send_mmsg_plain(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::io::Result<usize> {
+fn send_mmsg_plain(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::io::Result<usize> {
     use std::os::raw::c_void;
 
     // Keep the disabled and small-datagram path equivalent to the original
@@ -315,7 +313,8 @@ unsafe fn send_mmsg_plain(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::
     // SAFETY: See above.
     let mut headers: [libc::mmsghdr; TARGET_BATCH_SIZE] = unsafe { std::mem::zeroed() };
 
-    for (index, payload) in payloads.iter().enumerate() {
+    let count = payloads.len().min(TARGET_BATCH_SIZE);
+    for (index, payload) in payloads.iter().take(count).enumerate() {
         iovecs[index] = libc::iovec {
             iov_base: payload.as_ptr().cast_mut().cast::<c_void>(),
             iov_len: payload.len(),
@@ -325,7 +324,7 @@ unsafe fn send_mmsg_plain(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::
     }
 
     // SAFETY: Every header points at the live iovec and payload storage above.
-    unsafe { raw_send_mmsg(fd, &mut headers, payloads.len()) }
+    unsafe { raw_send_mmsg(fd, &mut headers, count) }
 }
 
 /// Send a batch of datagrams on a connected socket in one syscall.
@@ -334,11 +333,11 @@ unsafe fn send_mmsg_plain(fd: std::os::fd::RawFd, payloads: &[Vec<u8>]) -> std::
 /// rest. With GSO enabled, several logical datagrams can be accepted as one
 /// kernel message.
 ///
-/// # Safety
-///
-/// `fd` must be a live, connected, nonblocking UDP socket.
+/// The caller should pass a connected, nonblocking UDP socket. An invalid or
+/// incompatible descriptor is reported by the kernel; all userspace pointers
+/// passed to it are constructed and retained inside this function.
 #[cfg(target_os = "linux")]
-pub unsafe fn send_mmsg(
+pub fn send_mmsg(
     fd: std::os::fd::RawFd,
     payloads: &[Vec<u8>],
     enable_gso: bool,
@@ -355,8 +354,7 @@ pub unsafe fn send_mmsg(
     // retain the exact low-overhead sendmmsg path for the whole batch; a later
     // large datagram can start a GSO batch on the next event-loop round.
     if !enable_gso || payloads[0].len() < UDP_MIN_GSO_SEGMENT_SIZE {
-        // SAFETY: This function carries the same live-socket contract.
-        return unsafe { send_mmsg_plain(fd, payloads) };
+        return send_mmsg_plain(fd, payloads);
     }
 
     let (groups, group_count) = plan_send(payloads, true);
@@ -521,8 +519,7 @@ mod tests {
         }
 
         let payloads = vec![vec![1; 1_200], vec![2; 1_200], vec![3; 600]];
-        // SAFETY: `sender` is live, connected, and nonblocking.
-        let sent = unsafe { send_mmsg(sender.as_raw_fd(), &payloads, true) }.unwrap();
+        let sent = send_mmsg(sender.as_raw_fd(), &payloads, true).unwrap();
         assert_eq!(sent, payloads.len());
 
         let expected = [(1_200, 1), (1_200, 2), (600, 3)];
@@ -551,8 +548,7 @@ mod tests {
         sender.set_nonblocking(true).unwrap();
 
         let payloads = vec![vec![1; 64], vec![2; 64], vec![3; 32]];
-        // SAFETY: `sender` is live, connected, and nonblocking.
-        let sent = unsafe { send_mmsg(sender.as_raw_fd(), &payloads, true) }.unwrap();
+        let sent = send_mmsg(sender.as_raw_fd(), &payloads, true).unwrap();
         assert_eq!(sent, payloads.len());
 
         let expected = [(64, 1), (64, 2), (32, 3)];
@@ -579,5 +575,16 @@ mod tests {
         batch.set_single(2_048);
         batch.truncated[0] = true;
         assert_eq!(batch.datagrams(1).count(), 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn safe_batch_wrappers_reject_invalid_descriptors() {
+        let mut batch = TargetRecvBatch::new(1_350);
+        let receive_error = recv_mmsg(-1, &mut batch).unwrap_err();
+        assert_eq!(receive_error.raw_os_error(), Some(libc::EBADF));
+
+        let send_error = send_mmsg(-1, &[vec![0; 64]], false).unwrap_err();
+        assert_eq!(send_error.raw_os_error(), Some(libc::EBADF));
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -114,6 +114,23 @@ const MAX_PENDING_AUTH_GLOBAL: usize = 256;
 /// that is what `Shared::auth_permits` does.
 const MAX_PENDING_AUTH_PER_CONNECTION: usize = 16;
 
+/// Configuration ceilings that keep one hostile connection, or one mistaken
+/// configuration edit, from turning protocol credit into unbounded memory.
+/// Defaults remain far below these values; the ceilings leave room for large
+/// deployments while making the worst case auditable.
+const MAX_CONFIGURED_CONNECTIONS: usize = 1_000_000;
+const MAX_CONFIGURED_CONNECTIONS_PER_IP: usize = 65_536;
+const MAX_TUNNELS_PER_CONNECTION: usize = 4_096;
+const MAX_QUIC_STREAMS_BIDI: u64 = 4_096;
+const MAX_QUIC_DATAGRAM_QUEUE_LEN: usize = 4_096;
+const MAX_QUIC_CONNECTION_WINDOW: u64 = 1024 * 1024 * 1024;
+const MAX_QUIC_STREAM_WINDOW: u64 = 256 * 1024 * 1024;
+const MAX_HTTP2_CONCURRENT_STREAMS: u32 = 4_096;
+const MAX_HTTP2_STREAM_WINDOW: u32 = 16 * 1024 * 1024;
+const MAX_HTTP2_CONNECTION_WINDOW: u32 = 64 * 1024 * 1024;
+const MAX_HTTP2_HEADER_LIST_SIZE: u32 = 1024 * 1024;
+const MAX_HTTP2_SEND_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
 /// How many fresh kernel-selected ports to try when an ephemeral listener
 /// happens to overlap another listener.
 ///
@@ -516,11 +533,19 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
     let listeners = plan_listeners(config)?;
     let any_client_cert = any_client_cert_listener(config);
 
-    if config.server.max_connections == 0 {
-        anyhow::bail!("server.max_connections must be at least 1");
+    if !(1..=MAX_CONFIGURED_CONNECTIONS).contains(&config.server.max_connections) {
+        anyhow::bail!(
+            "server.max_connections ({}) must be between 1 and {}",
+            config.server.max_connections,
+            MAX_CONFIGURED_CONNECTIONS
+        );
     }
-    if config.server.max_connections_per_ip == 0 {
-        anyhow::bail!("server.max_connections_per_ip must be at least 1");
+    if !(1..=MAX_CONFIGURED_CONNECTIONS_PER_IP).contains(&config.server.max_connections_per_ip) {
+        anyhow::bail!(
+            "server.max_connections_per_ip ({}) must be between 1 and {}",
+            config.server.max_connections_per_ip,
+            MAX_CONFIGURED_CONNECTIONS_PER_IP
+        );
     }
     if !(1..=MAX_PENDING_AUTH_GLOBAL).contains(&config.server.max_pending_auth_per_ip) {
         anyhow::bail!(
@@ -529,8 +554,12 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
             MAX_PENDING_AUTH_GLOBAL
         );
     }
-    if config.server.max_tunnels_per_connection == 0 {
-        anyhow::bail!("server.max_tunnels_per_connection must be at least 1");
+    if !(1..=MAX_TUNNELS_PER_CONNECTION).contains(&config.server.max_tunnels_per_connection) {
+        anyhow::bail!(
+            "server.max_tunnels_per_connection ({}) must be between 1 and {}",
+            config.server.max_tunnels_per_connection,
+            MAX_TUNNELS_PER_CONNECTION
+        );
     }
     const MAX_TARGET_CONNECT_TIMEOUT_SECS: u64 = 300;
     if !(1..=MAX_TARGET_CONNECT_TIMEOUT_SECS).contains(&config.tcp_proxy.connect_timeout_secs) {
@@ -611,6 +640,37 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
             config.quic.initial_max_stream_data
         );
     }
+    if config.quic.max_connection_window > MAX_QUIC_CONNECTION_WINDOW {
+        anyhow::bail!(
+            "quic.max_connection_window ({}) must not exceed {} bytes",
+            config.quic.max_connection_window,
+            MAX_QUIC_CONNECTION_WINDOW
+        );
+    }
+    if config.quic.max_stream_window > MAX_QUIC_STREAM_WINDOW {
+        anyhow::bail!(
+            "quic.max_stream_window ({}) must not exceed {} bytes",
+            config.quic.max_stream_window,
+            MAX_QUIC_STREAM_WINDOW
+        );
+    }
+    if !(1..=MAX_QUIC_STREAMS_BIDI).contains(&config.quic.initial_max_streams_bidi) {
+        anyhow::bail!(
+            "quic.initial_max_streams_bidi ({}) must be between 1 and {}",
+            config.quic.initial_max_streams_bidi,
+            MAX_QUIC_STREAMS_BIDI
+        );
+    }
+    for (name, value) in [
+        ("dgram_recv_queue_len", config.quic.dgram_recv_queue_len),
+        ("dgram_send_queue_len", config.quic.dgram_send_queue_len),
+    ] {
+        if !(1..=MAX_QUIC_DATAGRAM_QUEUE_LEN).contains(&value) {
+            anyhow::bail!(
+                "quic.{name} ({value}) must be between 1 and {MAX_QUIC_DATAGRAM_QUEUE_LEN}"
+            );
+        }
+    }
 
     if !(quiche::MIN_CLIENT_INITIAL_LEN..=MAX_DATAGRAM_SIZE)
         .contains(&config.quic.max_datagram_size)
@@ -623,32 +683,37 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
         );
     }
 
-    const MAX_HTTP2_WINDOW: u32 = (1_u32 << 31) - 1;
-    if !(1..=MAX_HTTP2_WINDOW).contains(&config.http2.initial_stream_window) {
+    if !(1..=MAX_HTTP2_STREAM_WINDOW).contains(&config.http2.initial_stream_window) {
         anyhow::bail!(
-            "http2.initial_stream_window ({}) must be between 1 and {MAX_HTTP2_WINDOW}",
+            "http2.initial_stream_window ({}) must be between 1 and {MAX_HTTP2_STREAM_WINDOW}",
             config.http2.initial_stream_window
         );
     }
-    if !(1..=MAX_HTTP2_WINDOW).contains(&config.http2.initial_connection_window) {
+    if !(1..=MAX_HTTP2_CONNECTION_WINDOW).contains(&config.http2.initial_connection_window) {
         anyhow::bail!(
-            "http2.initial_connection_window ({}) must be between 1 and {MAX_HTTP2_WINDOW}",
+            "http2.initial_connection_window ({}) must be between 1 and {MAX_HTTP2_CONNECTION_WINDOW}",
             config.http2.initial_connection_window
         );
     }
-    if config.http2.max_concurrent_streams == 0 {
-        anyhow::bail!("http2.max_concurrent_streams must be at least 1");
+    if !(1..=MAX_HTTP2_CONCURRENT_STREAMS).contains(&config.http2.max_concurrent_streams) {
+        anyhow::bail!(
+            "http2.max_concurrent_streams ({}) must be between 1 and {}",
+            config.http2.max_concurrent_streams,
+            MAX_HTTP2_CONCURRENT_STREAMS
+        );
     }
-    if config.http2.max_header_list_size == 0 {
-        anyhow::bail!("http2.max_header_list_size must be at least 1");
+    if !(1..=MAX_HTTP2_HEADER_LIST_SIZE).contains(&config.http2.max_header_list_size) {
+        anyhow::bail!(
+            "http2.max_header_list_size ({}) must be between 1 and {}",
+            config.http2.max_header_list_size,
+            MAX_HTTP2_HEADER_LIST_SIZE
+        );
     }
-    if config.http2.max_send_buffer_size == 0
-        || config.http2.max_send_buffer_size > u32::MAX as usize
-    {
+    if !(1..=MAX_HTTP2_SEND_BUFFER_SIZE).contains(&config.http2.max_send_buffer_size) {
         anyhow::bail!(
             "http2.max_send_buffer_size ({}) must be between 1 and {}",
             config.http2.max_send_buffer_size,
-            u32::MAX
+            MAX_HTTP2_SEND_BUFFER_SIZE
         );
     }
     const MAX_HTTP2_DATA_FRAME_BUDGET: usize = 16 * 1024 * 1024;
@@ -1627,6 +1692,11 @@ fn build_quic_config(
     // the identity it already negotiated.
     let mut builder = boring::ssl::SslContextBuilder::new(boring::ssl::SslMethod::tls())
         .map_err(|e| anyhow::anyhow!("failed to create TLS context: {e}"))?;
+    // CONNECT, CONNECT-UDP, and CONNECT-IP all create externally observable
+    // side effects and therefore must never be accepted as replayable 0-RTT
+    // data. Keep resumption, but lock Early Data off explicitly rather than
+    // relying on quiche's current default.
+    tls::disable_early_data(&mut builder);
     tls::configure_dynamic_identity(&mut builder, tls_identity);
     if let Some(roster) = client_certs {
         // quiche's normal peer verification cannot express the self-signed,
@@ -1810,9 +1880,7 @@ async fn recv_target_batch(
 
         socket
             .async_io(Interest::READABLE, || {
-                // SAFETY: The socket is live, connected, and nonblocking for
-                // the duration of this readiness callback.
-                unsafe { target_udp::recv_mmsg(socket.as_raw_fd(), batch) }
+                target_udp::recv_mmsg(socket.as_raw_fd(), batch)
             })
             .await
     }
@@ -2841,8 +2909,10 @@ impl Shard {
             }
         }
 
-        // Upgrade to HTTP/3 once QUIC handshake completes.
-        if client.h3.is_none() && client.quic.is_established() {
+        // Upgrade only after the full handshake. The TLS context rejects
+        // Early Data; the second condition is defense in depth against a
+        // future TLS/configuration regression reaching this application gate.
+        if client.h3.is_none() && client.quic.is_established() && !client.quic.is_in_early_data() {
             match quiche::h3::Connection::with_transport(&mut client.quic, &self.h3_config) {
                 Ok(h3) => {
                     client.h3 = Some(h3);
@@ -4403,6 +4473,50 @@ mod tests {
             Err(error) => error.to_string(),
         };
         assert!(error.contains("retry_token_ttl_secs"));
+    }
+
+    #[test]
+    fn attacker_controlled_protocol_credit_has_configuration_ceilings() {
+        let mut config = ServerConfig::default();
+        config.listeners[0].auth.enabled = false;
+        let error = |config: &ServerConfig| match super::validate_server_config(config) {
+            Ok(_) => panic!("oversized resource configuration must be rejected"),
+            Err(error) => error.to_string(),
+        };
+
+        config.server.max_connections = super::MAX_CONFIGURED_CONNECTIONS + 1;
+        let message = error(&config);
+        assert!(message.contains("max_connections"), "{message}");
+        config.server.max_connections = 10_000;
+
+        config.server.max_tunnels_per_connection = super::MAX_TUNNELS_PER_CONNECTION + 1;
+        let message = error(&config);
+        assert!(message.contains("max_tunnels_per_connection"), "{message}");
+        config.server.max_tunnels_per_connection = 100;
+
+        config.quic.initial_max_streams_bidi = super::MAX_QUIC_STREAMS_BIDI + 1;
+        let message = error(&config);
+        assert!(message.contains("initial_max_streams_bidi"), "{message}");
+        config.quic.initial_max_streams_bidi = 128;
+
+        config.quic.dgram_recv_queue_len = super::MAX_QUIC_DATAGRAM_QUEUE_LEN + 1;
+        let message = error(&config);
+        assert!(message.contains("dgram_recv_queue_len"), "{message}");
+        config.quic.dgram_recv_queue_len = 2_048;
+
+        config.quic.max_connection_window = super::MAX_QUIC_CONNECTION_WINDOW + 1;
+        let message = error(&config);
+        assert!(message.contains("max_connection_window"), "{message}");
+        config.quic.max_connection_window = 24 * 1024 * 1024;
+
+        config.http2.max_concurrent_streams = super::MAX_HTTP2_CONCURRENT_STREAMS + 1;
+        let message = error(&config);
+        assert!(message.contains("max_concurrent_streams"), "{message}");
+        config.http2.max_concurrent_streams = 128;
+
+        config.http2.initial_connection_window = super::MAX_HTTP2_CONNECTION_WINDOW + 1;
+        let message = error(&config);
+        assert!(message.contains("initial_connection_window"), "{message}");
     }
 
     #[test]

--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -19,6 +19,21 @@ use tracing::warn;
 
 use crate::config::TlsSection;
 
+/// Disable TLS 1.3 Early Data on a server context, even if a future quiche
+/// default or refactor starts enabling it elsewhere.
+///
+/// MASQUE CONNECT requests create network side effects and are not replay
+/// safe. Session resumption remains enabled; only 0-RTT application data is
+/// refused, so every CONNECT waits for the peer's Finished message.
+pub(super) fn disable_early_data(builder: &mut SslContextBuilder) {
+    unsafe {
+        // SAFETY: `builder.as_ptr()` is the live, uniquely configured SSL_CTX
+        // owned by this builder. BoringSSL only flips a context boolean and
+        // neither retains the pointer nor transfers ownership.
+        boring_sys::SSL_CTX_set_early_data_enabled(builder.as_ptr(), 0);
+    }
+}
+
 /// One completely parsed and matched server certificate chain and private key.
 ///
 /// Keeping parsed BoringSSL objects rather than file paths is what makes a

--- a/src/tunnel/udp.rs
+++ b/src/tunnel/udp.rs
@@ -334,14 +334,11 @@ impl UdpTunnel {
         #[cfg(target_os = "linux")]
         {
             use std::os::fd::AsRawFd;
-            // SAFETY: The socket is live, connected, and nonblocking.
-            let sent = match unsafe {
-                target_udp::send_mmsg(
-                    self.send_socket.as_raw_fd(),
-                    &self.send_stage[..staged],
-                    self.udp_gso,
-                )
-            } {
+            let sent = match target_udp::send_mmsg(
+                self.send_socket.as_raw_fd(),
+                &self.send_stage[..staged],
+                self.udp_gso,
+            ) {
                 Ok(sent) => sent,
                 Err(error) if self.udp_gso && target_udp::is_udp_gso_error(&error) => {
                     self.udp_gso = false;
@@ -350,15 +347,11 @@ impl UdpTunnel {
                         %error,
                         "target UDP GSO unavailable, falling back to sendmmsg"
                     );
-                    // SAFETY: The socket is still live, connected, and
-                    // nonblocking; no message was accepted on the failed call.
-                    unsafe {
-                        target_udp::send_mmsg(
-                            self.send_socket.as_raw_fd(),
-                            &self.send_stage[..staged],
-                            false,
-                        )
-                    }?
+                    target_udp::send_mmsg(
+                        self.send_socket.as_raw_fd(),
+                        &self.send_stage[..staged],
+                        false,
+                    )?
                 }
                 Err(error) => return Err(error),
             };

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -639,9 +639,12 @@ fn refuses_to_edit_a_file_another_edit_holds() {
         .truncate(false)
         .open(&lock_path)
         .unwrap();
-    // SAFETY: a descriptor this test owns, released when the file is dropped.
     assert_eq!(
-        unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        unsafe {
+            // SAFETY: a descriptor this test owns, released when the file is
+            // dropped.
+            libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB)
+        },
         0
     );
 

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -222,6 +222,17 @@ impl Client {
     }
 
     fn connect_with(peer: SocketAddr, identity: Option<(&Path, &Path)>) -> anyhow::Result<Self> {
+        Self::connect_with_session(peer, identity, None, false)
+    }
+
+    /// Build a resuming client that is willing to send Early Data if the
+    /// server's ticket permits it. Production tickets must never do so.
+    fn connect_with_session(
+        peer: SocketAddr,
+        identity: Option<(&Path, &Path)>,
+        session: Option<&[u8]>,
+        enable_early_data: bool,
+    ) -> anyhow::Result<Self> {
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.connect(peer)?;
         socket.set_read_timeout(Some(Duration::from_millis(50)))?;
@@ -244,6 +255,9 @@ impl Client {
         config.set_initial_max_streams_bidi(16);
         config.set_initial_max_streams_uni(16);
         config.enable_dgram(true, 256, 256);
+        if enable_early_data {
+            config.enable_early_data();
+        }
 
         let mut scid = [0u8; quiche::MAX_CONN_ID_LEN];
         ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut scid)
@@ -251,13 +265,18 @@ impl Client {
 
         // The SNI these clients send names the vendor's endpoint rather than
         // this server, which is exactly why they cannot verify the chain.
-        let quic = quiche::connect(
+        let mut quic = quiche::connect(
             Some("consumer-masque.cloudflareclient.com"),
             &quiche::ConnectionId::from_ref(&scid),
             local,
             peer,
             &mut config,
         )?;
+        if let Some(session) = session {
+            // This is still before the connection has emitted or received a
+            // packet, as required by quiche::Connection::set_session().
+            quic.set_session(session)?;
+        }
 
         Ok(Self {
             socket,
@@ -322,6 +341,19 @@ impl Client {
             }
         }
         anyhow::bail!("handshake timed out")
+    }
+
+    /// Receive the post-handshake session ticket and serialized QUIC transport
+    /// parameters needed to attempt a real resumed connection.
+    fn session(&mut self, timeout: Duration) -> anyhow::Result<Vec<u8>> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            self.drive()?;
+            if let Some(session) = self.quic.session() {
+                return Ok(session.to_vec());
+            }
+        }
+        anyhow::bail!("server did not issue a session ticket within {timeout:?}")
     }
 
     fn peer_certificate_der(&self) -> Vec<u8> {
@@ -1032,6 +1064,46 @@ fn quic_retry_always_completes_a_real_handshake() {
     let stream_id = client.send_connect_ip("connect-ip").unwrap();
     assert_eq!(
         client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+}
+
+/// A real ticket issued by the production TLS context must not allow the
+/// resuming client to construct HTTP/3 before the full handshake. Because
+/// CONNECT, CONNECT-UDP, and CONNECT-IP all enter through that same H3 layer,
+/// this prevents every tunnel kind from executing as replayable Early Data.
+#[test]
+fn session_tickets_never_enable_zero_rtt_connect_requests() {
+    let fixture = fixture("no-zero-rtt");
+    let identity = Some((fixture.client_cert.as_path(), fixture.client_key.as_path()));
+
+    let mut first = Client::connect_with_session(fixture.peer, identity, None, true).unwrap();
+    first.handshake(Duration::from_secs(5)).unwrap();
+    let session = first.session(Duration::from_secs(5)).unwrap();
+
+    let mut resumed =
+        Client::connect_with_session(fixture.peer, identity, Some(&session), true).unwrap();
+    // Emit the resumed Initial. If the ticket advertised 0-RTT, quiche would
+    // now report Early Data and permit H3 request headers to be serialized.
+    resumed.flush().unwrap();
+    assert!(
+        !resumed.quic.is_in_early_data(),
+        "the server's session ticket unexpectedly authorized Early Data"
+    );
+    assert!(
+        resumed.init_h3().is_err(),
+        "HTTP/3 became usable before the full handshake"
+    );
+
+    // Disabling Early Data must not disable ordinary session resumption or
+    // requests after the handshake.
+    resumed.handshake(Duration::from_secs(5)).unwrap();
+    resumed.init_h3().unwrap();
+    let stream_id = resumed.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        resumed
             .response_status(stream_id, Duration::from_secs(5))
             .unwrap(),
         200

--- a/tests/resource_exhaustion.rs
+++ b/tests/resource_exhaustion.rs
@@ -1,0 +1,566 @@
+//! Scheduled Linux pressure verification for externally reachable resource
+//! limits.
+//!
+//! The server runs as a child process so `/proc` measurements include only the
+//! service, not the load generator. The test is ignored in the fast suite and
+//! executed explicitly by scheduled verification (also under ASan).
+
+#![cfg(target_os = "linux")]
+
+use std::future::poll_fn;
+use std::net::{SocketAddr, TcpListener as StdTcpListener, TcpStream as StdTcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use boring::asn1::Asn1Time;
+use boring::bn::BigNum;
+use boring::ec::{EcGroup, EcKey};
+use boring::hash::MessageDigest;
+use boring::nid::Nid;
+use boring::pkey::{PKey, Private};
+use boring::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use boring::x509::{X509Builder, X509NameBuilder};
+use bytes::{Buf as _, Bytes};
+use http::{Method, Request, StatusCode};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::task::JoinSet;
+
+use masque::capsule::encoder;
+
+const MAX_CONNECTIONS_PER_IP: usize = 8;
+const MAX_PENDING_AUTH_PER_IP: u64 = 2;
+const MAX_TUNNELS_PER_CONNECTION: usize = 4;
+const BAD_PASSWORD_ATTEMPTS: usize = 64;
+const STREAM_ATTEMPTS: usize = 128;
+const DATAGRAMS_PER_TUNNEL: usize = 4_096;
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "masque-resource-pressure-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+struct ChildServer(Child);
+
+impl ChildServer {
+    fn pid(&self) -> u32 {
+        self.0.id()
+    }
+}
+
+impl Drop for ChildServer {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn p256_key() -> PKey<Private> {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap()
+}
+
+fn write_identity(dir: &Path) -> (PathBuf, PathBuf) {
+    let key = p256_key();
+    let mut name = X509NameBuilder::new().unwrap();
+    name.append_entry_by_text("CN", "localhost").unwrap();
+    let name = name.build();
+    let mut cert = X509Builder::new().unwrap();
+    cert.set_version(2).unwrap();
+    cert.set_serial_number(&BigNum::from_u32(1).unwrap().to_asn1_integer().unwrap())
+        .unwrap();
+    cert.set_subject_name(&name).unwrap();
+    cert.set_issuer_name(&name).unwrap();
+    cert.set_pubkey(&key).unwrap();
+    cert.set_not_before(&Asn1Time::days_from_now(0).unwrap())
+        .unwrap();
+    cert.set_not_after(&Asn1Time::days_from_now(1).unwrap())
+        .unwrap();
+    cert.sign(&key, MessageDigest::sha256()).unwrap();
+
+    let cert_path = dir.join("server.crt");
+    let key_path = dir.join("server.key");
+    std::fs::write(&cert_path, cert.build().to_pem().unwrap()).unwrap();
+    std::fs::write(&key_path, key.private_key_to_pem_pkcs8().unwrap()).unwrap();
+    (cert_path, key_path)
+}
+
+fn unused_tcp_addr(excluded: &[u16]) -> SocketAddr {
+    loop {
+        let listener = StdTcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        if !excluded.contains(&addr.port()) {
+            return addr;
+        }
+    }
+}
+
+fn write_config(
+    dir: &Path,
+    cert: &Path,
+    key: &Path,
+    basic_addr: SocketAddr,
+    open_addr: SocketAddr,
+    observability_addr: SocketAddr,
+) -> PathBuf {
+    let password_hash = masque::auth::hash_password(b"correct-password").unwrap();
+    let config = format!(
+        r#"[server]
+idle_timeout_secs = 60
+max_connections = 16
+max_connections_per_ip = {MAX_CONNECTIONS_PER_IP}
+max_pending_auth_per_ip = {MAX_PENDING_AUTH_PER_IP}
+max_tunnels_per_connection = {MAX_TUNNELS_PER_CONNECTION}
+
+[tls]
+cert_path = {cert:?}
+key_path = {key:?}
+
+[tcp_proxy]
+enabled = true
+allow_targets = ["127.0.0.0/8"]
+deny_targets = []
+
+[udp_proxy]
+enabled = true
+allow_targets = ["127.0.0.0/8"]
+deny_targets = []
+
+[ip_proxy]
+enabled = false
+
+[observability]
+listen_addr = "{observability_addr}"
+
+[[listeners]]
+listen_addr = "{basic_addr}"
+transport = "http2"
+shards = 1
+
+[listeners.auth]
+enabled = true
+mode = "basic"
+
+[[listeners.auth.users]]
+username = "alice"
+password_hash = {password_hash:?}
+
+[[listeners]]
+listen_addr = "{open_addr}"
+transport = "http2"
+shards = 1
+
+[listeners.auth]
+enabled = false
+mode = "basic"
+"#,
+        cert = cert.display().to_string(),
+        key = key.display().to_string(),
+    );
+    let path = dir.join("masque.toml");
+    std::fs::write(&path, config).unwrap();
+    path
+}
+
+async fn http_get(addr: SocketAddr, path: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(addr).await?;
+    stream
+        .write_all(format!("GET {path} HTTP/1.0\r\n\r\n").as_bytes())
+        .await?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await?;
+    let body = response
+        .windows(4)
+        .position(|bytes| bytes == b"\r\n\r\n")
+        .map(|offset| &response[offset + 4..])
+        .unwrap_or_default();
+    Ok(String::from_utf8_lossy(body).into_owned())
+}
+
+async fn wait_ready(child: &mut Child, addr: SocketAddr) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            panic!("pressure-test server exited during startup: {status}");
+        }
+        if http_get(addr, "/readyz")
+            .await
+            .is_ok_and(|body| body == "ready\n")
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "pressure-test server did not become ready"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn metric_sum(metrics: &str, name: &str, required_labels: &[&str]) -> u64 {
+    metrics
+        .lines()
+        .filter(|line| {
+            (line.starts_with(&format!("{name}{{")) || line.starts_with(&format!("{name} ")))
+                && required_labels.iter().all(|label| line.contains(label))
+        })
+        .filter_map(|line| line.split_ascii_whitespace().nth(1))
+        .map(|value| value.parse::<u64>().unwrap())
+        .sum()
+}
+
+fn process_fd_count(pid: u32) -> usize {
+    std::fs::read_dir(format!("/proc/{pid}/fd"))
+        .unwrap()
+        .count()
+}
+
+fn process_rss_bytes(pid: u32) -> u64 {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    let kib = status
+        .lines()
+        .find_map(|line| line.strip_prefix("VmRSS:"))
+        .and_then(|value| value.split_ascii_whitespace().next())
+        .unwrap()
+        .parse::<u64>()
+        .unwrap();
+    kib * 1024
+}
+
+fn process_cpu_ticks(pid: u32) -> u64 {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+    let after_command = stat.rsplit_once(") ").unwrap().1;
+    let fields: Vec<&str> = after_command.split_ascii_whitespace().collect();
+    // `fields[0]` is process state (field 3); utime/stime are fields 14/15.
+    fields[11].parse::<u64>().unwrap() + fields[12].parse::<u64>().unwrap()
+}
+
+fn clock_ticks_per_second() -> u64 {
+    let output = Command::new("getconf")
+        .arg("CLK_TCK")
+        .output()
+        .expect("getconf CLK_TCK is available on Linux");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap()
+}
+
+async fn connect_h2(
+    addr: SocketAddr,
+) -> (
+    h2::client::SendRequest<Bytes>,
+    tokio::task::JoinHandle<Result<(), h2::Error>>,
+) {
+    let mut connector = SslConnector::builder(SslMethod::tls_client()).unwrap();
+    connector.set_verify(SslVerifyMode::NONE);
+    connector.set_alpn_protos(b"\x02h2").unwrap();
+    let tls = tokio_boring::connect(
+        connector.build().configure().unwrap(),
+        "localhost",
+        TcpStream::connect(addr).await.unwrap(),
+    )
+    .await
+    .unwrap();
+    let (client, connection) = h2::client::handshake(tls).await.unwrap();
+    let driver = tokio::spawn(connection);
+    (client.ready().await.unwrap(), driver)
+}
+
+fn bad_password_request() -> Request<()> {
+    let credentials = STANDARD.encode(b"alice:wrong-password");
+    Request::builder()
+        .method(Method::CONNECT)
+        .uri("127.0.0.1:9")
+        .header("proxy-authorization", format!("Basic {credentials}"))
+        .body(())
+        .unwrap()
+}
+
+fn connect_udp_request(target: SocketAddr) -> Request<()> {
+    let uri = format!(
+        "https://localhost/.well-known/masque/udp/{}/{}/",
+        target.ip(),
+        target.port()
+    );
+    let mut request = Request::builder()
+        .method(Method::CONNECT)
+        .uri(uri)
+        .header("capsule-protocol", "?1")
+        .body(())
+        .unwrap();
+    request
+        .extensions_mut()
+        .insert(h2::ext::Protocol::from_static("connect-udp"));
+    request
+}
+
+async fn send_repeated_capsules(mut stream: h2::SendStream<Bytes>, capsule: Bytes, count: usize) {
+    for _ in 0..count {
+        let mut remaining = capsule.clone();
+        while remaining.has_remaining() {
+            stream.reserve_capacity(remaining.remaining());
+            let capacity = tokio::time::timeout(
+                Duration::from_secs(5),
+                poll_fn(|cx| stream.poll_capacity(cx)),
+            )
+            .await
+            .expect("HTTP/2 flow control stalled")
+            .expect("CONNECT-UDP stream closed")
+            .expect("HTTP/2 flow control failed");
+            let chunk = remaining.split_to(capacity.min(remaining.remaining()));
+            stream.send_data(chunk, false).unwrap();
+        }
+    }
+    stream.send_data(Bytes::new(), true).unwrap();
+}
+
+async fn wait_for_metric_zero(addr: SocketAddr, name: &str) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let metrics = http_get(addr, "/metrics").await.unwrap();
+        if metric_sum(&metrics, name, &[]) == 0 {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{name} did not return to zero"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "scheduled Linux resource pressure verification"]
+async fn hostile_inputs_stay_inside_cpu_memory_and_fd_bounds() {
+    let directory = TempDir::new();
+    let (cert, key) = write_identity(directory.path());
+    let basic_addr = unused_tcp_addr(&[]);
+    let open_addr = unused_tcp_addr(&[basic_addr.port()]);
+    let observability_addr = unused_tcp_addr(&[basic_addr.port(), open_addr.port()]);
+    let config = write_config(
+        directory.path(),
+        &cert,
+        &key,
+        basic_addr,
+        open_addr,
+        observability_addr,
+    );
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_masque-server"))
+        .arg("--config")
+        .arg(config)
+        .env("RUST_LOG", "error")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_ready(&mut child, observability_addr).await;
+    let server = ChildServer(child);
+    let pid = server.pid();
+    let baseline_fds = process_fd_count(pid);
+    let baseline_rss = process_rss_bytes(pid);
+    let mut peak_fds = baseline_fds;
+    let mut peak_rss = baseline_rss;
+
+    // Raw TCP peers that never send a ClientHello occupy a bounded number of
+    // handshake tasks and descriptors; excess sockets are accepted then
+    // dropped immediately by source admission.
+    let half_open: Vec<_> = (0..64)
+        .filter_map(|_| StdTcpStream::connect(basic_addr).ok())
+        .collect();
+    assert!(half_open.len() >= MAX_CONNECTIONS_PER_IP);
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    peak_fds = peak_fds.max(process_fd_count(pid));
+    peak_rss = peak_rss.max(process_rss_bytes(pid));
+    let metrics = http_get(observability_addr, "/metrics").await.unwrap();
+    let basic_label = format!("listener=\"{basic_addr}\"");
+    assert!(
+        metric_sum(&metrics, "masque_connections_active_max", &[&basic_label])
+            <= MAX_CONNECTIONS_PER_IP as u64
+    );
+    assert!(
+        metric_sum(
+            &metrics,
+            "masque_connections_rejected_total",
+            &[&basic_label]
+        ) > 0,
+        "half-open excess was not load-shed"
+    );
+    drop(half_open);
+    wait_for_metric_zero(observability_addr, "masque_connections_active").await;
+
+    // All requests are launched together. Per-source admission permits only
+    // two Argon2 jobs; the rest must fail fast instead of becoming a CPU and
+    // memory backlog.
+    let (client, driver) = connect_h2(basic_addr).await;
+    let cpu_before = process_cpu_ticks(pid);
+    let mut attempts = JoinSet::new();
+    for _ in 0..BAD_PASSWORD_ATTEMPTS {
+        let sender = client.clone();
+        attempts.spawn(async move {
+            let mut sender = sender.ready().await.unwrap();
+            let (response, _) = sender.send_request(bad_password_request(), true).unwrap();
+            tokio::time::timeout(Duration::from_secs(10), response)
+                .await
+                .unwrap()
+                .unwrap()
+                .status()
+        });
+    }
+    let mut unauthorized = 0;
+    let mut overloaded = 0;
+    while let Some(result) = attempts.join_next().await {
+        match result.unwrap() {
+            StatusCode::PROXY_AUTHENTICATION_REQUIRED => unauthorized += 1,
+            StatusCode::SERVICE_UNAVAILABLE => overloaded += 1,
+            status => panic!("unexpected bad-password response {status}"),
+        }
+        peak_fds = peak_fds.max(process_fd_count(pid));
+        peak_rss = peak_rss.max(process_rss_bytes(pid));
+    }
+    assert!(unauthorized > 0 && overloaded > 0);
+    let cpu_ticks = process_cpu_ticks(pid) - cpu_before;
+    assert!(
+        cpu_ticks <= clock_ticks_per_second() * 5,
+        "bad-password flood consumed {cpu_ticks} CPU ticks"
+    );
+    let metrics = http_get(observability_addr, "/metrics").await.unwrap();
+    assert!(
+        metric_sum(&metrics, "masque_auth_pending_max", &[&basic_label]) <= MAX_PENDING_AUTH_PER_IP
+    );
+    assert!(
+        metric_sum(&metrics, "masque_auth_running_max", &[&basic_label]) <= MAX_PENDING_AUTH_PER_IP
+    );
+    assert!(
+        metric_sum(
+            &metrics,
+            "masque_auth_attempts_total",
+            &[&basic_label, "result=\"overloaded\""]
+        ) > 0
+    );
+    drop(client);
+    driver.abort();
+    wait_for_metric_zero(observability_addr, "masque_connections_active").await;
+
+    // Open far more streams than the tunnel cap, keep every admitted tunnel
+    // alive, then push thousands of DATAGRAM capsules through each one.
+    let target = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_drain = tokio::spawn(async move {
+        let mut buf = [0_u8; 2048];
+        while target.recv_from(&mut buf).await.is_ok() {}
+    });
+    let (open_client, open_driver) = connect_h2(open_addr).await;
+    let mut requests = Vec::with_capacity(STREAM_ATTEMPTS);
+    for _ in 0..STREAM_ATTEMPTS {
+        let mut sender = open_client.clone().ready().await.unwrap();
+        requests.push(
+            sender
+                .send_request(connect_udp_request(target_addr), false)
+                .unwrap(),
+        );
+    }
+    let mut tunnels = Vec::new();
+    for (response, request_body) in requests {
+        let response = tokio::time::timeout(Duration::from_secs(10), response)
+            .await
+            .unwrap()
+            .unwrap();
+        match response.status() {
+            StatusCode::OK => tunnels.push(request_body),
+            StatusCode::SERVICE_UNAVAILABLE => {}
+            status => panic!("unexpected stream-flood response {status}"),
+        }
+    }
+    assert_eq!(tunnels.len(), MAX_TUNNELS_PER_CONNECTION);
+    peak_fds = peak_fds.max(process_fd_count(pid));
+    peak_rss = peak_rss.max(process_rss_bytes(pid));
+    let open_label = format!("listener=\"{open_addr}\"");
+    let metrics = http_get(observability_addr, "/metrics").await.unwrap();
+    assert_eq!(
+        metric_sum(
+            &metrics,
+            "masque_tunnels_active_max",
+            &[&open_label, "protocol=\"udp\""]
+        ),
+        MAX_TUNNELS_PER_CONNECTION as u64
+    );
+
+    let mut capsule = Vec::new();
+    encoder::encode_datagram_context_zero(&[0x5a; 256], &mut capsule);
+    let capsule = Bytes::from(capsule);
+    let mut senders = JoinSet::new();
+    for tunnel in tunnels {
+        let capsule = capsule.clone();
+        senders.spawn(send_repeated_capsules(
+            tunnel,
+            capsule,
+            DATAGRAMS_PER_TUNNEL,
+        ));
+    }
+    while let Some(result) = senders.join_next().await {
+        result.unwrap();
+        peak_fds = peak_fds.max(process_fd_count(pid));
+        peak_rss = peak_rss.max(process_rss_bytes(pid));
+    }
+    drop(open_client);
+    open_driver.abort();
+    target_drain.abort();
+    wait_for_metric_zero(observability_addr, "masque_connections_active").await;
+
+    // Descriptor usage is explained entirely by the source-connection and
+    // per-connection tunnel caps, plus fixed listeners/runtime descriptors.
+    let fd_budget = baseline_fds + MAX_CONNECTIONS_PER_IP + MAX_TUNNELS_PER_CONNECTION + 8;
+    assert!(
+        peak_fds <= fd_budget,
+        "server FD peak {peak_fds} exceeded baseline {baseline_fds} + bounded budget"
+    );
+
+    // Two Argon2id verifications account for roughly 38 MiB. Leave generous
+    // room for allocator and ASan quarantine overhead while still detecting a
+    // queued-hash or unbounded-frame regression. CI may raise this explicit
+    // delta for a sanitizer runtime without weakening the structural gauges.
+    let rss_delta_limit_mib = std::env::var("MASQUE_RESOURCE_RSS_DELTA_MIB")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(256);
+    let rss_delta = peak_rss.saturating_sub(baseline_rss);
+    assert!(
+        rss_delta <= rss_delta_limit_mib * 1024 * 1024,
+        "server RSS grew from {baseline_rss} to {peak_rss} bytes"
+    );
+
+    eprintln!(
+        "resource-pressure summary: bad-password unauthorized={unauthorized} overloaded={overloaded} cpu_ticks={cpu_ticks}; fd baseline={baseline_fds} peak={peak_fds} limit={fd_budget}; RSS baseline={baseline_rss} peak={peak_rss} delta={rss_delta} limit={} bytes; admitted_tunnels={MAX_TUNNELS_PER_CONNECTION} datagrams_per_tunnel={DATAGRAMS_PER_TUNNEL}",
+        rss_delta_limit_mib * 1024 * 1024
+    );
+}

--- a/tools/masque-e2e/Cargo.toml
+++ b/tools/masque-e2e/Cargo.toml
@@ -2,6 +2,14 @@
 name = "masque-e2e"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
+description = "End-to-end and benchmark client for masque-server development"
+license = "MIT"
+repository = "https://github.com/Vincent-bin/masque-server"
+publish = false
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "masque-e2e"

--- a/tools/masque-probe/Cargo.toml
+++ b/tools/masque-probe/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "masque-probe"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.88"
 description = "End-to-end connectivity diagnostics for MASQUE proxies"
 license = "MIT"
 repository = "https://github.com/Vincent-bin/masque-server"
 publish = false
+
+[lints]
+workspace = true
 
 [[bin]]
 name = "masque-probe"


### PR DESCRIPTION
## Summary

- explicitly disable TLS 1.3 Early Data and add a real resumed-session regression test for CONNECT requests
- cap attacker-controlled connection, tunnel, flow-control, stream, and queue resources; expose high-water metrics
- audit Linux packet-path unsafe boundaries and enforce workspace unsafe lints
- add pinned dependency security checks, GNU ASan verification, and an isolated resource-pressure suite
- prepare the `0.11.0` release metadata

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.88.0 check --workspace --all-targets --locked`
- `cargo test --workspace --release --locked`
- `cargo audit` (no known vulnerabilities; documented allowed `paste` maintenance warning through `tun-rs`)
- `cargo deny check advisories bans licenses sources`
- GNU AddressSanitizer packet-path, zero-RTT, and resource-pressure tests
- Linux production A/B benchmark: 64-byte throughput +1.4% to +1.9%; 1200-byte throughput +0.9% to +1.4%; no CPU or connection-rate regression
