### PR TITLE
fix: support musl UDP control length types

### DIFF
--- a/src/net/quic.rs
+++ b/src/net/quic.rs
@@ -598,6 +598,12 @@ fn gro_segment_size(header: &libc::msghdr) -> Option<usize> {
     unsafe {
         let control = libc::CMSG_FIRSTHDR(header);
         let required = libc::CMSG_LEN(std::mem::size_of::<u16>() as _) as usize;
+        // libc models socklen_t as u32 for musl and usize for glibc. Keep the
+        // conversion explicit only where the source type actually differs so
+        // both static release builds and the GNU Clippy gate agree.
+        #[cfg(target_env = "musl")]
+        let control_len = header.msg_controllen as usize;
+        #[cfg(not(target_env = "musl"))]
         let control_len = header.msg_controllen;
         if control.is_null()
             || control_len < required


### PR DESCRIPTION
## Summary

- keep `msghdr.msg_controllen` conversion portable across glibc (`usize`) and musl (`u32`)
- unblock the static x86_64 and ARM64 Linux release packages without suppressing the GNU Clippy gate

## Validation

- `cargo +1.97.1 fmt --all --check`
- `cargo +1.97.1 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.97.1 test --locked net::quic::tests`
- packaged `x86_64-unknown-linux-musl`; archive checksum passed and binaries are static x86-64 ELF
- packaged `aarch64-unknown-linux-musl`; archive checksum passed and binaries are static ARM64 ELF
