### PR TITLE
feat: support QUIC connection migration for v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.12.0 - 2026-09-01
+
+### Added
+
+- HTTP/3 connections survive validated client source-address and NAT port
+  migration. Each connection maintains one bounded spare CID, retires its CID
+  routes with quiche, transfers per-source admission only after PATH_RESPONSE,
+  and exports low-cardinality path and cross-shard forwarding metrics.
+- The E2E client verifies an established CONNECT-UDP tunnel across a real UDP
+  socket replacement. Linux coverage also verifies CID-based SO_REUSEPORT
+  steering and checks that migration cannot bypass per-source connection caps;
+  `MASQUE_BENCH_MIGRATED=1` measures the post-migration steady state.
+
+### Changed
+
+- Wrong-shard QUIC packets from one kernel receive round are forwarded as a
+  batch while a packet-count semaphore preserves the previous bounded-memory
+  limit.
+- Multi-shard Linux listeners encode a listener-local socket index in one byte
+  of each server CID and attach a classic reuseport BPF selector. Migrated
+  packets therefore stay on their connection-owning shard; the bounded shared
+  registry remains as a compatibility fallback when steering is unavailable.
+
 ## 0.11.0 - 2026-09-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-probe"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ undocumented_unsafe_blocks = "deny"
 
 [package]
 name = "masque-server"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ a staging environment.
 - CIDR allow and deny policies for TCP and UDP targets
 - Adaptive QUIC Retry plus process-wide per-source connection and Basic-auth
   admission limits
+- QUIC NAT rebinding and validated client-address migration without dropping
+  established HTTP/3 tunnels
 - Bounded queues and backpressure across authentication and tunnel I/O
 - Linux `recvmmsg`/`sendmmsg`, UDP GRO, optional UDP GSO, and TUN offload
-- Multi-core sharding with `SO_REUSEPORT`
+- Multi-core sharding with Linux `SO_REUSEPORT` CID steering
 - Optional loopback health/readiness endpoints and low-overhead Prometheus
   metrics, with packaged static alert rules and a Grafana dashboard JSON
 - Optional JSON logs plus native systemd readiness and shard-liveness watchdog

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,11 +139,30 @@ listener's UDP address using `SO_REUSEPORT`. The kernel normally keeps a client
 4-tuple on one of them. An HTTP/2 listener must use `shards = 1`; its one TCP
 accept loop dispatches connections across the Tokio runtime instead.
 
-QUIC permits address migration, so a packet can arrive on a shard that does
-not own its connection. A shared connection-ID registry identifies the owner,
-and the receiving shard forwards the packet through a bounded channel. TUN
-input uses the same ownership model. This keeps connection state single-owner
-without dropping legitimate migration traffic.
+QUIC permits address migration, so its UDP four-tuple is not a stable shard
+key. On a multi-shard Linux listener, the server reserves the first byte of its
+16-byte CIDs for the listener-local socket index and attaches a classic
+reuseport BPF selector. Both long- and short-header packets then return directly
+to the connection-owning socket after migration; the remaining 120 random bits
+keep CIDs impractical to predict.
+
+A shared connection-ID registry remains the correctness fallback when kernel
+steering is unavailable or a packet reaches the wrong shard. The receiving
+shard forwards that receive round through a bounded channel. The channel is
+admission-controlled by packet count rather than batch count, so coalescing
+wakeups does not enlarge its worst-case memory. TUN input uses the same
+ownership model. Connection state therefore stays single-owner without making
+migration depend on a particular Linux kernel capability.
+
+After the handshake, the server advertises one spare connection ID. A client
+can therefore move to a replacement source address without reusing the CID
+visible on the old path. Every active server CID maps to the same shard-owned
+connection; retired IDs are removed and replenished. quiche validates a new
+path with PATH_CHALLENGE/PATH_RESPONSE before the server transfers its
+per-source admission guard or reports `PeerMigrated`. A source at its configured
+connection limit cannot receive a migrated connection. Migration is an HTTP/3
+capability on one listener endpoint; HTTP/2 remains tied to its TCP connection,
+and switching server listeners creates a new connection.
 
 One HTTP/3 connection still uses one shard. Sharding improves aggregate
 throughput across multiple connections; it cannot parallelize a single QUIC

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -100,6 +100,10 @@ All metric names start with `masque_`.
 | `masque_connections_accepted_total` | counter | `listener`, `transport`, `auth` | Accepted connection objects |
 | `masque_connections_rejected_total` | counter | `listener`, `transport`, `auth`, `reason` | Connections rejected at a resource limit |
 | `masque_quic_retries_total` | counter | `listener`, `transport`, `auth`, `result` | Retry packets sent or invalid Retry tokens received |
+| `masque_quic_path_events_total` | counter | `listener`, `transport`, `auth`, `event` | QUIC path discovery, validation, failure, closure, CID reuse, and completed peer migration events |
+| `masque_quic_path_migrations_rejected_total` | counter | `listener`, `transport`, `auth`, `reason` | Validated migrations refused by the new source's resource limit |
+| `masque_quic_cross_shard_forwarded_packets_total` | counter | `listener`, `transport`, `auth` | QUIC packets delivered through the userspace wrong-shard fallback; normally zero with Linux CID steering |
+| `masque_quic_cross_shard_forwarded_bytes_total` | counter | `listener`, `transport`, `auth` | Bytes delivered through the userspace wrong-shard fallback |
 | `masque_quic_receive_batches_total` | counter | `listener`, `transport`, `auth` | Non-empty HTTP/3 network receive batches |
 | `masque_quic_receive_packets_total` | counter | `listener`, `transport`, `auth` | Received HTTP/3 QUIC UDP datagrams |
 | `masque_quic_receive_bytes_total` | counter | `listener`, `transport`, `auth` | Received HTTP/3 QUIC UDP bytes |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -179,6 +179,16 @@ Use `MASQUE_BENCH_QUIC_GSO=0|1` for the outer QUIC socket and
 updates during an A/B run; the default `0` measures the uninstrumented packet
 path.
 
+For HTTP/3 migration A/B testing, run the same UDP command once normally and
+once with `MASQUE_BENCH_MIGRATED=1`. The latter replaces the client's UDP
+socket after CONNECT-UDP setup, waits for the new path to validate, and labels
+machine-readable results as `path=masque_migrated`. Compare medians from at
+least three alternating runs; the unchanged-path run detects ordinary hot-path
+regressions, while the migrated run verifies Linux CID-based SO_REUSEPORT
+steering keeps the steady-state path on its original shard. A non-zero
+`masque_quic_cross_shard_forwarded_packets_total` identifies use of the bounded
+userspace fallback.
+
 CONNECT-TCP alternates a direct origin download with each proxy sample by
 default, then prints the median throughput and proxy/direct ratio. Set
 `MASQUE_TCP_DIRECT_BASELINE=0` only when the benchmark host intentionally

--- a/docs/security.md
+++ b/docs/security.md
@@ -84,6 +84,18 @@ binds the source IP and listener but not the source port, so normal NAT remaps
 do not break it. Use `retry_mode = "always"` where spoofed floods are a primary
 risk; it costs one extra handshake round trip.
 
+An established HTTP/3 connection may move to a new peer IP or UDP port. quiche
+does not report the migration until PATH_CHALLENGE/PATH_RESPONSE proves return
+routability. Only then does the server atomically transfer the connection's
+per-source admission guard; if the new source is already at its limit, the
+connection closes and the original counter remains balanced. Each connection
+advertises only one spare CID and retains only a bounded path-challenge queue,
+so source-port churn cannot create unbounded routing or validation state.
+Multi-shard Linux listeners reserve one of the 16 CID bytes for kernel socket
+selection; the other 15 bytes remain keyed or randomly generated, retaining
+120 bits of unpredictability. Failure to attach the selector changes only
+performance: the bounded userspace ownership map still routes valid packets.
+
 The optional operational endpoint has no authentication and therefore accepts
 only loopback addresses. It must stay host-local: use a local collector or a
 secure tunnel instead of forwarding `/metrics` to a public interface. Metric

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -155,8 +155,17 @@ truncated.
 
 `cargo test --test client_cert_connect_ip` covers the handshake, the
 `cf-connect-ip` request, pinned address assignment, reconnect overlap, datagram
-sizing, and rejection of unenrolled keys — all against a synthetic client that
-imitates this family. It runs anywhere.
+sizing, rejection of unenrolled keys, and a real QUIC source-port migration —
+all against a synthetic client that imitates this family. It runs anywhere.
+On Linux the same target also changes the peer IP, verifies migration cannot
+bypass `max_connections_per_ip`, proves long- and short-header CIDs select the
+intended SO_REUSEPORT socket, and confirms migrated connections do not enter
+the userspace cross-shard fallback.
+
+The general E2E client keeps an established CONNECT-UDP stream open while it
+replaces its UDP socket when `MASQUE_MIGRATION_CHECK=1`. Add
+`MASQUE_BENCH_MIGRATED=1` to its normal `MASQUE_BENCH=1` invocation to run the
+64-byte and 1200-byte measurements only after that path has validated.
 
 What it cannot cover is packet forwarding, because that needs a TUN device.
 Qualifying a real client therefore needs a Linux host with root. Two clients are

--- a/scripts/network-bench.sh
+++ b/scripts/network-bench.sh
@@ -245,6 +245,17 @@ case "$BENCH_MODE" in
             MASQUE_PASSWORD=test-password \
             RUST_LOG=warn \
             target/release/masque-e2e
+
+            if [ "$transport" = http3 ]; then
+                MASQUE_MIGRATION_CHECK=1 \
+                MASQUE_BENCH_TRANSPORT=http3 \
+                MASQUE_SERVER_ADDR=127.0.0.1:4433 \
+                ECHO_SERVER_ADDR=127.0.0.1:9999 \
+                MASQUE_USERNAME=test \
+                MASQUE_PASSWORD=test-password \
+                RUST_LOG=warn \
+                target/release/masque-e2e
+            fi
         done
         ;;
 esac

--- a/src/admission.rs
+++ b/src/admission.rs
@@ -60,6 +60,44 @@ impl SourceAdmission {
     pub(crate) fn source(&self) -> IpAddr {
         self.source
     }
+
+    /// Move a live admission to a newly validated source address.
+    ///
+    /// QUIC can keep one transport connection alive while its peer address
+    /// changes. Updating both counters under the same lock prevents a
+    /// migration from temporarily escaping the per-source bound, and leaves
+    /// the original admission untouched when the destination source is full.
+    pub(crate) fn try_rebind(&mut self, source: IpAddr) -> bool {
+        let source = canonical_ip(source);
+        if source == self.source {
+            return true;
+        }
+
+        let mut counts = self
+            .inner
+            .counts
+            .lock()
+            .expect("source admissions poisoned");
+        if !counts.get(&self.source).is_some_and(|count| *count > 0) {
+            debug_assert!(false, "live source admission has no counter");
+            return false;
+        }
+        if counts.get(&source).copied().unwrap_or_default() >= self.inner.max_per_ip {
+            return false;
+        }
+
+        *counts.entry(source).or_default() += 1;
+        let previous = counts
+            .get_mut(&self.source)
+            .expect("live source admission checked above");
+        *previous -= 1;
+        let remove_previous = *previous == 0;
+        if remove_previous {
+            counts.remove(&self.source);
+        }
+        self.source = source;
+        true
+    }
 }
 
 impl Drop for SourceAdmission {
@@ -119,5 +157,36 @@ mod tests {
         let _first = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
         let mapped = "::ffff:192.0.2.1".parse::<IpAddr>().unwrap();
         assert!(limiter.try_acquire(mapped).is_none());
+    }
+
+    #[test]
+    fn live_admission_rebinds_atomically() {
+        let limiter = SourceAdmissionLimiter::new(1);
+        let mut admission = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+
+        assert!(admission.try_rebind("192.0.2.2".parse().unwrap()));
+        assert_eq!(admission.source(), "192.0.2.2".parse::<IpAddr>().unwrap());
+        assert!(limiter.try_acquire("192.0.2.1".parse().unwrap()).is_some());
+        assert!(limiter.try_acquire("192.0.2.2".parse().unwrap()).is_none());
+    }
+
+    #[test]
+    fn rejected_rebind_keeps_the_original_admission() {
+        let limiter = SourceAdmissionLimiter::new(1);
+        let mut admission = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+        let _occupied = limiter.try_acquire("192.0.2.2".parse().unwrap()).unwrap();
+
+        assert!(!admission.try_rebind("192.0.2.2".parse().unwrap()));
+        assert_eq!(admission.source(), "192.0.2.1".parse::<IpAddr>().unwrap());
+        assert!(limiter.try_acquire("192.0.2.1".parse().unwrap()).is_none());
+    }
+
+    #[test]
+    fn rebind_canonicalizes_ipv4_mapped_ipv6() {
+        let limiter = SourceAdmissionLimiter::new(1);
+        let mut admission = limiter.try_acquire("192.0.2.1".parse().unwrap()).unwrap();
+
+        assert!(admission.try_rebind("::ffff:192.0.2.1".parse().unwrap()));
+        assert_eq!(admission.source(), "192.0.2.1".parse::<IpAddr>().unwrap());
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -119,8 +119,16 @@ pub struct ClientConnection {
     /// The deadline this connection currently holds in the server's timer
     /// queue, used to tell a live wakeup from one a later deadline superseded.
     pub(crate) scheduled_deadline: Option<std::time::Instant>,
-    /// Releases this source's process-wide connection admission on drop.
-    _source_admission: SourceAdmission,
+    /// Tracks the currently validated peer in the process-wide source budget
+    /// and releases it on drop.
+    source_admission: SourceAdmission,
+    /// Server-issued wire connection IDs that currently route to this
+    /// connection. The initial entry is also the shard's stable internal map
+    /// key; later IDs let a peer move paths without reusing a linkable CID.
+    server_connection_ids: Vec<quiche::ConnectionId<'static>>,
+    /// The stable map key cannot be removed when the peer retires its wire CID,
+    /// so remember whether it is still valid for packet demultiplexing.
+    primary_connection_id_active: bool,
     metrics: Arc<ShardMetrics>,
     published_tunnels: [usize; 3],
 }
@@ -131,6 +139,7 @@ impl ClientConnection {
         index: u64,
         metrics: Arc<ShardMetrics>,
         source_admission: SourceAdmission,
+        initial_connection_id: quiche::ConnectionId<'static>,
     ) -> Self {
         metrics.connection_opened();
         Self {
@@ -146,14 +155,48 @@ impl ClientConnection {
             identity: None,
             deferred_send: DeferredSend::default(),
             scheduled_deadline: None,
-            _source_admission: source_admission,
+            source_admission,
+            server_connection_ids: vec![initial_connection_id],
+            primary_connection_id_active: true,
             metrics,
             published_tunnels: [0; 3],
         }
     }
 
     pub(crate) fn source_ip(&self) -> std::net::IpAddr {
-        self._source_admission.source()
+        self.source_admission.source()
+    }
+
+    /// Transfer this connection's source budget after QUIC validates a new
+    /// peer path. A failed transfer leaves the old admission in place.
+    pub(crate) fn rebind_source_ip(&mut self, source: std::net::IpAddr) -> bool {
+        self.source_admission.try_rebind(source)
+    }
+
+    pub(crate) fn publish_connection_id(&mut self, id: quiche::ConnectionId<'static>) {
+        debug_assert!(!self.server_connection_ids.contains(&id));
+        self.server_connection_ids.push(id);
+    }
+
+    pub(crate) fn retire_connection_id(&mut self, id: &quiche::ConnectionId<'_>) {
+        if self.primary_connection_id_active
+            && self
+                .server_connection_ids
+                .first()
+                .is_some_and(|primary| primary.as_ref() == id.as_ref())
+        {
+            self.primary_connection_id_active = false;
+        }
+        self.server_connection_ids
+            .retain(|published| published.as_ref() != id.as_ref());
+    }
+
+    pub(crate) fn connection_ids(&self) -> &[quiche::ConnectionId<'static>] {
+        &self.server_connection_ids
+    }
+
+    pub(crate) fn primary_connection_id_active(&self) -> bool {
+        self.primary_connection_id_active
     }
 
     /// The next instant this connection needs the event loop's attention:

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -386,6 +386,46 @@ impl ListenerMetrics {
             )
             .unwrap();
         }
+        for (event, field) in [
+            (
+                "new",
+                (|shard: &ShardMetrics| &shard.quic_path_new) as fn(&ShardMetrics) -> &AtomicU64,
+            ),
+            ("validated", |shard| &shard.quic_path_validated),
+            ("failed_validation", |shard| {
+                &shard.quic_path_failed_validation
+            }),
+            ("closed", |shard| &shard.quic_path_closed),
+            ("reused_source_cid", |shard| {
+                &shard.quic_path_reused_source_cid
+            }),
+            ("peer_migrated", |shard| &shard.quic_path_peer_migrated),
+        ] {
+            writeln!(
+                out,
+                "masque_quic_path_events_total{{{label},event=\"{event}\"}} {}",
+                self.sum(field)
+            )
+            .unwrap();
+        }
+        writeln!(
+            out,
+            "masque_quic_path_migrations_rejected_total{{{label},reason=\"source_limit\"}} {}",
+            self.sum(|shard| &shard.quic_migration_source_limit)
+        )
+        .unwrap();
+        render_value(
+            out,
+            "masque_quic_cross_shard_forwarded_packets_total",
+            label,
+            self.sum(|shard| &shard.quic_cross_shard_forwarded_packets),
+        );
+        render_value(
+            out,
+            "masque_quic_cross_shard_forwarded_bytes_total",
+            label,
+            self.sum(|shard| &shard.quic_cross_shard_forwarded_bytes),
+        );
         for (name, field) in [
             (
                 "masque_quic_receive_batches_total",
@@ -521,6 +561,15 @@ pub(crate) struct ShardMetrics {
     connections_rejected_source_limit: AtomicU64,
     quic_retries_sent: AtomicU64,
     quic_retries_invalid: AtomicU64,
+    quic_path_new: AtomicU64,
+    quic_path_validated: AtomicU64,
+    quic_path_failed_validation: AtomicU64,
+    quic_path_closed: AtomicU64,
+    quic_path_reused_source_cid: AtomicU64,
+    quic_path_peer_migrated: AtomicU64,
+    quic_migration_source_limit: AtomicU64,
+    quic_cross_shard_forwarded_packets: AtomicU64,
+    quic_cross_shard_forwarded_bytes: AtomicU64,
     quic_receive_batches: AtomicU64,
     quic_receive_packets: AtomicU64,
     quic_receive_bytes: AtomicU64,
@@ -560,6 +609,15 @@ impl ShardMetrics {
             connections_rejected_source_limit: AtomicU64::new(0),
             quic_retries_sent: AtomicU64::new(0),
             quic_retries_invalid: AtomicU64::new(0),
+            quic_path_new: AtomicU64::new(0),
+            quic_path_validated: AtomicU64::new(0),
+            quic_path_failed_validation: AtomicU64::new(0),
+            quic_path_closed: AtomicU64::new(0),
+            quic_path_reused_source_cid: AtomicU64::new(0),
+            quic_path_peer_migrated: AtomicU64::new(0),
+            quic_migration_source_limit: AtomicU64::new(0),
+            quic_cross_shard_forwarded_packets: AtomicU64::new(0),
+            quic_cross_shard_forwarded_bytes: AtomicU64::new(0),
             quic_receive_batches: AtomicU64::new(0),
             quic_receive_packets: AtomicU64::new(0),
             quic_receive_bytes: AtomicU64::new(0),
@@ -652,6 +710,37 @@ impl ShardMetrics {
         if self.enabled {
             self.quic_retries_invalid.fetch_add(1, RELAXED);
         }
+    }
+
+    pub(crate) fn record_quic_path_event(&self, event: &quiche::PathEvent) {
+        if !self.enabled {
+            return;
+        }
+        let counter = match event {
+            quiche::PathEvent::New(..) => &self.quic_path_new,
+            quiche::PathEvent::Validated(..) => &self.quic_path_validated,
+            quiche::PathEvent::FailedValidation(..) => &self.quic_path_failed_validation,
+            quiche::PathEvent::Closed(..) => &self.quic_path_closed,
+            quiche::PathEvent::ReusedSourceConnectionId(..) => &self.quic_path_reused_source_cid,
+            quiche::PathEvent::PeerMigrated(..) => &self.quic_path_peer_migrated,
+        };
+        counter.fetch_add(1, RELAXED);
+    }
+
+    pub(crate) fn record_quic_migration_source_limit(&self) {
+        if self.enabled {
+            self.quic_migration_source_limit.fetch_add(1, RELAXED);
+        }
+    }
+
+    pub(crate) fn record_cross_shard_forward(&self, packets: usize, bytes: usize) {
+        if !self.enabled || packets == 0 {
+            return;
+        }
+        self.quic_cross_shard_forwarded_packets
+            .fetch_add(packets as u64, RELAXED);
+        self.quic_cross_shard_forwarded_bytes
+            .fetch_add(bytes as u64, RELAXED);
     }
 
     #[inline]
@@ -750,11 +839,11 @@ impl ShardMetrics {
         GaugeGuard::new(Arc::clone(self), Gauge::AuthRunning)
     }
 
-    pub(crate) fn record_shard_queue_drop(&self) {
-        if !self.enabled {
+    pub(crate) fn record_shard_queue_drop(&self, packets: usize) {
+        if !self.enabled || packets == 0 {
             return;
         }
-        self.dropped_shard_queue.fetch_add(1, RELAXED);
+        self.dropped_shard_queue.fetch_add(packets as u64, RELAXED);
     }
 
     pub(crate) fn record_datagram_queue_drop(&self, packets: usize) {
@@ -901,6 +990,26 @@ fn render_listener_headers(out: &mut String) {
             "counter",
         ),
         (
+            "masque_quic_path_events_total",
+            "QUIC peer-path discovery, validation, and migration events.",
+            "counter",
+        ),
+        (
+            "masque_quic_path_migrations_rejected_total",
+            "Validated QUIC peer migrations rejected by a resource bound.",
+            "counter",
+        ),
+        (
+            "masque_quic_cross_shard_forwarded_packets_total",
+            "QUIC packets forwarded to the shard that owns their connection ID.",
+            "counter",
+        ),
+        (
+            "masque_quic_cross_shard_forwarded_bytes_total",
+            "QUIC bytes forwarded to the shard that owns their connection ID.",
+            "counter",
+        ),
+        (
             "masque_quic_receive_batches_total",
             "Kernel receive batches containing QUIC packets.",
             "counter",
@@ -1026,6 +1135,17 @@ mod tests {
         listener.connection_rejected_source_limit();
         listener.record_quic_retries_sent(2);
         listener.record_quic_retry_invalid();
+        listener.record_quic_path_event(&quiche::PathEvent::New(
+            "127.0.0.1:8449".parse().unwrap(),
+            "192.0.2.1:50000".parse().unwrap(),
+        ));
+        listener.record_quic_path_event(&quiche::PathEvent::PeerMigrated(
+            "127.0.0.1:8449".parse().unwrap(),
+            "192.0.2.2:50001".parse().unwrap(),
+        ));
+        listener.record_quic_migration_source_limit();
+        listener.record_cross_shard_forward(3, 3600);
+        listener.record_shard_queue_drop(2);
         listener.record_tcp_relay_batch(4, 256 * 1024);
         listener.update_tunnels([0, 0, 0], [1, 2, 1]);
         listener.record_auth_success();
@@ -1072,6 +1192,21 @@ mod tests {
         ));
         assert!(rendered.contains(
             "masque_quic_retries_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",result=\"invalid\"} 1"
+        ));
+        assert!(rendered.contains(
+            "masque_quic_path_events_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",event=\"peer_migrated\"} 1"
+        ));
+        assert!(rendered.contains(
+            "masque_quic_path_migrations_rejected_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",reason=\"source_limit\"} 1"
+        ));
+        assert!(rendered.contains(
+            "masque_quic_cross_shard_forwarded_packets_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 3"
+        ));
+        assert!(rendered.contains(
+            "masque_quic_cross_shard_forwarded_bytes_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\"} 3600"
+        ));
+        assert!(rendered.contains(
+            "masque_packets_dropped_total{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",reason=\"shard_queue\"} 2"
         ));
         assert!(rendered.contains(
             "masque_tunnels_active{listener=\"127.0.0.1:8449\",transport=\"http3\",auth=\"basic\",protocol=\"udp\"} 2"

--- a/src/net/quic.rs
+++ b/src/net/quic.rs
@@ -268,6 +268,68 @@ pub(crate) struct QuicUdpSocket {
     socket: UdpSocket,
     udp_gso: bool,
     udp_gro: bool,
+    reuseport_cid_steering: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn bpf_statement(code: u32, value: u32) -> libc::sock_filter {
+    libc::sock_filter {
+        code: code as u16,
+        jt: 0,
+        jf: 0,
+        k: value,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn bpf_jump(code: u32, value: u32, jump_true: u8, jump_false: u8) -> libc::sock_filter {
+    libc::sock_filter {
+        code: code as u16,
+        jt: jump_true,
+        jf: jump_false,
+        k: value,
+    }
+}
+
+/// Route a QUIC packet to the socket index encoded in the first byte of its
+/// destination CID. The UDP reuseport hook sees transport payload bytes:
+/// short-header DCIDs start at byte 1, while long-header DCIDs start at byte 6.
+#[cfg(target_os = "linux")]
+fn attach_reuseport_cid_selector(fd: std::os::fd::RawFd, shards: usize) -> io::Result<()> {
+    debug_assert!(shards > 1 && shards <= u8::MAX as usize);
+
+    let mut filter = [
+        // A = first QUIC header byte.
+        bpf_statement(libc::BPF_LD | libc::BPF_B | libc::BPF_ABS, 0),
+        // Header Form is the high bit. Long headers load byte 6; short
+        // headers skip to byte 1.
+        bpf_jump(libc::BPF_JMP | libc::BPF_JSET | libc::BPF_K, 0x80, 0, 2),
+        bpf_statement(libc::BPF_LD | libc::BPF_B | libc::BPF_ABS, 6),
+        bpf_jump(libc::BPF_JMP | libc::BPF_JA, 1, 0, 0),
+        bpf_statement(libc::BPF_LD | libc::BPF_B | libc::BPF_ABS, 1),
+        bpf_statement(libc::BPF_ALU | libc::BPF_MOD | libc::BPF_K, shards as u32),
+        bpf_statement(libc::BPF_RET | libc::BPF_A, 0),
+    ];
+    let program = libc::sock_fprog {
+        len: filter.len() as u16,
+        filter: filter.as_mut_ptr(),
+    };
+
+    // SAFETY: `program` points to a live, verifier-safe classic BPF program
+    // for the duration of setsockopt, and `fd` is a live reuseport UDP socket.
+    let result = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_ATTACH_REUSEPORT_CBPF,
+            (&program as *const libc::sock_fprog).cast(),
+            std::mem::size_of_val(&program) as libc::socklen_t,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /// Bind a UDP socket, optionally with `SO_REUSEPORT` so several sockets can
@@ -277,7 +339,7 @@ pub(crate) struct QuicUdpSocket {
 /// The option has to be set between `socket()` and `bind()`, which
 /// `UdpSocket::bind` does not expose, so this goes through the raw syscalls.
 #[cfg(target_os = "linux")]
-fn bind_reuseport(addr: SocketAddr) -> io::Result<std::net::UdpSocket> {
+fn bind_reuseport(addr: SocketAddr, shards: usize) -> io::Result<(std::net::UdpSocket, bool)> {
     use std::os::fd::FromRawFd;
 
     let domain = match addr {
@@ -332,26 +394,35 @@ fn bind_reuseport(addr: SocketAddr) -> io::Result<std::net::UdpSocket> {
         return Err(io::Error::last_os_error());
     }
 
-    Ok(socket)
+    let cid_steering = match attach_reuseport_cid_selector(fd, shards) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(%error, shards, "QUIC CID reuseport steering unavailable; using cross-shard fallback");
+            false
+        }
+    };
+
+    Ok((socket, cid_steering))
 }
 
 impl QuicUdpSocket {
     /// Bind one socket for a server shard.
     ///
-    /// With `reuseport`, several shards bind the same address and the kernel
-    /// hashes each 4-tuple to one of them, so a client's packets consistently
-    /// reach the same shard until it migrates.
+    /// With more than one `reuseport_shards`, several sockets bind the same
+    /// address. Linux steers QUIC packets by the shard byte encoded in the
+    /// destination CID, so a changed four-tuple still reaches its owner.
     pub(crate) async fn bind_shared(
         addr: SocketAddr,
         max_segment_size: usize,
         enable_gso: bool,
         enable_gro: bool,
-        reuseport: bool,
+        reuseport_shards: usize,
     ) -> io::Result<Self> {
-        let socket = if reuseport {
+        let (socket, reuseport_cid_steering) = if reuseport_shards > 1 {
             #[cfg(target_os = "linux")]
             {
-                UdpSocket::from_std(bind_reuseport(addr)?)?
+                let (socket, cid_steering) = bind_reuseport(addr, reuseport_shards)?;
+                (UdpSocket::from_std(socket)?, cid_steering)
             }
             #[cfg(not(target_os = "linux"))]
             {
@@ -361,7 +432,7 @@ impl QuicUdpSocket {
                 ));
             }
         } else {
-            UdpSocket::bind(addr).await?
+            (UdpSocket::bind(addr).await?, false)
         };
 
         #[cfg(target_os = "linux")]
@@ -385,6 +456,7 @@ impl QuicUdpSocket {
             socket,
             udp_gso,
             udp_gro,
+            reuseport_cid_steering,
         })
     }
 
@@ -398,6 +470,10 @@ impl QuicUdpSocket {
 
     pub(crate) fn udp_gro_enabled(&self) -> bool {
         self.udp_gro
+    }
+
+    pub(crate) fn reuseport_cid_steering_enabled(&self) -> bool {
+        self.reuseport_cid_steering
     }
 
     #[cfg(target_os = "linux")]
@@ -958,7 +1034,7 @@ mod tests {
         let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let target = receiver.local_addr().unwrap();
         let mut sender =
-            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, true, true, false)
+            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, true, true, 1)
                 .await
                 .unwrap();
 
@@ -983,7 +1059,7 @@ mod tests {
         let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let target = receiver.local_addr().unwrap();
         let mut sender =
-            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, false, false, false)
+            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, false, false, 1)
                 .await
                 .unwrap();
 
@@ -1016,17 +1092,17 @@ mod tests {
         assert!(seen.into_iter().all(|received| received));
     }
 
-    /// Connection sharding is only worth anything if the kernel actually
-    /// spreads distinct 4-tuples across the sockets sharing the port. If this
-    /// fails, every shard but one would sit idle.
+    /// Established packets must follow their encoded CID shard after their
+    /// four-tuple changes. Cover both QUIC header forms because handshake
+    /// packets use the long offset before 1-RTT switches to the short one.
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn reuseport_spreads_source_ports_across_sockets() {
+    async fn reuseport_routes_long_and_short_headers_by_destination_cid() {
         const SHARDS: usize = 4;
-        const SENDERS: usize = 64;
+        const PACKETS_PER_HEADER: usize = 8;
 
         let first =
-            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, false, false, true)
+            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, false, false, SHARDS)
                 .await
                 .unwrap();
         let target = first.local_addr().unwrap();
@@ -1034,55 +1110,72 @@ mod tests {
         let mut shards = vec![first];
         for _ in 1..SHARDS {
             shards.push(
-                QuicUdpSocket::bind_shared(target, 1350, false, false, true)
+                QuicUdpSocket::bind_shared(target, 1350, false, false, SHARDS)
                     .await
                     .unwrap(),
             );
         }
+        assert!(
+            shards
+                .iter()
+                .all(QuicUdpSocket::reuseport_cid_steering_enabled)
+        );
 
-        // Each sender gets its own ephemeral port, so each is a distinct
-        // 4-tuple for the kernel to hash.
-        for _ in 0..SENDERS {
-            let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-            sender.send_to(b"shard probe", target).await.unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        for shard in 0..SHARDS {
+            for sequence in 0..PACKETS_PER_HEADER {
+                let mut short = [0u8; 16];
+                short[0] = 0x40;
+                short[1] = shard as u8;
+                short[2] = sequence as u8;
+                sender.send_to(&short, target).await.unwrap();
+
+                let mut long = [0u8; 16];
+                long[0] = 0xc0;
+                long[6] = shard as u8;
+                long[7] = sequence as u8;
+                sender.send_to(&long, target).await.unwrap();
+            }
         }
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
-        let mut used = 0;
         let mut delivered = 0;
-        for shard in &shards {
-            let mut batch = RecvPacketBatch::new(SENDERS);
-            match tokio::time::timeout(
+        for (expected_shard, shard) in shards.iter().enumerate() {
+            let mut batch = RecvPacketBatch::new(PACKETS_PER_HEADER * 2);
+            let received = tokio::time::timeout(
                 std::time::Duration::from_millis(200),
                 shard.recv_batch(&mut batch),
             )
             .await
-            {
-                Ok(Ok(received)) if received > 0 => {
-                    used += 1;
-                    batch.for_each_packet_mut(received, |_, _| delivered += 1);
-                }
-                _ => {}
-            }
+            .unwrap()
+            .unwrap();
+            let mut shard_delivered = 0;
+            batch.for_each_packet_mut(received, |packet, _| {
+                let encoded_shard = if packet[0] & 0x80 == 0 {
+                    packet[1]
+                } else {
+                    packet[6]
+                };
+                assert_eq!(encoded_shard as usize, expected_shard);
+                shard_delivered += 1;
+            });
+            assert_eq!(shard_delivered, PACKETS_PER_HEADER * 2);
+            delivered += shard_delivered;
         }
 
-        assert_eq!(delivered, SENDERS, "every datagram should reach some shard");
-        assert!(
-            used > 1,
-            "expected the kernel to use more than one of {SHARDS} shards, used {used}"
-        );
+        assert_eq!(delivered, SHARDS * PACKETS_PER_HEADER * 2);
     }
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn recvmmsg_and_gro_restore_logical_packets() {
         let receiver =
-            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, true, true, false)
+            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, true, true, 1)
                 .await
                 .unwrap();
         let target = receiver.local_addr().unwrap();
         let mut sender =
-            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, true, true, false)
+            QuicUdpSocket::bind_shared("127.0.0.1:0".parse().unwrap(), 1350, true, true, 1)
                 .await
                 .unwrap();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use std::sync::{Mutex, RwLock};
 
 use anyhow::Context as _;
-use tokio::sync::{Semaphore, watch};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
 
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
@@ -96,6 +96,18 @@ const MAX_SHARDS: usize = 32;
 
 /// Queue depth for packets handed between shards.
 const SHARD_FORWARD_QUEUE_CAPACITY: usize = 1024;
+
+/// Keep one active and one spare connection ID. Sequential migrations can
+/// replenish the spare after retirement without letting CID routing state
+/// grow with attacker-controlled path churn.
+const ACTIVE_CONNECTION_ID_LIMIT: u64 = 2;
+
+/// Bound unacknowledged PATH_CHALLENGEs retained by quiche per connection.
+const PATH_CHALLENGE_RECV_QUEUE_LEN: usize = 3;
+
+/// Private application error used when an otherwise valid peer migration
+/// would exceed the process-wide connection cap for its new source address.
+const MIGRATION_SOURCE_LIMIT_ERROR: u64 = 0x0101;
 
 /// Queue depth for completed credential verifications.
 const AUTH_RESULT_QUEUE_CAPACITY: usize = 256;
@@ -830,14 +842,14 @@ fn config_reload_settings(
 async fn open_quic_socket(
     config: &ServerConfig,
     listen_addr: SocketAddr,
-    reuseport: bool,
+    reuseport_shards: usize,
 ) -> anyhow::Result<QuicUdpSocket> {
     QuicUdpSocket::bind_shared(
         listen_addr,
         config.quic.max_datagram_size,
         config.quic.enable_udp_gso,
         config.quic.enable_udp_gro,
-        reuseport,
+        reuseport_shards,
     )
     .await
     .with_context(|| format!("failed to bind listener {listen_addr}"))
@@ -852,11 +864,11 @@ async fn open_quic_socket(
 async fn bind_first_listener_socket(
     config: &ServerConfig,
     requested: SocketAddr,
-    reuseport: bool,
+    reuseport_shards: usize,
     unavailable: &[SocketAddr],
 ) -> anyhow::Result<(QuicUdpSocket, SocketAddr)> {
     for attempt in 1..=MAX_EPHEMERAL_BIND_ATTEMPTS {
-        let socket = open_quic_socket(config, requested, reuseport).await?;
+        let socket = open_quic_socket(config, requested, reuseport_shards).await?;
         let bound = socket.local_addr()?;
 
         if requested.port() != 0 {
@@ -944,12 +956,14 @@ impl Server {
         // know which listener that owner belongs to.
         let mut forward_tx = Vec::with_capacity(total_shards);
         let mut forward_rx = Vec::with_capacity(total_shards);
+        let mut forward_slots = Vec::with_capacity(total_shards);
         let mut tun_tx = Vec::with_capacity(total_shards);
         let mut tun_rx = Vec::with_capacity(total_shards);
         for _ in 0..total_shards {
             let (tx, rx) = mpsc::channel(SHARD_FORWARD_QUEUE_CAPACITY);
             forward_tx.push(tx);
             forward_rx.push(rx);
+            forward_slots.push(Arc::new(Semaphore::new(SHARD_FORWARD_QUEUE_CAPACITY)));
             let (tx, rx) = mpsc::channel(SHARD_FORWARD_QUEUE_CAPACITY);
             tun_tx.push(tx);
             tun_rx.push(rx);
@@ -979,6 +993,7 @@ impl Server {
             ),
             tun,
             forward_tx,
+            forward_slots,
             tun_tx,
             auth_permits: Arc::new(Semaphore::new(auth_concurrency(basic_shards))),
             auth_queue_slots: Arc::new(Semaphore::new(MAX_PENDING_AUTH_GLOBAL)),
@@ -1030,18 +1045,13 @@ impl Server {
                 continue;
             }
 
-            // SO_REUSEPORT is what lets one listener's shards share an address.
-            // A single-shard listener must not set it, or a later listener that
-            // was misconfigured onto the same address could join its group.
-            let reuseport = plan.listener.shards > 1;
-
             // Bind `:0` only once, then use the assigned address for every
             // remaining shard. Asking the kernel for `:0` independently would
             // split one logical listener across unrelated ports.
             let (first_socket, bound_addr) = bind_first_listener_socket(
                 &config,
                 plan.listener.listen_addr,
-                reuseport,
+                plan.listener.shards,
                 &unavailable_http3_addrs,
             )
             .await?;
@@ -1067,6 +1077,7 @@ impl Server {
                 .expect("one inbox pair was created per planned shard");
             shards.push(Shard::from_socket(
                 shards.len(),
+                0,
                 Arc::clone(&shared),
                 Arc::clone(&config),
                 plan.listener.clone(),
@@ -1077,18 +1088,19 @@ impl Server {
                 tun_rx,
             )?);
 
-            for shard_metrics in listener_metrics.iter().skip(1) {
+            for (listener_shard_index, shard_metrics) in listener_metrics.iter().enumerate().skip(1)
+            {
                 let (forward_rx, tun_rx) = inboxes
                     .next()
                     .expect("one inbox pair was created per planned shard");
                 shards.push(
                     Shard::bind(
                         shards.len(),
+                        listener_shard_index,
                         Arc::clone(&shared),
                         Arc::clone(&config),
                         plan.listener.clone(),
                         listener_auth.as_ref().map(Arc::clone),
-                        reuseport,
                         Arc::clone(shard_metrics),
                         forward_rx,
                         tun_rx,
@@ -1733,6 +1745,14 @@ fn build_quic_config(
     quic_config.set_initial_max_streams_uni(100);
     quic_config.set_max_connection_window(config.quic.max_connection_window);
     quic_config.set_max_stream_window(config.quic.max_stream_window);
+    // Keep peer-address migration an explicit, tested part of the transport
+    // contract rather than inheriting whatever a future quiche default does.
+    // One spare CID is enough for a client to validate a replacement path;
+    // retired IDs are replenished while the connection is alive.
+    quic_config.set_disable_active_migration(false);
+    quic_config.set_active_connection_id_limit(ACTIVE_CONNECTION_ID_LIMIT);
+    quic_config.set_disable_dcid_reuse(false);
+    quic_config.set_path_challenge_recv_max_queue_len(PATH_CHALLENGE_RECV_QUEUE_LEN);
     quic_config.enable_pacing(true);
     quic_config.discover_pmtu(config.quic.discover_pmtu);
 
@@ -1898,6 +1918,39 @@ struct ForwardedPacket {
     from: SocketAddr,
 }
 
+/// A receive batch handed to the shard that owns its connection IDs.
+///
+/// `_slots` accounts every packet rather than every channel item, preserving
+/// the original queue's memory bound after packets are coalesced into batches.
+struct ForwardedPacketBatch {
+    packets: Vec<ForwardedPacket>,
+    bytes: usize,
+    _slots: OwnedSemaphorePermit,
+}
+
+#[derive(Default)]
+struct PendingForwardBatch {
+    packets: Vec<ForwardedPacket>,
+    bytes: usize,
+}
+
+impl PendingForwardBatch {
+    fn push(&mut self, packet: &[u8], from: SocketAddr) {
+        self.bytes += packet.len();
+        self.packets.push(ForwardedPacket {
+            data: packet.to_vec(),
+            from,
+        });
+    }
+}
+
+struct PacketOutput<'a> {
+    stateless: &'a mut [u8],
+    stateless_batch: &'a mut SendPacketBatch,
+    stateless_retries: &'a mut usize,
+    forward_batches: &'a mut [PendingForwardBatch],
+}
+
 /// Immutable facts that govern SIGHUP reloads.
 struct ConfigReload {
     path: std::path::PathBuf,
@@ -1945,8 +1998,8 @@ struct ReloadListener {
 ///
 /// None of it is on the per-packet path: the pool and routing table are touched
 /// only when a CONNECT-IP tunnel opens or closes or when a TUN packet needs an
-/// owner, and the ownership maps only when a connection is created, destroyed,
-/// or has migrated to a different shard's socket.
+/// owner, and the ownership maps only when a connection is created or
+/// destroyed, or one of its connection IDs is published or retired.
 struct Shared {
     address_pool: Mutex<AddressPool>,
     routing_table: RwLock<RoutingTable>,
@@ -1983,7 +2036,10 @@ struct Shared {
     /// Shared TUN device for CONNECT-IP tunnels (None if IP proxy disabled).
     tun: Option<TunManager>,
     /// Inbox per shard for packets forwarded after a migration.
-    forward_tx: Vec<mpsc::Sender<ForwardedPacket>>,
+    forward_tx: Vec<mpsc::Sender<ForwardedPacketBatch>>,
+    /// Packet-count permits for each forward inbox. Batching changes the
+    /// number of channel items but must not increase queued packet memory.
+    forward_slots: Vec<Arc<Semaphore>>,
     /// Inbox per shard for TUN packets belonging to its connections.
     tun_tx: Vec<mpsc::Sender<Vec<u8>>>,
     /// Bounds how many password verifications run at once.
@@ -2022,14 +2078,25 @@ struct Shared {
 }
 
 impl Shared {
-    fn record_shard_queue_drop(&self, shard: usize) {
+    fn record_shard_queue_drop(&self, shard: usize, packets: usize) {
         if let Some(metrics) = self
             .shard_metrics
             .read()
             .expect("shard metrics list poisoned")
             .get(shard)
         {
-            metrics.record_shard_queue_drop();
+            metrics.record_shard_queue_drop(packets);
+        }
+    }
+
+    fn record_cross_shard_forward(&self, shard: usize, packets: usize, bytes: usize) {
+        if let Some(metrics) = self
+            .shard_metrics
+            .read()
+            .expect("shard metrics list poisoned")
+            .get(shard)
+        {
+            metrics.record_cross_shard_forward(packets, bytes);
         }
     }
 
@@ -2076,6 +2143,9 @@ impl Shared {
 /// One shard: an independent event loop over its own share of connections.
 struct Shard {
     index: usize,
+    /// Listener-local socket index encoded into server CIDs on a reuseport
+    /// listener. `None` keeps all 128 CID bits random for a single shard.
+    reuseport_index: Option<u8>,
     shared: Arc<Shared>,
     /// Counters owned by this shard and aggregated per listener while scraping.
     metrics: Arc<ShardMetrics>,
@@ -2083,6 +2153,9 @@ struct Shard {
     quic_config: quiche::Config,
     h3_config: quiche::h3::Config,
     connections: FxHashMap<quiche::ConnectionId<'static>, ClientConnection>,
+    /// Additional server-issued CIDs mapped back to the stable connection-map
+    /// key. The initial CID stays on the one-lookup hot path above.
+    connection_id_aliases: FxHashMap<quiche::ConnectionId<'static>, quiche::ConnectionId<'static>>,
     auth: Option<Arc<SharedBasicAuthenticator>>,
     /// Set when clients authenticate with a certificate instead of credentials.
     ///
@@ -2101,7 +2174,7 @@ struct Shard {
     udp_setup_rx: mpsc::Receiver<UdpSetupResult>,
     tcp_event_tx: mpsc::Sender<TcpRelayEvent>,
     tcp_event_rx: mpsc::Receiver<TcpRelayEvent>,
-    forward_rx: mpsc::Receiver<ForwardedPacket>,
+    forward_rx: mpsc::Receiver<ForwardedPacketBatch>,
     tun_rx: mpsc::Receiver<Vec<u8>>,
     auth_tx: mpsc::Sender<AuthOutcome>,
     auth_rx: mpsc::Receiver<AuthOutcome>,
@@ -2116,18 +2189,27 @@ impl Shard {
     #[allow(clippy::too_many_arguments)]
     async fn bind(
         index: usize,
+        listener_shard_index: usize,
         shared: Arc<Shared>,
         config: Arc<ServerConfig>,
         listener: ResolvedListener,
         auth: Option<Arc<SharedBasicAuthenticator>>,
-        reuseport: bool,
         metrics: Arc<ShardMetrics>,
-        forward_rx: mpsc::Receiver<ForwardedPacket>,
+        forward_rx: mpsc::Receiver<ForwardedPacketBatch>,
         tun_rx: mpsc::Receiver<Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        let socket = open_quic_socket(&config, listener.listen_addr, reuseport).await?;
+        let socket = open_quic_socket(&config, listener.listen_addr, listener.shards).await?;
         Self::from_socket(
-            index, shared, config, listener, auth, socket, metrics, forward_rx, tun_rx,
+            index,
+            listener_shard_index,
+            shared,
+            config,
+            listener,
+            auth,
+            socket,
+            metrics,
+            forward_rx,
+            tun_rx,
         )
     }
 
@@ -2139,22 +2221,35 @@ impl Shard {
     #[allow(clippy::too_many_arguments)]
     fn from_socket(
         index: usize,
+        listener_shard_index: usize,
         shared: Arc<Shared>,
         config: Arc<ServerConfig>,
         listener: ResolvedListener,
         auth: Option<Arc<SharedBasicAuthenticator>>,
         socket: QuicUdpSocket,
         metrics: Arc<ShardMetrics>,
-        forward_rx: mpsc::Receiver<ForwardedPacket>,
+        forward_rx: mpsc::Receiver<ForwardedPacketBatch>,
         tun_rx: mpsc::Receiver<Vec<u8>>,
     ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            listener_shard_index < listener.shards,
+            "listener shard index {listener_shard_index} is outside {} shards",
+            listener.shards
+        );
+        let reuseport_index = if listener.shards > 1 {
+            Some(u8::try_from(listener_shard_index).context("listener shard index exceeds u8")?)
+        } else {
+            None
+        };
         let bound_addr = socket.local_addr()?;
         metrics.set_udp_offload_state(socket.udp_gso_enabled(), socket.udp_gro_enabled());
         info!(
             shard = index,
+            listener_shard = listener_shard_index,
             addr = %bound_addr,
             udp_gso = socket.udp_gso_enabled(),
             udp_gro = socket.udp_gro_enabled(),
+            reuseport_cid_steering = socket.reuseport_cid_steering_enabled(),
             "listening"
         );
 
@@ -2188,12 +2283,14 @@ impl Shard {
 
         Ok(Self {
             index,
+            reuseport_index,
             shared,
             metrics,
             socket,
             quic_config,
             h3_config,
             connections: FxHashMap::default(),
+            connection_id_aliases: FxHashMap::default(),
             auth,
             client_certs,
             tcp_policy,
@@ -2225,6 +2322,9 @@ impl Shard {
         let mut send_batch = SendPacketBatch::new();
         let mut stateless_out = vec![0u8; MAX_DATAGRAM_SIZE];
         let mut stateless_batch = SendPacketBatch::new();
+        let mut forward_batches: Vec<PendingForwardBatch> = (0..self.shared.forward_tx.len())
+            .map(|_| PendingForwardBatch::default())
+            .collect();
         // One shard reads the shared TUN device and hands each packet to the
         // connection that owns its address. Shard 0 is an arbitrary but stable
         // choice; nothing here depends on which listener that shard serves.
@@ -2253,6 +2353,10 @@ impl Shard {
             self.dirty.end_round();
             serviced.clear();
             stateless_batch.clear();
+            for batch in &mut forward_batches {
+                debug_assert!(batch.packets.is_empty());
+                debug_assert_eq!(batch.bytes, 0);
+            }
             let mut stateless_retries = 0usize;
 
             // Wake for the earliest connection deadline rather than scanning
@@ -2277,7 +2381,7 @@ impl Shard {
                 TcpRelay(Option<TcpRelayEvent>),
                 TunPacket(std::io::Result<usize>),
                 /// A QUIC packet another shard received for one of ours.
-                Forwarded(Option<ForwardedPacket>),
+                Forwarded(Option<ForwardedPacketBatch>),
                 /// A TUN packet another shard read for one of our tunnels.
                 TunInbound(Option<Vec<u8>>),
                 /// Credentials finished verifying off the event loop.
@@ -2352,26 +2456,37 @@ impl Shard {
                 Event::PacketBatch(Ok(received)) => {
                     let mut packet_count = 0usize;
                     let mut byte_count = 0usize;
+                    let mut packet_output = PacketOutput {
+                        stateless: &mut stateless_out,
+                        stateless_batch: &mut stateless_batch,
+                        stateless_retries: &mut stateless_retries,
+                        forward_batches: &mut forward_batches,
+                    };
                     recv_batch.for_each_packet_mut(received, |packet, from| {
                         packet_count += 1;
                         byte_count += packet.len();
                         if !shutting_down {
-                            self.handle_packet(
-                                packet,
-                                from,
-                                local_addr,
-                                &mut stateless_out,
-                                &mut stateless_batch,
-                                &mut stateless_retries,
-                            );
+                            self.handle_packet(packet, from, local_addr, &mut packet_output);
                             return;
                         }
 
                         // During shutdown, still feed packets to quiche so it
                         // can send CONNECTION_CLOSE frames.
-                        if let Ok(hdr) = quiche::Header::from_slice(packet, CONN_ID_LEN)
-                            && let Some(client) = self.connections.get_mut(&hdr.dcid)
-                        {
+                        if let Ok(hdr) = quiche::Header::from_slice(packet, CONN_ID_LEN) {
+                            let key = if let Some((id, client)) =
+                                self.connections.get_key_value(&hdr.dcid)
+                                && client.primary_connection_id_active()
+                            {
+                                Some(id.clone())
+                            } else {
+                                self.connection_id_aliases.get(&hdr.dcid).cloned()
+                            };
+                            let Some(key) = key else {
+                                return;
+                            };
+                            let Some(client) = self.connections.get_mut(&key) else {
+                                return;
+                            };
                             let recv_info = quiche::RecvInfo {
                                 from,
                                 to: local_addr,
@@ -2413,15 +2528,29 @@ impl Shard {
                 Event::TunPacket(Err(e)) => {
                     error!(%e, "TUN recv error");
                 }
-                Event::Forwarded(Some(mut packet)) => {
-                    self.handle_packet(
-                        &mut packet.data,
-                        packet.from,
-                        local_addr,
-                        &mut stateless_out,
-                        &mut stateless_batch,
-                        &mut stateless_retries,
+                Event::Forwarded(Some(mut batch)) => {
+                    debug_assert_eq!(
+                        batch.bytes,
+                        batch
+                            .packets
+                            .iter()
+                            .map(|packet| packet.data.len())
+                            .sum::<usize>()
                     );
+                    let mut packet_output = PacketOutput {
+                        stateless: &mut stateless_out,
+                        stateless_batch: &mut stateless_batch,
+                        stateless_retries: &mut stateless_retries,
+                        forward_batches: &mut forward_batches,
+                    };
+                    for packet in &mut batch.packets {
+                        self.handle_packet(
+                            &mut packet.data,
+                            packet.from,
+                            local_addr,
+                            &mut packet_output,
+                        );
+                    }
                 }
                 Event::Forwarded(None) => {}
                 Event::TunInbound(Some(packet)) => {
@@ -2434,6 +2563,8 @@ impl Shard {
                 Event::AuthDone(None) => {}
                 Event::Timeout => {}
             }
+
+            self.flush_forward_batches(&mut forward_batches);
 
             if !stateless_batch.is_empty() {
                 let udp_gso_before_send = self.socket.udp_gso_enabled();
@@ -2537,11 +2668,16 @@ impl Shard {
                             );
                     }
                     self.conn_by_index.remove(&client.index);
-                    self.shared
+                    let mut cid_routes = self
+                        .shared
                         .cid_shard
                         .write()
-                        .expect("cid ownership poisoned")
-                        .remove(&id);
+                        .expect("cid ownership poisoned");
+                    for connection_id in client.connection_ids() {
+                        cid_routes.remove(connection_id);
+                        self.connection_id_aliases.remove(connection_id);
+                    }
+                    drop(cid_routes);
                     self.shared
                         .index_shard
                         .write()
@@ -2629,19 +2765,168 @@ impl Shard {
         destination: &quiche::ConnectionId<'_>,
     ) -> quiche::ConnectionId<'static> {
         let signed = ring::hmac::sign(&self.shared.conn_id_key, destination);
-        quiche::ConnectionId::from_vec(signed.as_ref()[..CONN_ID_LEN].to_vec())
+        let mut id = signed.as_ref()[..CONN_ID_LEN].to_vec();
+        if let Some(index) = self.reuseport_index {
+            id[0] = index;
+        }
+        quiche::ConnectionId::from_vec(id)
     }
 
-    fn forward_packet(&self, shard: usize, packet: &[u8], from: SocketAddr) {
-        let forwarded = ForwardedPacket {
-            data: packet.to_vec(),
-            from,
-        };
-        // Dropping under pressure is what the network would have done; QUIC
-        // retransmits without making this unbounded cross-shard state.
-        if self.shared.forward_tx[shard].try_send(forwarded).is_err() {
-            self.shared.record_shard_queue_drop(shard);
-            debug!(shard, "shard forward queue full, dropping packet");
+    /// Apply edge-triggered path notifications after a successful receive.
+    /// `PeerMigrated` is emitted by quiche only after PATH_RESPONSE validated
+    /// the replacement path, so it is the first safe point to move IP-based
+    /// resource accounting.
+    fn handle_path_events(metrics: &ShardMetrics, client: &mut ClientConnection) -> bool {
+        while let Some(event) = client.quic.path_event_next() {
+            metrics.record_quic_path_event(&event);
+            match event {
+                quiche::PathEvent::PeerMigrated(_local, peer) => {
+                    if !client.rebind_source_ip(peer.ip()) {
+                        metrics.record_quic_migration_source_limit();
+                        warn!(
+                            connection_index = client.index,
+                            "closing migrated connection at source connection limit"
+                        );
+                        let _ = client.quic.close(
+                            true,
+                            MIGRATION_SOURCE_LIMIT_ERROR,
+                            b"migration source limit",
+                        );
+                        return false;
+                    }
+                    info!(connection_index = client.index, "QUIC peer path migrated");
+                }
+                quiche::PathEvent::FailedValidation(..) => {
+                    debug!(
+                        connection_index = client.index,
+                        "QUIC peer path validation failed"
+                    );
+                }
+                quiche::PathEvent::ReusedSourceConnectionId(..) => {
+                    debug!(
+                        connection_index = client.index,
+                        "peer reused a source connection ID on another path"
+                    );
+                }
+                quiche::PathEvent::New(..)
+                | quiche::PathEvent::Validated(..)
+                | quiche::PathEvent::Closed(..) => {}
+            }
+        }
+        true
+    }
+
+    /// Remove retired server CIDs and keep one spare available for a client
+    /// that wants to migrate without reusing the ID visible on its old path.
+    fn sync_connection_ids(
+        shared: &Shared,
+        shard: usize,
+        reuseport_index: Option<u8>,
+        aliases: &mut FxHashMap<quiche::ConnectionId<'static>, quiche::ConnectionId<'static>>,
+        primary: &quiche::ConnectionId<'static>,
+        client: &mut ClientConnection,
+    ) {
+        let mut retired = Vec::new();
+        while let Some(id) = client.quic.retired_scid_next() {
+            retired.push(id);
+        }
+        if !retired.is_empty() {
+            let mut routes = shared.cid_shard.write().expect("cid ownership poisoned");
+            for id in retired {
+                routes.remove(&id);
+                aliases.remove(&id);
+                client.retire_connection_id(&id);
+            }
+        }
+
+        if !client.quic.is_established() {
+            return;
+        }
+
+        while client.quic.scids_left() > 0 {
+            let mut random = [0u8; CONN_ID_LEN + 16];
+            if ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut random)
+                .is_err()
+            {
+                warn!(
+                    connection_index = client.index,
+                    "cannot generate spare QUIC connection ID"
+                );
+                return;
+            }
+            if let Some(index) = reuseport_index {
+                random[0] = index;
+            }
+            let id = quiche::ConnectionId::from_vec(random[..CONN_ID_LEN].to_vec());
+            let reset_token = u128::from_be_bytes(
+                random[CONN_ID_LEN..]
+                    .try_into()
+                    .expect("reset token has a fixed 16-byte slice"),
+            );
+
+            let mut routes = shared.cid_shard.write().expect("cid ownership poisoned");
+            if routes.contains_key(&id) {
+                continue;
+            }
+            if let Err(error) = client.quic.new_scid(&id, reset_token, false) {
+                debug!(
+                    connection_index = client.index,
+                    %error,
+                    "cannot publish spare QUIC connection ID"
+                );
+                return;
+            }
+            routes.insert(id.clone(), shard);
+            drop(routes);
+            aliases.insert(id.clone(), primary.clone());
+            client.publish_connection_id(id);
+        }
+    }
+
+    fn queue_forward_packet(
+        &self,
+        shard: usize,
+        packet: &[u8],
+        from: SocketAddr,
+        batches: &mut [PendingForwardBatch],
+    ) {
+        if let Some(batch) = batches.get_mut(shard) {
+            batch.push(packet, from);
+        }
+    }
+
+    /// Publish at most one channel item per destination shard for this receive
+    /// round while preserving the original packet-count queue bound.
+    fn flush_forward_batches(&self, batches: &mut [PendingForwardBatch]) {
+        for (shard, pending) in batches.iter_mut().enumerate() {
+            if pending.packets.is_empty() {
+                continue;
+            }
+
+            let packets = pending.packets.len();
+            let bytes = pending.bytes;
+            let slots = Arc::clone(&self.shared.forward_slots[shard]);
+            let Ok(slots) = slots.try_acquire_many_owned(packets as u32) else {
+                pending.packets.clear();
+                pending.bytes = 0;
+                self.shared.record_shard_queue_drop(shard, packets);
+                debug!(shard, packets, "shard forward queue full, dropping batch");
+                continue;
+            };
+
+            let batch = ForwardedPacketBatch {
+                packets: std::mem::take(&mut pending.packets),
+                bytes,
+                _slots: slots,
+            };
+            pending.bytes = 0;
+            if self.shared.forward_tx[shard].try_send(batch).is_err() {
+                self.shared.record_shard_queue_drop(shard, packets);
+                debug!(shard, packets, "shard forward inbox full, dropping batch");
+                continue;
+            }
+            self.shared
+                .record_cross_shard_forward(shard, packets, bytes);
         }
     }
 
@@ -2670,9 +2955,7 @@ impl Shard {
         buf: &mut [u8],
         from: SocketAddr,
         local: SocketAddr,
-        stateless_out: &mut [u8],
-        stateless_batch: &mut SendPacketBatch,
-        stateless_retries: &mut usize,
+        output: &mut PacketOutput<'_>,
     ) {
         let hdr = match quiche::Header::from_slice(buf, CONN_ID_LEN) {
             Ok(v) => v,
@@ -2685,7 +2968,11 @@ impl Shard {
         // Established packets carry the server-issued CID and take this fast
         // path without hashing. If migration made the packet land on another
         // SO_REUSEPORT shard, the shared ownership map names the right inbox.
-        let key = if let Some((conn_id, _)) = self.connections.get_key_value(&hdr.dcid) {
+        let key = if let Some((conn_id, client)) = self.connections.get_key_value(&hdr.dcid)
+            && client.primary_connection_id_active()
+        {
+            conn_id.clone()
+        } else if let Some(conn_id) = self.connection_id_aliases.get(&hdr.dcid) {
             conn_id.clone()
         } else {
             let direct_owner = self
@@ -2697,9 +2984,9 @@ impl Shard {
                 .copied();
             if let Some(owner) = direct_owner {
                 if owner != self.index {
-                    self.forward_packet(owner, buf, from);
+                    self.queue_forward_packet(owner, buf, from, output.forward_batches);
                 } else {
-                    debug!("connection ownership published without local state");
+                    debug!("connection ownership published without local state or CID alias");
                 }
                 return;
             }
@@ -2718,12 +3005,12 @@ impl Shard {
             }
 
             if !quiche::version_is_supported(hdr.version) {
-                match quiche::negotiate_version(&hdr.scid, &hdr.dcid, stateless_out) {
+                match quiche::negotiate_version(&hdr.scid, &hdr.dcid, output.stateless) {
                     Ok(written) => self.queue_stateless_packet(
-                        &stateless_out[..written],
+                        &output.stateless[..written],
                         local,
                         from,
-                        stateless_batch,
+                        output.stateless_batch,
                     ),
                     Err(error) => debug!(%error, "failed to build QUIC version negotiation"),
                 }
@@ -2746,7 +3033,7 @@ impl Shard {
                     .copied();
                 if let Some(owner) = derived_owner {
                     if owner != self.index {
-                        self.forward_packet(owner, buf, from);
+                        self.queue_forward_packet(owner, buf, from, output.forward_batches);
                     } else {
                         debug!("derived connection ownership published without local state");
                     }
@@ -2768,16 +3055,16 @@ impl Shard {
                         &derived,
                         &retry_token,
                         hdr.version,
-                        stateless_out,
+                        output.stateless,
                     ) {
                         Ok(written) => {
                             self.queue_stateless_packet(
-                                &stateless_out[..written],
+                                &output.stateless[..written],
                                 local,
                                 from,
-                                stateless_batch,
+                                output.stateless_batch,
                             );
-                            *stateless_retries += 1;
+                            *output.stateless_retries += 1;
                         }
                         Err(error) => debug!(%error, "failed to build QUIC Retry"),
                     }
@@ -2853,6 +3140,7 @@ impl Shard {
                     conn_idx,
                     Arc::clone(&self.metrics),
                     source_admission,
+                    scid.clone(),
                 );
                 self.connections.insert(scid.clone(), client);
                 scid
@@ -2873,6 +3161,18 @@ impl Shard {
             debug!(%e, "quiche recv error");
             return;
         }
+
+        if !Self::handle_path_events(&self.metrics, client) {
+            return;
+        }
+        Self::sync_connection_ids(
+            &self.shared,
+            self.index,
+            self.reuseport_index,
+            &mut self.connection_id_aliases,
+            &key,
+            client,
+        );
 
         // Resolve the client's certificate to a roster entry once, at the
         // handshake boundary. The TLS callback has already refused unknown

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -11,6 +11,10 @@
 //! and 24 hours of validity; `:protocol: cf-connect-ip`; a hardcoded authority;
 //! and `:path: /`.
 
+#[cfg(target_os = "linux")]
+use std::io::{Read as _, Write as _};
+#[cfg(target_os = "linux")]
+use std::net::TcpStream;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -42,6 +46,8 @@ const CLIENT_IPV6: &str = "fd00:abcd::2";
 /// QUIC maps a TLS alert to `CRYPTO_ERROR` (0x100) plus the alert number.
 /// Alert 49 is `access_denied`.
 const ACCESS_DENIED_CRYPTO_ERROR: u64 = 0x100 + 49;
+#[cfg(target_os = "linux")]
+const MIGRATION_SOURCE_LIMIT_ERROR: u64 = 0x0101;
 
 /// The tunnel MTU these clients use, matching `ip_proxy.tun_mtu`.
 const TUN_MTU: usize = 1280;
@@ -173,6 +179,10 @@ fn server_config(
 /// server, so no parallel test can take it in between, and a caller cannot
 /// start talking to a socket that is not up yet.
 fn spawn_server(config: ServerConfig) -> Vec<SocketAddr> {
+    spawn_server_with_observability(config).0
+}
+
+fn spawn_server_with_observability(config: ServerConfig) -> (Vec<SocketAddr>, Option<SocketAddr>) {
     let (bound_tx, bound_rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -184,7 +194,7 @@ fn spawn_server(config: ServerConfig) -> Vec<SocketAddr> {
                 Ok(mut server) => {
                     // A failed send means the test gave up; run anyway and let
                     // the detached thread die with the process.
-                    let _ = bound_tx.send(server.listen_addrs());
+                    let _ = bound_tx.send((server.listen_addrs(), server.observability_addr()));
                     let _ = server.run().await;
                 }
                 Err(e) => panic!("server failed to bind: {e:#}"),
@@ -195,6 +205,30 @@ fn spawn_server(config: ServerConfig) -> Vec<SocketAddr> {
     bound_rx
         .recv_timeout(Duration::from_secs(10))
         .expect("server did not report its listen addresses")
+}
+
+#[cfg(target_os = "linux")]
+fn scrape_metrics(addr: SocketAddr) -> String {
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(2)).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    stream
+        .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    response
+}
+
+#[cfg(target_os = "linux")]
+fn metric_total(rendered: &str, name: &str) -> u64 {
+    rendered
+        .lines()
+        .filter(|line| line.starts_with(name))
+        .filter_map(|line| line.rsplit_once(' '))
+        .filter_map(|(_, value)| value.parse::<u64>().ok())
+        .sum()
 }
 
 // ── Client ───────────────────────────────────────────────────────────
@@ -221,6 +255,16 @@ impl Client {
         Self::connect_with(peer, None)
     }
 
+    #[cfg(target_os = "linux")]
+    fn connect_from(
+        peer: SocketAddr,
+        cert: &Path,
+        key: &Path,
+        source_ip: std::net::IpAddr,
+    ) -> anyhow::Result<Self> {
+        Self::connect_with_session_from(peer, Some((cert, key)), None, false, source_ip)
+    }
+
     fn connect_with(peer: SocketAddr, identity: Option<(&Path, &Path)>) -> anyhow::Result<Self> {
         Self::connect_with_session(peer, identity, None, false)
     }
@@ -233,7 +277,23 @@ impl Client {
         session: Option<&[u8]>,
         enable_early_data: bool,
     ) -> anyhow::Result<Self> {
-        let socket = UdpSocket::bind("127.0.0.1:0")?;
+        Self::connect_with_session_from(
+            peer,
+            identity,
+            session,
+            enable_early_data,
+            "127.0.0.1".parse().unwrap(),
+        )
+    }
+
+    fn connect_with_session_from(
+        peer: SocketAddr,
+        identity: Option<(&Path, &Path)>,
+        session: Option<&[u8]>,
+        enable_early_data: bool,
+        source_ip: std::net::IpAddr,
+    ) -> anyhow::Result<Self> {
+        let socket = UdpSocket::bind(SocketAddr::new(source_ip, 0))?;
         socket.connect(peer)?;
         socket.set_read_timeout(Some(Duration::from_millis(50)))?;
         let local = socket.local_addr()?;
@@ -254,6 +314,8 @@ impl Client {
         config.set_initial_max_stream_data_uni(262_144);
         config.set_initial_max_streams_bidi(16);
         config.set_initial_max_streams_uni(16);
+        config.set_active_connection_id_limit(2);
+        config.set_disable_active_migration(false);
         config.enable_dgram(true, 256, 256);
         if enable_early_data {
             config.enable_early_data();
@@ -327,6 +389,80 @@ impl Client {
         self.flush()?;
         self.recv_once()?;
         self.flush()
+    }
+
+    /// Give the server a spare destination CID before moving to another
+    /// socket. Active migration requires both endpoints to have supplied one.
+    fn publish_spare_connection_id(&mut self) -> anyhow::Result<()> {
+        while self.quic.scids_left() > 0 {
+            let mut random = [0u8; CLIENT_CONN_ID_LEN + 16];
+            ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut random)
+                .map_err(|_| anyhow::anyhow!("RNG failed"))?;
+            let id = quiche::ConnectionId::from_ref(&random[..CLIENT_CONN_ID_LEN]);
+            let reset_token = u128::from_be_bytes(
+                random[CLIENT_CONN_ID_LEN..]
+                    .try_into()
+                    .expect("reset token is 16 bytes"),
+            );
+            self.quic.new_scid(&id, reset_token, false)?;
+        }
+        self.flush()
+    }
+
+    /// Replace the connected UDP socket while retaining this QUIC and H3
+    /// connection, then wait for the replacement path to validate.
+    fn migrate_source(&mut self, timeout: Duration) -> anyhow::Result<(SocketAddr, SocketAddr)> {
+        self.migrate_source_from("127.0.0.1".parse().unwrap(), timeout)
+    }
+
+    fn migrate_source_from(
+        &mut self,
+        source_ip: std::net::IpAddr,
+        timeout: Duration,
+    ) -> anyhow::Result<(SocketAddr, SocketAddr)> {
+        self.publish_spare_connection_id()?;
+        let old_local = self.socket.local_addr()?;
+        let peer = self.socket.peer_addr()?;
+        let replacement = UdpSocket::bind(SocketAddr::new(source_ip, 0))?;
+        replacement.connect(peer)?;
+        replacement.set_read_timeout(Some(Duration::from_millis(50)))?;
+        let new_local = replacement.local_addr()?;
+        anyhow::ensure!(
+            old_local != new_local,
+            "replacement socket reused the old address"
+        );
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.quic.migrate_source(new_local) {
+                Ok(_) => {
+                    // `migrate_source()` selects the new path. Explicitly
+                    // probe the server side and send a non-probing PING so the
+                    // server also observes peer migration and validates us.
+                    self.quic.probe_path(new_local, peer)?;
+                    self.quic.send_ack_eliciting()?;
+                    break;
+                }
+                Err(quiche::Error::OutOfIdentifiers) if Instant::now() < deadline => {
+                    // The server publishes its spare CID immediately after the
+                    // handshake; receive until that NEW_CONNECTION_ID arrives.
+                    self.drive()?;
+                }
+                Err(error) => anyhow::bail!("cannot start QUIC migration: {error}"),
+            }
+        }
+
+        self.socket = replacement;
+        while Instant::now() < deadline {
+            self.drive()?;
+            if self.quic.is_path_validated(new_local, peer) == Ok(true) {
+                return Ok((old_local, new_local));
+            }
+            if self.quic.is_closed() {
+                anyhow::bail!("connection closed during migration");
+            }
+        }
+        anyhow::bail!("replacement QUIC path did not validate within {timeout:?}")
     }
 
     fn handshake(&mut self, timeout: Duration) -> anyhow::Result<()> {
@@ -1349,6 +1485,210 @@ fn a_full_mtu_ip_packet_fits_in_one_datagram() {
         .dgram_send(&framed)
         .expect("a full-MTU packet must be sendable as one datagram");
     client.flush().unwrap();
+}
+
+/// Changing the client's UDP source port must preserve both the QUIC/H3
+/// connection and an already-open CONNECT stream. This is the common NAT
+/// rebinding form of connection migration and exercises the spare CID that the
+/// server publishes after the handshake.
+#[test]
+fn client_source_port_migrates_without_reconnecting() {
+    let fixture = fixture("migration");
+    let mut client =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+    let existing_stream = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(existing_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    let (old_local, new_local) = client.migrate_source(Duration::from_secs(5)).unwrap();
+    assert_eq!(old_local.ip(), new_local.ip());
+    assert_ne!(old_local.port(), new_local.port());
+
+    // Response-body state belonging to the pre-migration stream survives.
+    let capsules = client.capsules(existing_stream, 2, Duration::from_secs(5));
+    assert!(
+        capsules
+            .iter()
+            .any(|frame| matches!(frame, CapsuleFrame::AddressAssign(_))),
+        "the pre-migration CONNECT stream stopped making progress"
+    );
+
+    // A new stream on the same H3 connection works without another TLS or
+    // client-certificate handshake.
+    let later_stream = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(later_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+    assert!(!client.quic.is_closed());
+}
+
+/// A validated address change, not only a NAT port remap, keeps the same
+/// authenticated HTTP/3 connection alive. The loopback /8 gives the test two
+/// routable local addresses without depending on an external interface.
+#[cfg(target_os = "linux")]
+#[test]
+fn client_source_ip_migrates_without_reconnecting() {
+    let fixture = fixture("migration-ip");
+    let mut client =
+        Client::connect(fixture.peer, &fixture.client_cert, &fixture.client_key).unwrap();
+
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+    let first_stream = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(first_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+
+    let (old_local, new_local) = client
+        .migrate_source_from("127.0.0.2".parse().unwrap(), Duration::from_secs(5))
+        .unwrap();
+    assert_ne!(old_local.ip(), new_local.ip());
+
+    let later_stream = client.send_connect_ip("connect-ip").unwrap();
+    assert_eq!(
+        client
+            .response_status(later_stream, Duration::from_secs(5))
+            .unwrap(),
+        200
+    );
+    assert!(!client.quic.is_closed());
+}
+
+/// Linux steers every server-issued destination CID to its owning reuseport
+/// socket. Source-port migration must therefore stay on the connection's
+/// shard instead of paying the userspace cross-shard forwarding cost.
+#[cfg(target_os = "linux")]
+#[test]
+fn migrated_connections_stay_on_reuseport_owner() {
+    let dir = TempDir::new("migration-shards");
+    let server_key = p256_key();
+    let (server_cert, server_key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+    let client_key = p256_key();
+    let (client_cert, client_key_path) = write_pem(
+        dir.path(),
+        "client",
+        &client_key,
+        &self_signed(&client_key, None),
+    );
+    let mut config = server_config(
+        server_cert,
+        server_key_path,
+        ephemeral_addr(),
+        vec![ClientEntry {
+            name: "migrating-client".into(),
+            public_key: public_key_b64(&client_key),
+            ipv4: None,
+            ipv6: None,
+        }],
+    );
+    config.listeners[0].shards = 4;
+    config.observability.listen_addr = Some(ephemeral_addr());
+    let (listeners, observability) = spawn_server_with_observability(config);
+    assert_eq!(listeners.len(), 4);
+    let peer = listeners[0];
+    let observability = observability.expect("metrics listener must be bound");
+
+    for _ in 0..8 {
+        let mut client = Client::connect(peer, &client_cert, &client_key_path).unwrap();
+        client.handshake(Duration::from_secs(5)).unwrap();
+        client.migrate_source(Duration::from_secs(5)).unwrap();
+        assert!(!client.quic.is_closed());
+    }
+
+    let metrics = scrape_metrics(observability);
+    assert!(
+        metrics.lines().any(|line| {
+            line.starts_with("masque_quic_path_events_total{")
+                && line.contains("event=\"peer_migrated\"")
+                && line
+                    .rsplit_once(' ')
+                    .and_then(|(_, value)| value.parse::<u64>().ok())
+                    .is_some_and(|value| value >= 8)
+        }),
+        "all eight migrations should be observable as completed peer migrations"
+    );
+    assert_eq!(
+        metric_total(&metrics, "masque_quic_cross_shard_forwarded_packets_total{"),
+        0,
+        "CID steering should keep migrated packets on their owning shard"
+    );
+}
+
+/// A validated path cannot use migration to bypass the live-connection cap of
+/// its new source. The old admission remains balanced and the already-admitted
+/// connection at the destination source is unaffected.
+#[cfg(target_os = "linux")]
+#[test]
+fn migration_to_a_full_source_is_closed() {
+    let dir = TempDir::new("migration-source-limit");
+    let server_key = p256_key();
+    let (server_cert, server_key_path) = write_pem(
+        dir.path(),
+        "server",
+        &server_key,
+        &self_signed(&server_key, Some("masque-server")),
+    );
+    let client_key = p256_key();
+    let (client_cert, client_key_path) = write_pem(
+        dir.path(),
+        "client",
+        &client_key,
+        &self_signed(&client_key, None),
+    );
+    let mut config = server_config(
+        server_cert,
+        server_key_path,
+        ephemeral_addr(),
+        vec![ClientEntry {
+            name: "limited-client".into(),
+            public_key: public_key_b64(&client_key),
+            ipv4: None,
+            ipv6: None,
+        }],
+    );
+    config.server.max_connections_per_ip = 1;
+    let peer = spawn_server(config)[0];
+
+    let occupied_source = "127.0.0.2".parse().unwrap();
+    let mut occupied =
+        Client::connect_from(peer, &client_cert, &client_key_path, occupied_source).unwrap();
+    occupied.handshake(Duration::from_secs(5)).unwrap();
+
+    let mut migrating = Client::connect(peer, &client_cert, &client_key_path).unwrap();
+    migrating.handshake(Duration::from_secs(5)).unwrap();
+    let _ = migrating.migrate_source_from(occupied_source, Duration::from_secs(2));
+    assert!(
+        migrating.wait_for_close(Duration::from_secs(5)),
+        "migration into a full source budget remained open"
+    );
+    assert_eq!(
+        migrating
+            .quic
+            .peer_error()
+            .map(|error| (error.is_app, error.error_code)),
+        Some((true, MIGRATION_SOURCE_LIMIT_ERROR))
+    );
+
+    occupied.drive().unwrap();
+    assert!(!occupied.quic.is_closed());
 }
 
 /// A network change often makes the replacement QUIC connection arrive before

--- a/tools/masque-e2e/src/main.rs
+++ b/tools/masque-e2e/src/main.rs
@@ -320,6 +320,8 @@ impl Client {
         config.set_max_stream_window(16_777_216);
         config.set_initial_max_streams_bidi(128);
         config.set_initial_max_streams_uni(100);
+        config.set_active_connection_id_limit(2);
+        config.set_disable_active_migration(false);
         config.enable_pacing(true);
         config.enable_dgram(true, 1000, 1000);
 
@@ -395,6 +397,72 @@ impl Client {
         self.recv_once()?;
         self.flush()?;
         Ok(())
+    }
+
+    fn publish_spare_connection_id(&mut self) -> Result<()> {
+        while self.quic.scids_left() > 0 {
+            let mut random = [0u8; quiche::MAX_CONN_ID_LEN + 16];
+            ring::rand::SystemRandom::new()
+                .fill(&mut random)
+                .map_err(|_| anyhow::anyhow!("RNG failed"))?;
+            let id = quiche::ConnectionId::from_ref(&random[..quiche::MAX_CONN_ID_LEN]);
+            let reset_token = u128::from_be_bytes(
+                random[quiche::MAX_CONN_ID_LEN..]
+                    .try_into()
+                    .expect("reset token is 16 bytes"),
+            );
+            self.quic.new_scid(&id, reset_token, false)?;
+        }
+        self.flush()
+    }
+
+    /// Change the UDP source port while preserving the QUIC and H3 state.
+    fn migrate_source(&mut self, timeout: Duration) -> Result<(SocketAddr, SocketAddr)> {
+        self.publish_spare_connection_id()?;
+        let old_local = self.local;
+        let bind_addr = if old_local.is_ipv4() {
+            SocketAddr::from(([0, 0, 0, 0], 0))
+        } else {
+            SocketAddr::from(([0u16; 8], 0))
+        };
+        let replacement = UdpSocket::bind(bind_addr)?;
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        tune_udp_receive_buffer(&replacement);
+        #[cfg(target_os = "macos")]
+        bind_udp_socket_to_requested_interface(&replacement)?;
+        replacement.connect(self.peer)?;
+        let new_local = replacement.local_addr()?;
+        if new_local == old_local {
+            bail!("replacement UDP socket reused {old_local}");
+        }
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.quic.migrate_source(new_local) {
+                Ok(_) => {
+                    self.quic.probe_path(new_local, self.peer)?;
+                    self.quic.send_ack_eliciting()?;
+                    break;
+                }
+                Err(quiche::Error::OutOfIdentifiers) if Instant::now() < deadline => {
+                    self.drive()?;
+                }
+                Err(error) => bail!("cannot start QUIC migration: {error}"),
+            }
+        }
+
+        self.socket = replacement;
+        self.local = new_local;
+        while Instant::now() < deadline {
+            self.drive()?;
+            if self.quic.is_path_validated(new_local, self.peer) == Ok(true) {
+                return Ok((old_local, new_local));
+            }
+            if self.quic.is_closed() {
+                bail!("QUIC connection closed during migration");
+            }
+        }
+        bail!("replacement QUIC path did not validate within {timeout:?}")
     }
 
     /// Complete the QUIC handshake.
@@ -1609,6 +1677,25 @@ fn test_connect_udp_happy_path(server_addr: &str, echo_addr: &str) -> Result<()>
     Ok(())
 }
 
+fn test_quic_migration(server_addr: &str, echo_addr: &str) -> Result<()> {
+    let (mut client, stream_id) = connect_udp_tunnel(server_addr, echo_addr)?;
+    let before = b"before QUIC migration";
+    client.send_dgram(stream_id, before)?;
+    if client.recv_dgram(Duration::from_secs(5))?.payload != before {
+        bail!("pre-migration CONNECT-UDP payload mismatch");
+    }
+
+    let (old_local, new_local) = client.migrate_source(Duration::from_secs(5))?;
+
+    let after = b"after QUIC migration";
+    client.send_dgram(stream_id, after)?;
+    if client.recv_dgram(Duration::from_secs(5))?.payload != after {
+        bail!("post-migration CONNECT-UDP payload mismatch");
+    }
+    info!(%old_local, %new_local, "CONNECT-UDP survived QUIC source migration");
+    Ok(())
+}
+
 fn test_proxy_auth_required(server_addr: &str, echo_addr: &str) -> Result<()> {
     let mut client = Client::connect(server_addr)?;
     client.handshake()?;
@@ -1934,7 +2021,7 @@ fn print_udp_result(
     let rx_pps = received as f64 / seconds;
     let goodput_gbps = received as f64 * payload_size as f64 * 8.0 / seconds / 1e9;
     let response_shortfall_pct = sent.saturating_sub(received) as f64 * 100.0 / sent.max(1) as f64;
-    let relay_gbps = if path == "masque" {
+    let relay_gbps = if path.starts_with("masque") {
         Some(goodput_gbps * 2.0)
     } else {
         None
@@ -2007,9 +2094,22 @@ fn benchmark_direct_udp(
 
 fn benchmark_http3_udp(server_addr: &str, echo_addr: &str, config: UdpBenchConfig) -> Result<()> {
     println!("MASQUE CONNECT-UDP (transport=http3):");
+    let migrate_before_measurement = std::env::var_os("MASQUE_BENCH_MIGRATED").is_some();
+    let result_path = if migrate_before_measurement {
+        "masque_migrated"
+    } else {
+        "masque"
+    };
     let setup_started = Instant::now();
     let (mut client, stream_id) = connect_udp_tunnel(server_addr, echo_addr)?;
     let setup = setup_started.elapsed();
+    let migration = if migrate_before_measurement {
+        let started = Instant::now();
+        client.migrate_source(Duration::from_secs(5))?;
+        Some(started.elapsed())
+    } else {
+        None
+    };
 
     let latency_payload = vec![0x3c; 64];
     let mut latencies = Vec::with_capacity(config.latency_samples);
@@ -2025,8 +2125,11 @@ fn benchmark_http3_udp(server_addr: &str, echo_addr: &str, config: UdpBenchConfi
     latencies.sort_by(f64::total_cmp);
     let percentile = |p: f64| percentile_nearest_rank(&latencies, p).unwrap();
     println!(
-        "  setup {:.3} ms; RTT 64B ({} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
+        "  setup {:.3} ms{}; RTT 64B ({} samples): p50 {:.1} us, p95 {:.1} us, p99 {:.1} us",
         setup.as_secs_f64() * 1e3,
+        migration
+            .map(|elapsed| format!("; migration {:.3} ms", elapsed.as_secs_f64() * 1e3))
+            .unwrap_or_default(),
         config.latency_samples,
         percentile(0.50),
         percentile(0.95),
@@ -2037,6 +2140,9 @@ fn benchmark_http3_udp(server_addr: &str, echo_addr: &str, config: UdpBenchConfi
 
     for payload_size in [64, 1_200] {
         let (mut client, stream_id) = connect_udp_tunnel(server_addr, echo_addr)?;
+        if migrate_before_measurement {
+            client.migrate_source(Duration::from_secs(5))?;
+        }
         let (sent, received, expired) = client.run_echo_throughput(
             stream_id,
             payload_size,
@@ -2046,7 +2152,7 @@ fn benchmark_http3_udp(server_addr: &str, echo_addr: &str, config: UdpBenchConfi
         )?;
         print_udp_result(
             "http3",
-            "masque",
+            result_path,
             payload_size,
             config.duration,
             sent,
@@ -2449,6 +2555,19 @@ fn main() {
         return;
     }
 
+    if std::env::var_os("MASQUE_MIGRATION_CHECK").is_some() {
+        if transport == BenchTransport::Http2 {
+            error!("QUIC migration is available only on HTTP/3 listeners");
+            std::process::exit(2);
+        }
+        if let Err(error) = test_quic_migration(&server_addr, &echo_addr) {
+            error!(%error, "QUIC migration check failed");
+            std::process::exit(1);
+        }
+        info!("QUIC migration check passed");
+        return;
+    }
+
     if std::env::var_os("MASQUE_LOAD").is_some() {
         if transport == BenchTransport::Http2 {
             error!("HTTP/2 multi-connection load mode is not implemented; use tcp or udp mode");
@@ -2503,6 +2622,7 @@ fn main() {
         ),
         ("proxy_auth_required", test_proxy_auth_required),
         ("connect_udp_happy_path", test_connect_udp_happy_path),
+        ("quic_migration", test_quic_migration),
         ("connect_udp_policy_deny", test_connect_udp_policy_deny),
         ("connect_udp_bad_uri", test_connect_udp_bad_uri),
         ("non_connect_404", test_non_connect_404),

--- a/tools/masque-probe/Cargo.toml
+++ b/tools/masque-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masque-probe"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.88"
 description = "End-to-end connectivity diagnostics for MASQUE proxies"


### PR DESCRIPTION
## Summary

- keep established HTTP/3 CONNECT tunnels alive across validated client IP and NAT port changes
- maintain bounded spare connection IDs, retire obsolete routes, and atomically transfer per-source admission after path validation
- add low-cardinality path-validation and cross-shard forwarding metrics
- steer Linux multi-shard traffic by server CID with a classic SO_REUSEPORT BPF selector, retaining the bounded userspace registry as a fallback
- batch wrong-shard packets while preserving the existing packet-count memory bound
- add real socket-replacement E2E coverage, Linux steering/admission regressions, migration benchmarks, and operator documentation
- bump `masque-server` and `masque-probe` to 0.12.0 and archive the release notes

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`
- `scripts/validate-release.sh v0.12.0`
- Linux Rust 1.88 all-target compilation and QUIC migration/socket integration coverage

## Performance

Post-migration steady-state throughput remained within measurement noise of the normal path. The final 1200-byte confirmation measured 1.0609 Gbit/s normally and 1.0578 Gbit/s after migration (-0.29%).
