### PR TITLE
feat: add Basic authentication stealth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.12.1 - 2026-09-01
+
+### Added
+
+- Basic listeners can opt into `auth.stealth = true`, making missing, malformed,
+  or invalid authorization and authentication overload look like an ordinary
+  empty `404` instead of exposing a `407` challenge or `503`. HTTP/2 and HTTP/3
+  share the behavior, while correct proactive credentials are unaffected.
+- `add-listener --stealth` and the installer's `MASQUE_BASIC_STEALTH=1` expose
+  the mode without hand-editing a generated configuration.
+
 ## 0.12.0 - 2026-09-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-probe"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ undocumented_unsafe_blocks = "deny"
 
 [package]
 name = "masque-server"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ a staging environment.
 - HTTP/3 over UDP for performance, plus HTTP/2 Extended CONNECT and the
   Cloudflare/usque CONNECT-IP dialect over TCP/TLS as compatibility fallbacks
 - Multiple HTTP Basic accounts per listener with Argon2id password
-  verification, or TLS client-certificate authentication against a public-key
-  roster
+  verification and optional 404 response camouflage, or TLS client-certificate
+  authentication against a public-key roster
 - Multiple listeners in one process, each with its own Basic or client-certificate
   authentication mode while sharing proxy policies, client roster, and TUN state
 - CIDR allow and deny policies for TCP and UDP targets
@@ -76,6 +76,11 @@ identity remains active.
 
 Authentication is fail-closed. In `basic` mode the server refuses to start until
 at least one uniquely named account with a valid Argon2id hash is configured.
+Clients such as Surge send Basic authorization on their first CONNECT, so a
+Basic listener may set `stealth = true` to return an ordinary empty 404 instead
+of advertising a 407 challenge to unauthenticated probes. See
+[Authentication](docs/configuration.md#authentication) for the compatibility
+and security limits of this option.
 
 Alternatively, set `mode = "client_cert"` in `[listeners.auth]` to authenticate
 clients during the TLS handshake. Generate each client's P-256 key and
@@ -187,7 +192,8 @@ curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/inst
 ```
 
 For a new configuration the installer prompts for `basic`, `client_cert`, or
-`dual` authentication and optional TLS file locations. Basic mode creates the
+`dual` authentication, optional Basic stealth mode, and optional TLS file
+locations. Basic mode creates the
 first account, generates a random password when none is supplied, and can write
 a ready-to-import Surge configuration while the plaintext is still available.
 Client-certificate mode enrolls the first

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -46,6 +46,10 @@ enabled = true
 # To serve both kinds of client, add the second listener shown at the end of
 # this file. Every listener has its own explicit authentication table.
 mode = "basic"
+# Optional response camouflage for clients such as Surge that send credentials
+# on their first CONNECT. Missing or invalid credentials receive the same empty
+# 404 as an unsupported request instead of a 407 challenge.
+stealth = false
 
 # Repeat this table for independent accounts on the same address and port.
 # Account edits can be made with add-user/set-password/remove-user and applied

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -22,6 +22,7 @@ GRAFANA_DASHBOARD_PATH=$MONITORING_DIR/grafana-dashboard.json
 AUTH_MODE=
 AUTH_USERNAME=
 AUTH_PASSWORD=
+BASIC_STEALTH=false
 GENERATED_PASSWORD=0
 CONFIG_CHANGED=0
 FRESH_CONFIG=0
@@ -285,6 +286,34 @@ choose_auth_mode() {
     AUTH_MODE=$(normalize_auth_mode "$requested_mode")
 }
 
+choose_basic_stealth() {
+    requested=${MASQUE_BASIC_STEALTH:-}
+    if [ -z "$requested" ]; then
+        if can_prompt; then
+            {
+                echo
+                echo "Basic stealth mode returns an ordinary 404 instead of a 407 challenge."
+                echo "Enable it only when clients send credentials on their first CONNECT."
+            } >/dev/tty
+            requested=$(prompt_value "Enable Basic stealth mode? (yes/no)" no)
+        else
+            requested=no
+        fi
+    fi
+
+    case "$requested" in
+        1|true|yes)
+            BASIC_STEALTH=true
+            ;;
+        0|false|no)
+            BASIC_STEALTH=false
+            ;;
+        *)
+            die "MASQUE_BASIC_STEALTH must be 0 or 1"
+            ;;
+    esac
+}
+
 # Report what the deployed configuration actually authenticates with.
 #
 # Taken from `check-config`, which validates and resolves the listeners the same
@@ -434,11 +463,13 @@ render_new_config() {
             sed \
                 -e "s|__MASQUE_AUTH_USERNAME__|$AUTH_USERNAME|" \
                 -e "s|__MASQUE_AUTH_PASSWORD_HASH__|$AUTH_PASSWORD_HASH|" \
+                -e "s|^stealth = false$|stealth = $BASIC_STEALTH|" \
                 "$PACKAGE_DIR/config/masque.toml" >"$CONFIG_TMP"
             ;;
         client_cert)
             sed \
                 -e 's|^mode = "basic"$|mode = "client_cert"|' \
+                -e '/^stealth = false$/d' \
                 -e '/^\[\[listeners\.auth\.users\]\]$/d' \
                 -e '/^username = "__MASQUE_AUTH_USERNAME__"$/d' \
                 -e '/^password_hash = "__MASQUE_AUTH_PASSWORD_HASH__"$/d' \
@@ -777,6 +808,9 @@ install -d -o root -g masque -m 0750 /etc/masque/certs
 
 if [ "$FRESH_CONFIG" -eq 1 ]; then
     choose_auth_mode
+    if mode_uses_basic; then
+        choose_basic_stealth
+    fi
     install_tls_material 1
     render_new_config
     configure_fresh_listen_port
@@ -830,6 +864,7 @@ fi
 if [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
     echo
     echo "Basic client credentials:"
+    echo "  Stealth mode: $BASIC_STEALTH"
     echo "  Username: $AUTH_USERNAME"
     if [ "$GENERATED_PASSWORD" -eq 1 ]; then
         echo "  Password: $AUTH_PASSWORD"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,6 +150,7 @@ connect, and vice versa. To serve both kinds of client, define two listeners.
 | --- | --- |
 | `enabled` | Master switch. `false` disables authentication whatever `mode` says |
 | `mode` | `basic` (default) or `client_cert` |
+| `stealth` | `basic` only; use an empty `404` instead of a `407` challenge (default `false`) |
 | `[[listeners.auth.users]]` | `basic` only; one or more accounts on this socket |
 | `users[].username` | Unique Basic username on this listener |
 | `users[].password_hash` | Argon2id PHC string |
@@ -174,6 +175,8 @@ shards = 1
 [listeners.auth]
 enabled = true
 mode = "basic"
+# Compatible clients must send Proxy-Authorization on their first request.
+stealth = true
 
 [[listeners.auth.users]]
 username = "proxy-user"
@@ -192,8 +195,21 @@ printf '%s' 'a-strong-password' | masque-server hash-password
 ```
 
 Clients send `Proxy-Authorization: Basic BASE64(user:password)` on each
-request. Missing, malformed, duplicated, or wrong credentials receive
-`407 Proxy Authentication Required`.
+request. By default, missing, malformed, duplicated, or wrong credentials
+receive `407 Proxy Authentication Required`.
+
+With `stealth = true`, every such authentication failure instead receives the
+same empty `404` as an unsupported request, with no `Proxy-Authenticate`
+header. [Surge](https://manual.nssurge.com/policies/masque.html) sends Basic
+authorization proactively on each CONNECT and is compatible with this setting.
+A client that waits for a 407 challenge is not:
+it must remain on the default setting. Changing `stealth` requires a restart;
+account changes remain reloadable with `SIGHUP`.
+
+This option reduces the application-response fingerprint of an unauthenticated
+probe. It does not hide the listening QUIC/TLS service or imitate a real web
+site, and authentication timing is not deliberately equalized because doing so
+would turn malformed probes into Argon2 work.
 
 The server accepts at most 4,096 accounts on one listener and refuses to start
 if there are no users, usernames are duplicated, a username is empty or
@@ -564,6 +580,7 @@ add-listener options:
       --username <NAME>     Basic username
       --password-hash <PHC>  Argon2id hash, as printed by hash-password
       --password-stdin      Read the password from stdin and hash it here
+      --stealth            Return 404 instead of challenging failed Basic auth
       --emit-client surge   Emit the Basic credential in Surge syntax
       --client-endpoint <HOST:PORT>  Public endpoint written to that client config
       --client-name <NAME>  Optional Surge proxy name

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,7 +37,8 @@ from `/dev/tty`. A new installation offers three modes:
 
 - `basic` creates the first account, generates a high-entropy password unless
   one is provided, prints the credentials once, and optionally writes a secret
-  Surge configuration while the plaintext is available;
+  Surge configuration while the plaintext is available; it also asks whether
+  to hide failed authentication behind an empty 404 (off by default);
 - `client_cert` enrolls the first client, appends the generated `[[clients]]`
   entry, writes the usque JSON to a new `0600` file, and prints the mihomo block;
 - `dual` does both, writing a
@@ -69,6 +70,7 @@ The following environment variables make provisioning non-interactive:
 | `MASQUE_AUTH_MODE` | `basic`, `client_cert`, or `dual` |
 | `MASQUE_AUTH_USERNAME` | Basic username; defaults to `masque` |
 | `MASQUE_AUTH_PASSWORD` | Basic password; random when omitted |
+| `MASQUE_BASIC_STEALTH` | `1` to return an empty 404 instead of a Basic 407 challenge; default `0` |
 | `MASQUE_BASIC_CLIENT_ENDPOINT` | Optional public Basic endpoint in `host:port` form; enables Surge configuration generation |
 | `MASQUE_BASIC_CLIENT_NAME` | Optional proxy name in the generated Surge configuration |
 | `MASQUE_BASIC_CLIENT_CONFIG_OUT` | Absolute secret Surge output path; defaults to `/root/masque-surge.conf` when generation is enabled |

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -28,7 +28,7 @@ Proxy-Authorization: Basic BASE64(username:password)
 
 The server validates syntax, looks up the username in that listener's account
 set, and snapshots only the matching Argon2id hash before scheduling password
-verification. Missing or invalid credentials return:
+verification. Missing or invalid credentials normally return:
 
 ```text
 :status: 407
@@ -37,6 +37,11 @@ proxy-authenticate: Basic realm="masque", charset="UTF-8"
 
 Authentication is per request, so one authenticated tunnel does not authorize
 later streams that omit the header.
+
+When that listener sets `auth.stealth = true`, the failure response is instead
+an empty `404` without `proxy-authenticate`. Correct credentials must therefore
+arrive on the first CONNECT request. This changes only the unauthenticated
+response, not successful proxy protocol behavior.
 
 With a listener's `auth.mode = "client_cert"` there is no per-request step: the client is
 identified once, from its TLS client certificate, during the TLS handshake. An
@@ -117,8 +122,8 @@ head-of-line block unrelated IP packets after loss.
 | `200` | Tunnel established |
 | `400` | Malformed headers, authority, URI, datagram, or capsule |
 | `403` | Target rejected by policy or proxy type disabled |
-| `404` | Request is not a supported CONNECT endpoint |
-| `407` | Proxy credentials missing or invalid |
+| `404` | Unsupported CONNECT endpoint, or failed Basic authentication with `auth.stealth = true` |
+| `407` | Proxy credentials missing or invalid on a default Basic listener |
 | `429` / `503` | Per-connection or global setup capacity exhausted |
 | `502` | DNS, target socket, or upstream TCP setup failed |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -39,6 +39,17 @@ removed without changing every other client. Account edits become active on
 `SIGHUP`; existing tunnels remain, while later CONNECT requests use the new
 snapshot.
 
+A Basic listener may opt into `auth.stealth = true`. Missing, malformed,
+duplicated, unknown, or incorrect credentials then receive the same empty 404
+as an unsupported request instead of a 407 challenge. This removes an obvious
+HTTP authentication fingerprint and also hides authentication-overload status
+from an unauthenticated caller. It is response camouflage, not protocol
+obfuscation: QUIC/TLS handshakes, ALPN, packet sizes, timing, and the open port
+remain observable. The server deliberately keeps cheap malformed and unknown
+user rejection cheap instead of running dummy Argon2 work, so a determined
+observer may still distinguish timing classes. Clients must send credentials
+proactively; challenge-driven clients need the default `stealth = false`.
+
 With a listener's `auth.mode = "client_cert"` the cost profile is different: identity is
 established once during the handshake, by public key, so there is no per-request
 verification to bound and no password to brute-force. An unenrolled key is

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -327,6 +327,7 @@ mod tests {
         let auth = BasicAuthenticator::from_section(&AuthSection {
             enabled: true,
             mode: AuthMode::Basic,
+            stealth: false,
             username: String::new(),
             password_hash: String::new(),
             users: vec![
@@ -354,6 +355,7 @@ mod tests {
         let duplicate = AuthSection {
             enabled: true,
             mode: AuthMode::Basic,
+            stealth: false,
             username: String::new(),
             password_hash: String::new(),
             users: vec![

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,10 @@ pub struct AuthSection {
     /// Master switch. `false` disables authentication whatever `mode` says.
     pub enabled: bool,
     pub mode: AuthMode,
+    /// Hide Basic authentication failures behind the same empty `404` used
+    /// for unsupported HTTP requests instead of advertising a `407` challenge.
+    /// Clients must send `Proxy-Authorization` on their first CONNECT.
+    pub stealth: bool,
     /// Legacy single-user spelling retained so existing configurations keep
     /// working. New configurations should use repeated
     /// `[[listeners.auth.users]]` tables instead.
@@ -161,6 +165,7 @@ impl std::fmt::Debug for AuthSection {
         f.debug_struct("AuthSection")
             .field("enabled", &self.enabled)
             .field("mode", &self.mode)
+            .field("stealth", &self.stealth)
             .field("username", &self.username)
             .field(
                 "password_hash",
@@ -184,6 +189,11 @@ impl AuthSection {
     /// Whether a client certificate is required to complete the handshake.
     pub fn client_cert_enabled(&self) -> bool {
         self.enabled && self.mode == AuthMode::ClientCert
+    }
+
+    /// Whether failed Basic authorization should resemble an ordinary 404.
+    pub fn stealth_enabled(&self) -> bool {
+        self.basic_enabled() && self.stealth
     }
 }
 
@@ -437,6 +447,7 @@ impl Default for AuthSection {
             // credentials or explicitly opts out for a private test setup.
             enabled: true,
             mode: AuthMode::Basic,
+            stealth: false,
             username: String::new(),
             password_hash: String::new(),
             users: Vec::new(),

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -71,6 +71,8 @@ pub struct AddListener {
     pub client_output: Option<BasicClientOutput>,
     /// Write `enabled = false`, for a listener on a trusted network.
     pub disable_auth: bool,
+    /// Hide failed Basic authentication behind an ordinary 404 response.
+    pub stealth: bool,
     /// Do not try to bind the new address before writing it.
     pub no_bind_check: bool,
     /// Print the block that would be appended and leave the file alone.
@@ -183,6 +185,12 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
             "Surge MASQUE client output requires an HTTP/3 listener"
         );
     }
+    if request.stealth {
+        ensure!(
+            !request.disable_auth && mode == AuthMode::Basic,
+            "--stealth applies only to an authenticated Basic listener"
+        );
+    }
 
     let shards = match (transport, request.shards) {
         (ListenerTransport::Http2, Some(1) | None) => 1,
@@ -199,6 +207,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         AuthSection {
             enabled: false,
             mode,
+            stealth: false,
             username: String::new(),
             password_hash: String::new(),
             users: Vec::new(),
@@ -208,6 +217,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
             AuthMode::ClientCert => AuthSection {
                 enabled: true,
                 mode,
+                stealth: false,
                 username: String::new(),
                 password_hash: String::new(),
                 users: Vec::new(),
@@ -228,6 +238,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
                 AuthSection {
                     enabled: true,
                     mode,
+                    stealth: request.stealth,
                     username: String::new(),
                     password_hash: String::new(),
                     users: vec![BasicUser {
@@ -908,6 +919,9 @@ pub fn listener_toml_block(listener: &ListenerSection) -> String {
     match listener.auth.mode {
         AuthMode::Basic => {
             block.push_str("mode = \"basic\"\n");
+            if listener.auth.stealth {
+                block.push_str("stealth = true\n");
+            }
             for (username, password_hash) in effective_basic_users(&listener.auth) {
                 block.push_str("\n[[listeners.auth.users]]\n");
                 block.push_str(&format!("username = {}\n", toml_string(username)));
@@ -1526,6 +1540,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::ClientCert,
+                stealth: false,
                 username: String::new(),
                 password_hash: String::new(),
                 users: Vec::new(),
@@ -1565,6 +1580,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::Basic,
+                stealth: false,
                 username: String::new(),
                 password_hash: String::new(),
                 users: vec![BasicUser {
@@ -1597,6 +1613,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
             auth: AuthSection {
                 enabled: false,
                 mode: AuthMode::Basic,
+                stealth: false,
                 username: String::new(),
                 password_hash: String::new(),
                 users: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,11 @@ enum Command {
         #[arg(long)]
         password_stdin: bool,
 
+        /// Hide missing or invalid Basic credentials behind an ordinary 404.
+        /// The client must send authorization on its first CONNECT request.
+        #[arg(long, conflicts_with = "disable_auth")]
+        stealth: bool,
+
         /// Emit a ready-to-import client configuration while the plaintext
         /// password is still available.
         #[arg(
@@ -574,6 +579,7 @@ async fn main() -> anyhow::Result<()> {
         client_name,
         client_out,
         disable_auth,
+        stealth,
         no_bind_check,
         dry_run,
         yes,
@@ -604,6 +610,7 @@ async fn main() -> anyhow::Result<()> {
                 password_stdin: *password_stdin,
                 client_output,
                 disable_auth: *disable_auth,
+                stealth: *stealth,
                 no_bind_check: *no_bind_check,
                 dry_run: *dry_run,
                 assume_yes: *yes,

--- a/src/server/authentication.rs
+++ b/src/server/authentication.rs
@@ -63,7 +63,13 @@ impl Shard {
                     if let Some(client) = self.connections.get_mut(&conn_id) {
                         client.awaiting_auth.remove(&stream_id);
                         if let Some(h3) = &mut client.h3 {
-                            Self::send_error_response(h3, &mut client.quic, stream_id, 503);
+                            Self::send_auth_rejection(
+                                h3,
+                                &mut client.quic,
+                                stream_id,
+                                self.stealth_auth,
+                                503,
+                            );
                         }
                     }
                     continue;
@@ -77,7 +83,13 @@ impl Shard {
                     if let Some(client) = self.connections.get_mut(&conn_id) {
                         client.awaiting_auth.remove(&stream_id);
                         if let Some(h3) = &mut client.h3 {
-                            Self::send_error_response(h3, &mut client.quic, stream_id, 503);
+                            Self::send_auth_rejection(
+                                h3,
+                                &mut client.quic,
+                                stream_id,
+                                self.stealth_auth,
+                                503,
+                            );
                         }
                     }
                     continue;
@@ -194,7 +206,7 @@ impl Shard {
 
             if !authorized {
                 warn!(stream_id, "proxy authentication failed");
-                Self::send_proxy_auth_required(h3, &mut client.quic, stream_id);
+                Self::send_auth_rejection(h3, &mut client.quic, stream_id, self.stealth_auth, 407);
                 return;
             }
 
@@ -207,6 +219,7 @@ impl Shard {
             let request_context = RequestContext {
                 config: &self.config,
                 auth: self.auth.as_deref(),
+                stealth_auth: self.stealth_auth,
             };
             Self::dispatch_connect(
                 h3,

--- a/src/server/http2.rs
+++ b/src/server/http2.rs
@@ -45,6 +45,7 @@ pub(super) struct Http2Listener {
     config: Arc<ServerConfig>,
     shared: Arc<Shared>,
     auth: Option<Arc<SharedBasicAuthenticator>>,
+    stealth_auth: bool,
     client_certs: Option<Arc<SharedRoster>>,
     tcp_policy: TargetPolicy,
     udp_policy: TargetPolicy,
@@ -82,6 +83,7 @@ impl Http2Listener {
             .auth
             .client_cert_enabled()
             .then(|| Arc::clone(&shared.clients));
+        let stealth_auth = listener.auth.stealth_enabled();
 
         info!(addr = %listen_addr, transport = "http2", "listening");
         Ok(Self {
@@ -100,6 +102,7 @@ impl Http2Listener {
             config,
             shared,
             auth,
+            stealth_auth,
             client_certs,
             metrics,
         })
@@ -156,6 +159,7 @@ impl Http2Listener {
                         config: Arc::clone(&self.config),
                         shared: Arc::clone(&self.shared),
                         auth: self.auth.as_ref().map(Arc::clone),
+                        stealth_auth: self.stealth_auth,
                         client_certs: self.client_certs.as_ref().map(Arc::clone),
                         tcp_policy: self.tcp_policy.clone(),
                         udp_policy: self.udp_policy.clone(),
@@ -196,6 +200,7 @@ struct ConnectionContext {
     config: Arc<ServerConfig>,
     shared: Arc<Shared>,
     auth: Option<Arc<SharedBasicAuthenticator>>,
+    stealth_auth: bool,
     client_certs: Option<Arc<SharedRoster>>,
     tcp_policy: TargetPolicy,
     udp_policy: TargetPolicy,

--- a/src/server/http2/auth.rs
+++ b/src/server/http2/auth.rs
@@ -56,12 +56,20 @@ pub(super) async fn authorize_request(
     let mut values = request.headers().get_all(PROXY_AUTHORIZATION).iter();
     let first = values.next().map(HeaderValue::as_bytes);
     if values.next().is_some() {
-        let _ = send_proxy_auth_required(respond);
+        let _ = send_auth_rejection(
+            respond,
+            context.stealth_auth,
+            StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+        );
         return Authorization::ResponseSent;
     }
     let (credential, password) = match auth.precheck(first) {
         AuthPrecheck::Rejected => {
-            let _ = send_proxy_auth_required(respond);
+            let _ = send_auth_rejection(
+                respond,
+                context.stealth_auth,
+                StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+            );
             return Authorization::ResponseSent;
         }
         AuthPrecheck::NeedsVerify {
@@ -73,7 +81,11 @@ pub(super) async fn authorize_request(
         Ok(slot) => slot,
         Err(_) => {
             context.metrics.record_auth_overloaded();
-            let _ = send_error(respond, StatusCode::SERVICE_UNAVAILABLE);
+            let _ = send_auth_rejection(
+                respond,
+                context.stealth_auth,
+                StatusCode::SERVICE_UNAVAILABLE,
+            );
             return Authorization::ResponseSent;
         }
     };
@@ -81,7 +93,11 @@ pub(super) async fn authorize_request(
         Some(slot) => slot,
         None => {
             context.metrics.record_auth_overloaded();
-            let _ = send_error(respond, StatusCode::SERVICE_UNAVAILABLE);
+            let _ = send_auth_rejection(
+                respond,
+                context.stealth_auth,
+                StatusCode::SERVICE_UNAVAILABLE,
+            );
             return Authorization::ResponseSent;
         }
     };
@@ -102,11 +118,19 @@ pub(super) async fn authorize_request(
     match authorized {
         AuthResult::Authorized => Authorization::Granted,
         AuthResult::Rejected => {
-            let _ = send_proxy_auth_required(respond);
+            let _ = send_auth_rejection(
+                respond,
+                context.stealth_auth,
+                StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+            );
             Authorization::ResponseSent
         }
         AuthResult::Overloaded => {
-            let _ = send_error(respond, StatusCode::SERVICE_UNAVAILABLE);
+            let _ = send_auth_rejection(
+                respond,
+                context.stealth_auth,
+                StatusCode::SERVICE_UNAVAILABLE,
+            );
             Authorization::ResponseSent
         }
     }
@@ -172,4 +196,18 @@ fn send_proxy_auth_required(respond: &mut SendResponse<Bytes>) -> Result<(), h2:
         .body(())
         .expect("static proxy-authenticate response is valid");
     respond.send_response(response, true).map(|_| ())
+}
+
+fn send_auth_rejection(
+    respond: &mut SendResponse<Bytes>,
+    stealth: bool,
+    fallback: StatusCode,
+) -> Result<(), h2::Error> {
+    if stealth {
+        send_error(respond, StatusCode::NOT_FOUND)
+    } else if fallback == StatusCode::PROXY_AUTHENTICATION_REQUIRED {
+        send_proxy_auth_required(respond)
+    } else {
+        send_error(respond, fallback)
+    }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -627,6 +627,9 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
     // the listener it came from or it cannot be found in a multi-listener file.
     for plan in &listeners {
         let addr = plan.listener.listen_addr;
+        if plan.listener.auth.stealth && !plan.listener.auth.basic_enabled() {
+            anyhow::bail!("listener {addr} auth.stealth requires enabled Basic authentication");
+        }
         if plan.listener.auth.basic_enabled() {
             BasicAuthenticator::from_section(&plan.listener.auth)
                 .with_context(|| format!("listener {addr}"))?;
@@ -833,6 +836,7 @@ fn config_reload_settings(
                 listen_addr: listener.listen_addr,
                 transport: listener.transport,
                 auth: ReloadAuthKind::from(&listener.auth),
+                stealth: listener.auth.stealth_enabled(),
             })
             .collect(),
     })
@@ -1533,10 +1537,12 @@ fn reload_configuration(shared: &Shared) -> anyhow::Result<ReloadOutcome> {
         if startup.listen_addr != current.listen_addr
             || startup.transport != current.transport
             || startup.auth != current_auth
+            || startup.stealth != current.auth.stealth_enabled()
         {
             anyhow::bail!(
-                "refusing to reload listener {}: address, transport, order, or authentication \
-                 mode changed; restart the service to apply trust-boundary changes",
+                "refusing to reload listener {}: address, transport, order, authentication \
+                 mode, or stealth setting changed; restart the service to apply trust-boundary \
+                 changes",
                 index + 1
             );
         }
@@ -1992,6 +1998,7 @@ struct ReloadListener {
     listen_addr: SocketAddr,
     transport: ListenerTransport,
     auth: ReloadAuthKind,
+    stealth: bool,
 }
 
 /// State every shard shares.
@@ -2157,6 +2164,8 @@ struct Shard {
     /// key. The initial CID stays on the one-lookup hot path above.
     connection_id_aliases: FxHashMap<quiche::ConnectionId<'static>, quiche::ConnectionId<'static>>,
     auth: Option<Arc<SharedBasicAuthenticator>>,
+    /// Whether failed Basic authorization uses the ordinary empty 404.
+    stealth_auth: bool,
     /// Set when clients authenticate with a certificate instead of credentials.
     ///
     /// The TLS context already refuses unregistered keys, so this exists to
@@ -2258,6 +2267,7 @@ impl Shard {
         } else {
             None
         };
+        let stealth_auth = listener.auth.stealth_enabled();
 
         let quic_config = build_quic_config(
             &config,
@@ -2292,6 +2302,7 @@ impl Shard {
             connections: FxHashMap::default(),
             connection_id_aliases: FxHashMap::default(),
             auth,
+            stealth_auth,
             client_certs,
             tcp_policy,
             udp_policy,
@@ -3241,6 +3252,7 @@ impl Shard {
                         let request_context = RequestContext {
                             config: &self.config,
                             auth: self.auth.as_deref(),
+                            stealth_auth: self.stealth_auth,
                         };
                         if let Some(pending) = Self::handle_request(
                             h3,
@@ -3255,7 +3267,13 @@ impl Shard {
                                     stream_id,
                                     "too many CONNECT requests awaiting authorization"
                                 );
-                                Self::send_error_response(h3, &mut client.quic, stream_id, 503);
+                                Self::send_auth_rejection(
+                                    h3,
+                                    &mut client.quic,
+                                    stream_id,
+                                    self.stealth_auth,
+                                    503,
+                                );
                             } else {
                                 client.awaiting_auth.insert(stream_id, AwaitingAuth::new());
                                 pending_auth.push(pending);
@@ -4446,6 +4464,27 @@ impl Shard {
         }
     }
 
+    /// Reject a request whose Basic credentials have not been verified.
+    ///
+    /// A stealth listener deliberately emits the same empty 404 as an
+    /// unsupported request. Ordinary listeners retain the challenge or the
+    /// overload status supplied by the caller.
+    fn send_auth_rejection(
+        h3: &mut quiche::h3::Connection,
+        quic: &mut quiche::Connection,
+        stream_id: u64,
+        stealth: bool,
+        fallback_status: u16,
+    ) {
+        if stealth {
+            Self::send_error_response(h3, quic, stream_id, 404);
+        } else if fallback_status == 407 {
+            Self::send_proxy_auth_required(h3, quic, stream_id);
+        } else {
+            Self::send_error_response(h3, quic, stream_id, fallback_status);
+        }
+    }
+
     /// Send an HTTP error response.
     fn send_error_response(
         h3: &mut quiche::h3::Connection,
@@ -4619,6 +4658,7 @@ mod tests {
             auth: AuthSection {
                 enabled: true,
                 mode,
+                stealth: false,
                 // Enough to satisfy `BasicAuthenticator`; the hash is only
                 // parsed when a request actually arrives.
                 username: "alice".into(),
@@ -4658,6 +4698,24 @@ mod tests {
         assert!(super::active_client_registry(&config, true).is_err());
     }
 
+    #[test]
+    fn stealth_auth_requires_an_enabled_basic_listener() {
+        let mut config = ServerConfig::default();
+        config.listeners[0].auth.enabled = false;
+        config.listeners[0].auth.stealth = true;
+
+        let error = match super::validate_server_config(&config) {
+            Ok(_) => panic!("stealth authentication was accepted without Basic auth"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("auth.stealth requires enabled Basic authentication"),
+            "unexpected diagnostic: {error:#}"
+        );
+    }
+
     /// The roster belongs to the server, so one certificate listener among
     /// several is enough to make it load — and to keep reload available.
     #[test]
@@ -4687,6 +4745,12 @@ mod tests {
         let reload = super::config_reload_settings(&config, Some(path.clone())).unwrap();
         assert!(!reload.client_cert_enabled);
         assert_eq!(reload.tls, config.tls);
+        assert!(!reload.listeners[0].stealth);
+
+        config.listeners[0].auth.stealth = true;
+        let reload = super::config_reload_settings(&config, Some(path.clone())).unwrap();
+        assert!(reload.listeners[0].stealth);
+        config.listeners[0].auth.stealth = false;
 
         config.listeners[0].auth.mode = AuthMode::ClientCert;
         config.ip_proxy.enabled = false;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -95,6 +95,7 @@ pub(super) fn classify_connect_request(
 pub(super) struct RequestContext<'a> {
     pub(super) config: &'a ServerConfig,
     pub(super) auth: Option<&'a SharedBasicAuthenticator>,
+    pub(super) stealth_auth: bool,
 }
 
 impl Shard {
@@ -155,13 +156,13 @@ impl Shard {
             // deliberately slow enough that it must not run on this thread.
             if duplicate_proxy_authorization {
                 warn!(stream_id, "duplicate proxy credentials");
-                Self::send_proxy_auth_required(h3, quic, stream_id);
+                Self::send_auth_rejection(h3, quic, stream_id, context.stealth_auth, 407);
                 return None;
             }
             match auth.precheck(proxy_authorization) {
                 AuthPrecheck::Rejected => {
                     warn!(stream_id, "proxy authentication failed");
-                    Self::send_proxy_auth_required(h3, quic, stream_id);
+                    Self::send_auth_rejection(h3, quic, stream_id, context.stealth_auth, 407);
                     return None;
                 }
                 AuthPrecheck::NeedsVerify {

--- a/src/support.rs
+++ b/src/support.rs
@@ -75,6 +75,7 @@ struct ListenerSummary {
     transport: &'static str,
     shards: usize,
     authentication: &'static str,
+    stealth: bool,
     basic_user_count: usize,
 }
 
@@ -194,6 +195,7 @@ pub fn collect(
                     transport: listener.transport.as_str(),
                     shards: listener.shards,
                     authentication: auth_label(&listener.auth),
+                    stealth: listener.auth.stealth_enabled(),
                     basic_user_count: basic_user_count(&listener.auth),
                 })
                 .collect(),
@@ -439,6 +441,7 @@ mod tests {
             assert!(!json.contains(secret), "bundle leaked {secret}");
         }
         assert!(json.contains("\"basic_user_count\": 1"));
+        assert!(json.contains("\"stealth\": false"));
         assert!(json.contains("\"registered_client_count\": 1"));
     }
 }

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -288,6 +288,51 @@ fn adds_a_basic_listener_with_a_password_read_from_stdin() {
 }
 
 #[test]
+fn adds_a_stealth_basic_listener() {
+    let fixture = Fixture::new(false);
+    let output = fixture.user_command(
+        "add-listener",
+        &[
+            "--listen-addr",
+            "127.0.0.1:8466",
+            "--mode",
+            "basic",
+            "--username",
+            "phone",
+            "--password-stdin",
+            "--stealth",
+            "--no-bind-check",
+        ],
+        Some(b"listener-secret\n"),
+    );
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(fixture.config().listeners[1].auth.stealth_enabled());
+    assert!(fixture.text().contains("stealth = true"));
+}
+
+#[test]
+fn refuses_stealth_without_basic_authentication() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8467",
+        "--mode",
+        "client-cert",
+        "--stealth",
+    ]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("--stealth applies only to an authenticated Basic listener")
+    );
+    fixture.assert_unchanged();
+}
+
+#[test]
 fn adding_a_basic_listener_can_emit_its_private_surge_configuration() {
     let fixture = Fixture::new(false);
     let client_path = fixture._dir.path().join("new-listener.conf");

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -124,9 +124,14 @@ fn packaged_config_uses_the_current_listener_schema() {
     assert_eq!(config.listeners.len(), 1);
     assert_eq!(config.listeners[0].listen_addr.to_string(), "0.0.0.0:443");
     assert!(config.listeners[0].auth.basic_enabled());
+    assert!(!config.listeners[0].auth.stealth_enabled());
     assert_eq!(config.listeners[0].auth.users.len(), 1);
     assert!(config.listeners[0].auth.username.is_empty());
     assert!(config.listeners[0].auth.password_hash.is_empty());
+
+    let stealth = text.replacen("stealth = false", "stealth = true", 1);
+    let config = masque::config::parse_toml(&stealth).unwrap();
+    assert!(config.listeners[0].auth.stealth_enabled());
 }
 
 #[test]

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -563,21 +563,22 @@ impl Client {
         Ok(stream_id)
     }
 
-    /// Wait for the response status on `stream_id`.
-    fn response_status(&mut self, stream_id: u64, timeout: Duration) -> anyhow::Result<u16> {
+    /// Wait for the response headers on `stream_id`.
+    fn response_headers(
+        &mut self,
+        stream_id: u64,
+        timeout: Duration,
+    ) -> anyhow::Result<Vec<(Vec<u8>, Vec<u8>)>> {
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
             loop {
                 let h3 = self.h3.as_mut().unwrap();
                 match h3.poll(&mut self.quic) {
                     Ok((sid, quiche::h3::Event::Headers { list, .. })) if sid == stream_id => {
-                        for header in &list {
-                            if header.name() == b":status" {
-                                let status = std::str::from_utf8(header.value())?;
-                                return Ok(status.parse()?);
-                            }
-                        }
-                        anyhow::bail!("response had no :status");
+                        return Ok(list
+                            .iter()
+                            .map(|header| (header.name().to_vec(), header.value().to_vec()))
+                            .collect());
                     }
                     Ok(_) => continue,
                     Err(quiche::h3::Error::Done) => break,
@@ -587,6 +588,17 @@ impl Client {
             self.drive()?;
         }
         anyhow::bail!("no response within {timeout:?}")
+    }
+
+    /// Wait for the response status on `stream_id`.
+    fn response_status(&mut self, stream_id: u64, timeout: Duration) -> anyhow::Result<u16> {
+        let headers = self.response_headers(stream_id, timeout)?;
+        let status = headers
+            .iter()
+            .find(|(name, _)| name == b":status")
+            .map(|(_, value)| value.as_slice())
+            .ok_or_else(|| anyhow::anyhow!("response had no :status"))?;
+        Ok(std::str::from_utf8(status)?.parse()?)
     }
 
     /// Collect capsules from the response body until `wanted` of them arrive.
@@ -714,6 +726,10 @@ struct DualFixture {
 /// `auth.mode` fixes the TLS context when a socket is bound, so this is the
 /// only shape in which one process can serve both.
 fn dual_fixture(tag: &str) -> DualFixture {
+    dual_fixture_with_stealth(tag, false)
+}
+
+fn dual_fixture_with_stealth(tag: &str, stealth: bool) -> DualFixture {
     let dir = TempDir::new(tag);
 
     let server_key = p256_key();
@@ -750,6 +766,7 @@ fn dual_fixture(tag: &str) -> DualFixture {
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::Basic,
+                stealth,
                 username: BASIC_USERNAME.into(),
                 password_hash: masque::auth::hash_password(BASIC_PASSWORD.as_bytes()).unwrap(),
                 users: Vec::new(),
@@ -762,6 +779,7 @@ fn dual_fixture(tag: &str) -> DualFixture {
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::ClientCert,
+                stealth: false,
                 username: String::new(),
                 password_hash: String::new(),
                 users: Vec::new(),
@@ -1391,6 +1409,61 @@ fn a_listener_enforces_only_its_own_authentication_mode() {
     assert!(
         client.wait_for_close(Duration::from_secs(5)),
         "Basic credentials must not open the certificate listener"
+    );
+}
+
+/// Surge sends Basic authorization proactively on every CONNECT, so hiding
+/// the challenge must preserve a successful first request while making all
+/// unauthenticated failures indistinguishable from the ordinary H3 404.
+#[test]
+fn stealth_basic_listener_hides_the_challenge_and_accepts_first_request_credentials() {
+    let fixture = dual_fixture_with_stealth("dual-stealth", true);
+    let mut client = Client::connect_anonymous(fixture.basic_peer).unwrap();
+    client.handshake(Duration::from_secs(5)).unwrap();
+    client.init_h3().unwrap();
+
+    let stream_id = client.send_connect_ip("connect-ip").unwrap();
+    let headers = client
+        .response_headers(stream_id, Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(
+        headers
+            .iter()
+            .find(|(name, _)| name == b":status")
+            .map(|(_, value)| value.as_slice()),
+        Some(b"404".as_slice())
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|(name, _)| name != b"proxy-authenticate"),
+        "a stealth response must not advertise Basic authentication"
+    );
+
+    let wrong = format!(
+        "Basic {}",
+        STANDARD.encode(format!("{BASIC_USERNAME}:wrong"))
+    );
+    let stream_id = client
+        .send_connect_ip_with_credentials("connect-ip", Some(&wrong))
+        .unwrap();
+    assert_eq!(
+        client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        404,
+        "wrong credentials must use the same camouflage response"
+    );
+
+    let stream_id = client
+        .send_connect_ip_with_credentials("connect-ip", Some(&fixture.credentials))
+        .unwrap();
+    assert_eq!(
+        client
+            .response_status(stream_id, Duration::from_secs(5))
+            .unwrap(),
+        200,
+        "correct credentials on the first request must still work"
     );
 }
 

--- a/tests/http2_connect.rs
+++ b/tests/http2_connect.rs
@@ -501,6 +501,80 @@ async fn basic_auth_challenges_missing_credentials_and_accepts_valid_credentials
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stealth_basic_auth_uses_404_and_accepts_proactive_credentials() {
+    let files = TestFiles::new();
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_task = tokio::spawn(async move {
+        let (mut stream, _) = target.accept().await.unwrap();
+        let mut byte = [0_u8; 1];
+        stream.read_exact(&mut byte).await.unwrap();
+        stream.write_all(&byte).await.unwrap();
+    });
+
+    let mut config = http2_config(&files);
+    config.listeners[0].auth.enabled = true;
+    config.listeners[0].auth.mode = AuthMode::Basic;
+    config.listeners[0].auth.stealth = true;
+    config.listeners[0].auth.users = vec![BasicUser {
+        username: "alice".into(),
+        password_hash: masque::auth::hash_password(b"alice-secret").unwrap(),
+    }];
+    let (server_addr, server_task) = spawn_http2_config(config).await;
+    let (mut client, driver) = connect_h2(server_addr).await;
+
+    let (response, _) = client
+        .send_request(connect_request(target_addr), true)
+        .unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(response.headers().get("proxy-authenticate").is_none());
+
+    client = client.ready().await.unwrap();
+    let mut request = connect_request(target_addr);
+    request.headers_mut().insert(
+        "proxy-authorization",
+        format!("Basic {}", STANDARD.encode("alice:wrong"))
+            .parse()
+            .unwrap(),
+    );
+    let (response, _) = client.send_request(request, true).unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(response.headers().get("proxy-authenticate").is_none());
+
+    client = client.ready().await.unwrap();
+    let mut request = connect_request(target_addr);
+    request.headers_mut().insert(
+        "proxy-authorization",
+        format!("Basic {}", STANDARD.encode("alice:alice-secret"))
+            .parse()
+            .unwrap(),
+    );
+    let (response, mut request_body) = client.send_request(request, false).unwrap();
+    let response = response.await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    request_body
+        .send_data(Bytes::from_static(b"s"), true)
+        .unwrap();
+    let mut response_body = response.into_body();
+    let echoed = tokio::time::timeout(Duration::from_secs(2), response_body.data())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(&echoed[..], b"s");
+    response_body
+        .flow_control()
+        .release_capacity(echoed.len())
+        .unwrap();
+
+    target_task.await.unwrap();
+    server_task.abort();
+    driver.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn client_certificate_authenticates_http2_connection() {
     let files = TestFiles::new();
     let client_key = p256_key();

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -184,6 +184,7 @@ DUAL_SURGE_CONFIG=$TEST_TMP/dual-surge.conf
 MASQUE_AUTH_MODE=dual \
     MASQUE_AUTH_USERNAME=proxy-user \
     MASQUE_AUTH_PASSWORD=a-strong-password \
+    MASQUE_BASIC_STEALTH=1 \
     MASQUE_LISTEN_PORT=8449 \
     MASQUE_CERT_LISTEN_PORT=8450 \
     MASQUE_CLIENT_NAME=laptop \
@@ -208,6 +209,8 @@ grep -q '^listen_addr = "0.0.0.0:8449"$' "$CONFIG_PATH" ||
     die "the Basic listener did not take MASQUE_LISTEN_PORT"
 grep -q '^listen_addr = "0.0.0.0:8450"$' "$CONFIG_PATH" ||
     die "the certificate listener did not take MASQUE_CERT_LISTEN_PORT"
+grep -q '^stealth = true$' "$CONFIG_PATH" ||
+    die "the Basic listener did not enable MASQUE_BASIC_STEALTH"
 # [server] contains only process-wide limits; listeners name every socket.
 grep -q '^\[server\]$' "$CONFIG_PATH" ||
     die "the [server] section disappeared from the dual configuration"

--- a/tools/masque-probe/Cargo.toml
+++ b/tools/masque-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masque-probe"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.88"
 description = "End-to-end connectivity diagnostics for MASQUE proxies"


### PR DESCRIPTION
## Summary

- add opt-in Basic authentication response camouflage for HTTP/2 and HTTP/3
- preserve the standard 407 challenge by default and return an empty 404 only when stealth mode is enabled
- add installer, add-listener, support-bundle, configuration, and security documentation support
- release as v0.12.1

## Compatibility

Surge sends Basic credentials with each CONNECT request, so proactive authorization continues to work when the 407 challenge is hidden. Challenge-driven clients retain the default behavior.

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --release --locked
- scripts/validate-release.sh v0.12.1
- H2 and H3 real-connection tests cover missing, wrong, and valid first-request credentials
- core release microbenchmark completed without a packet-path regression