### PR TITLE
Fix early CONNECT-UDP loss and add listener MTU override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ pre-1.0.
 
 ## Unreleased
 
+### Added
+
+- HTTP/3 listeners may override the global `quic.max_datagram_size`, allowing a
+  1200-byte low-MTU or nested-relay endpoint to coexist with 1350-byte direct
+  listeners. `add-listener --max-datagram-size` writes the same setting.
+
+### Fixed
+
+- CONNECT-UDP retains a small, bounded set of client DATAGRAMs that arrive
+  while Basic authentication or asynchronous target setup is still pending.
+  Clients such as Surge may therefore send their first UDP packet immediately
+  after the CONNECT headers without losing it before the server returns 200.
+
 ## 0.12.1 - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ a staging environment.
   CONNECT-TCP, CONNECT-UDP, and optional CONNECT-IP over HTTP/3 or HTTP/2
 - Credential-safe client configuration generation and a redacted JSON support
   bundle for reproducible troubleshooting
+- Per-listener QUIC packet ceilings for mixed direct and low-MTU relay endpoints
 - Static Linux x86_64 and ARM64 release archives with a systemd installer
 
 ## Quick start

--- a/deploy/config/masque.toml
+++ b/deploy/config/masque.toml
@@ -33,6 +33,11 @@ transport = "http3"
 # is what lets a CPU-bound server use more than one core. 0 = one per core for a
 # single listener. Linux only; measure before raising it.
 shards = 1
+# Optional HTTP/3-only override. Leave absent to inherit the 1350-byte [quic]
+# default; use 1200 for a listener dedicated to a verified low-MTU or nested
+# MASQUE path. It cannot carry the default 1280-byte CONNECT-IP packets, so use
+# it for CONNECT-UDP/TCP or lower ip_proxy.tun_mtu consistently on both ends.
+# max_datagram_size = 1200
 
 [listeners.auth]
 enabled = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,11 +170,12 @@ connection.
 
 `[[listeners]]` runs one or more listeners in one process. Startup resolves each
 entry into a small listener plan containing its transport, address, shard count,
-and authentication. Every worker references the same process-wide
+optional QUIC packet ceiling, and authentication. Every worker references the same process-wide
 `ServerConfig`, so proxy policies, TLS tuning, and limits are shared rather than
 copied. Each listener owns one authentication snapshot shared by its shards and
-established HTTP/2 connections. QUIC tuning applies only to HTTP/3,
-and HTTP/2 flow-control tuning applies only to HTTP/2. The authentication mode
+established HTTP/2 connections. QUIC tuning applies only to HTTP/3; its
+`max_datagram_size` default may be overridden by one listener. HTTP/2
+flow-control tuning applies only to HTTP/2. The authentication mode
 decides which TLS context is built, and that policy is fixed when the socket
 binds. A process-wide TLS identity snapshot is selected once per new handshake;
 `SIGHUP` validates and atomically replaces it and every active authentication

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,14 +384,16 @@ mode = "client_cert"
 | `listen_addr` | Required; there is no default, so a typo cannot silently land on someone else's port |
 | `transport` | `http3` (default) binds UDP/QUIC; `http2` binds TCP/TLS |
 | `shards` | HTTP/3 event loops; defaults to `1`. HTTP/2 must use exactly `1` |
+| `max_datagram_size` | Optional HTTP/3 packet ceiling; inherits `quic.max_datagram_size` when absent and is rejected on HTTP/2 |
 | `[listeners.auth]` | Required; authentication is always explicit per socket |
 
-Everything else stays server-wide: TLS, HTTP/2 and QUIC settings, TCP/UDP target
-policies, connection limits, one `[[clients]]` roster, one TUN device, one
-CONNECT-IP address pool, and one routing table. That is the reason to run two
-listeners in one process rather than two processes — two processes would need
-two TUN devices and two address pools, and overlapping pools hand the same
-tunnel address to two clients.
+Apart from that one QUIC packet-size override, everything else stays
+server-wide: TLS, HTTP/2 and QUIC settings, TCP/UDP target policies, connection
+limits, one `[[clients]]` roster, one TUN device, one CONNECT-IP address pool,
+and one routing table. That is the reason to run two listeners in one process
+rather than two processes — two processes would need two TUN devices and two
+address pools, and overlapping pools hand the same tunnel address to two
+clients.
 
 Use one HTTP/3 shard until a benchmark shows one event loop is CPU-bound.
 Memory and the effective connection capacity increase with the shard count.
@@ -440,7 +442,7 @@ the server will actually run rather than the ones written down
 
 ```
 configuration is compatible with masque-server 0.8.0: /etc/masque/masque.toml
-listener 0.0.0.0:443 transport=http3 auth=basic shards=1
+listener 0.0.0.0:443 transport=http3 auth=basic shards=1 max_datagram_size=1350
 listener 0.0.0.0:4443 transport=http2 auth=client_cert shards=1
 ```
 
@@ -577,6 +579,7 @@ add-listener options:
       --transport <TRANSPORT>  http3 | http2 [scripted default: http3]
       --mode <MODE>         basic | client-cert
       --shards <N>          Event loops for this listener [default: 1]
+      --max-datagram-size <BYTES>  Override the HTTP/3 QUIC packet ceiling
       --username <NAME>     Basic username
       --password-hash <PHC>  Argon2id hash, as printed by hash-password
       --password-stdin      Read the password from stdin and hash it here
@@ -594,7 +597,8 @@ add-listener options:
 Combinations that would be ignored are refused rather than dropped:
 `--username`, `--password-hash`, and `--password-stdin` apply to `--mode basic`
 only, and `--disable-auth` cannot be combined with `--mode`, since a listener
-that demands nothing has no mode to record.
+that demands nothing has no mode to record. `--max-datagram-size` applies only
+to HTTP/3; HTTP/2 uses `[http2].max_datagram_size`.
 
 The four client-output options have the same safety and file format described
 under [Basic account management](#basic-account-management). They apply only to
@@ -713,6 +717,22 @@ Important relationships:
   whole datagrams, so increasing it raises per-connection memory directly.
 - Path-MTU discovery cannot probe beyond `max_datagram_size`; raising only
   `discover_pmtu` has no benefit.
+- `quic.max_datagram_size` remains the default for every HTTP/3 listener. An
+  individual listener may override it in its own block:
+
+  ```toml
+  [[listeners]]
+  listen_addr = "[::]:9449"
+  transport = "http3"
+  max_datagram_size = 1200
+  ```
+
+  The override must be `1200..65535`, is rejected on HTTP/2, and needs a
+  restart. Keep ordinary direct listeners at the 1350 default; 1200 is useful
+  for a low-MTU path or an inner QUIC connection carried through another
+  MASQUE hop. A 1200-byte listener cannot carry the default 1280-byte
+  CONNECT-IP packets; reserve it for CONNECT-UDP/TCP traffic, or lower
+  `ip_proxy.tun_mtu` consistently on both ends before using CONNECT-IP there.
 - UDP GSO is opt-in because some virtual egress paths advertise it but drop
   super-packets. Enable it only after an external-path A/B test.
 - Supported congestion controllers are `cubic`, `reno`, and `bbr2`. CUBIC is

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -96,6 +96,7 @@ Important settings:
 | Setting | Effect |
 | --- | --- |
 | `listeners[].shards` | Aggregate multi-connection CPU parallelism for that listener |
+| `listeners[].max_datagram_size` | Optional HTTP/3 packet ceiling for a low-MTU or nested listener; otherwise inherits `quic.max_datagram_size` |
 | `http2.initial_*_window` | HTTP/2 initial bandwidth-delay credit |
 | `http2.max_concurrent_streams` | HTTP/2 per-connection stream concurrency |
 | `http2.max_send_buffer_size` | HTTP/2 buffered response bound per stream |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -326,7 +326,7 @@ that, and all three were hit while qualifying this feature:
 | In-tunnel traffic works, egress does not | The host's forwarding path, not the server. See [Egress testing needs an uncontended host](#egress-testing-needs-an-uncontended-host). |
 | Egress ICMP works but TCP hangs | Almost always a transparent proxy on the server host that exempts ICMP from its policy routing. Check `ip rule show`. |
 | Server logs `spoofed source address, dropping` | The client's interface address disagrees with its pinned address. Re-enroll so both sides match. |
-| Small packets work, bulk transfers stall | The framed MTU exceeds the selected transport's datagram budget. Raise `quic.max_datagram_size` for HTTP/3 or `http2.max_datagram_size` for HTTP/2, or lower the client's MTU; keep the client at 1280 unless both ends were changed together. |
+| Small packets work, bulk transfers stall | The framed MTU exceeds the selected transport's datagram budget. Raise `quic.max_datagram_size` (or that HTTP/3 listener's `max_datagram_size`) for HTTP/3, raise `http2.max_datagram_size` for HTTP/2, or lower the client's MTU; keep the client at 1280 unless both ends were changed together. |
 | Tunnel drops roughly every 30s | `server.idle_timeout_secs` is at or below the client's keepalive period. |
 
 ## Release checklist

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,6 +215,12 @@ pub struct ListenerSection {
     /// one per available core and is accepted only for a single listener.
     #[serde(default = "default_listener_shards")]
     pub shards: usize,
+    /// Optional HTTP/3 packet-size ceiling for this listener. When absent,
+    /// `quic.max_datagram_size` remains the process-wide default. A listener
+    /// override lets a relay/low-MTU endpoint use 1200 without penalising
+    /// ordinary single-hop listeners.
+    #[serde(default)]
+    pub max_datagram_size: Option<usize>,
     /// Authentication for this listener. Required so a socket's trust boundary
     /// is never inherited from a distant part of the file.
     pub auth: AuthSection,
@@ -230,7 +236,14 @@ pub struct ResolvedListener {
     pub listen_addr: SocketAddr,
     pub transport: ListenerTransport,
     pub shards: usize,
+    pub max_datagram_size: Option<usize>,
     pub auth: AuthSection,
+}
+
+impl ResolvedListener {
+    pub fn effective_quic_max_datagram_size(&self, default: usize) -> usize {
+        self.max_datagram_size.unwrap_or(default)
+    }
 }
 
 /// One pre-registered client.
@@ -410,6 +423,7 @@ impl Default for ServerConfig {
                 listen_addr: "0.0.0.0:443".parse().unwrap(),
                 transport: ListenerTransport::Http3,
                 shards: default_listener_shards(),
+                max_datagram_size: None,
                 auth: AuthSection::default(),
             }],
         }
@@ -821,6 +835,34 @@ mode = "client_cert"
         assert_eq!(cfg.listeners[1].shards, 2);
         assert!(cfg.listeners[1].auth.client_cert_enabled());
         assert!(!cfg.listeners[1].auth.basic_enabled());
+    }
+
+    #[test]
+    fn http3_listener_can_override_the_global_datagram_size() {
+        let cfg = parse_toml(
+            r#"
+[quic]
+max_datagram_size = 1350
+
+[[listeners]]
+listen_addr = "0.0.0.0:8443"
+max_datagram_size = 1200
+
+[listeners.auth]
+enabled = false
+
+[[listeners]]
+listen_addr = "0.0.0.0:8444"
+
+[listeners.auth]
+enabled = false
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.quic.max_datagram_size, 1350);
+        assert_eq!(cfg.listeners[0].max_datagram_size, Some(1200));
+        assert_eq!(cfg.listeners[1].max_datagram_size, None);
     }
 
     #[test]

--- a/src/config_edit.rs
+++ b/src/config_edit.rs
@@ -63,6 +63,7 @@ pub struct AddListener {
     pub transport: Option<ListenerTransport>,
     pub mode: Option<AuthMode>,
     pub shards: Option<usize>,
+    pub max_datagram_size: Option<usize>,
     pub username: Option<String>,
     pub password_hash: Option<String>,
     /// Read the password from standard input and hash it.
@@ -201,6 +202,12 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         (ListenerTransport::Http3, None) if interactive => prompt_shards()?,
         (ListenerTransport::Http3, None) => 1,
     };
+    if transport == ListenerTransport::Http2 && request.max_datagram_size.is_some() {
+        bail!(
+            "--max-datagram-size applies only to an HTTP/3 listener; use \
+             [http2].max_datagram_size for HTTP/2"
+        );
+    }
 
     let mut resolved_password: Option<ResolvedUserPassword> = None;
     let auth = if request.disable_auth {
@@ -254,6 +261,7 @@ pub fn add_listener(config_path: &Path, request: AddListener) -> anyhow::Result<
         listen_addr,
         transport,
         shards,
+        max_datagram_size: request.max_datagram_size,
         auth,
     };
 
@@ -907,6 +915,9 @@ pub fn listener_toml_block(listener: &ListenerSection) -> String {
         toml_string(listener.transport.as_str())
     ));
     block.push_str(&format!("shards = {}\n", listener.shards));
+    if let Some(max_datagram_size) = listener.max_datagram_size {
+        block.push_str(&format!("max_datagram_size = {max_datagram_size}\n"));
+    }
     block.push_str("\n[listeners.auth]\n");
 
     if !listener.auth.enabled {
@@ -1537,6 +1548,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
             listen_addr: format!("0.0.0.0:{port}").parse().unwrap(),
             transport: config::ListenerTransport::Http3,
             shards: 1,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::ClientCert,
@@ -1559,6 +1571,17 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
         assert!(listener_toml_block(&listener).contains("transport = \"http3\""));
     }
 
+    #[test]
+    fn listener_block_preserves_an_http3_datagram_size_override() {
+        let mut listener = client_cert_listener(4443);
+        listener.max_datagram_size = Some(1200);
+        let block = listener_toml_block(&listener);
+        assert!(block.contains("max_datagram_size = 1200"));
+
+        let parsed = config::parse_toml(&append_block(BASIC_CONFIG, &block)).unwrap();
+        assert_eq!(parsed.listeners[1], listener);
+    }
+
     /// The edit is textual, so the comments an operator relies on must survive
     /// it. That is the whole reason the file is not re-serialised.
     #[test]
@@ -1577,6 +1600,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
             listen_addr: "127.0.0.1:8443".parse().unwrap(),
             transport: config::ListenerTransport::Http3,
             shards: 2,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::Basic,
@@ -1610,6 +1634,7 @@ password_hash = "$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$hash"
             listen_addr: "127.0.0.1:8443".parse().unwrap(),
             transport: config::ListenerTransport::Http3,
             shards: 1,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: false,
                 mode: AuthMode::Basic,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,21 +9,33 @@ use crate::fxhash::FxHashMap;
 use crate::metrics::ShardMetrics;
 use crate::tunnel::ip::IpTunnel;
 use crate::tunnel::tcp::{PendingTcpTunnel, TcpTunnel};
-use crate::tunnel::udp::{PendingUdpTunnel, UdpTunnel};
+use crate::tunnel::udp::{EarlyUdpBudget, EarlyUdpDatagrams, PendingUdpTunnel, UdpTunnel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EarlyUdpDatagramResult {
+    Buffered,
+    CapacityExceeded,
+    UnknownTunnel,
+}
 
 /// One CONNECT stream waiting for its credentials to be verified.
 pub(crate) struct AwaitingAuth {
     pub(crate) client_finished: bool,
     cancelled: Arc<AtomicBool>,
     task: Option<tokio::task::AbortHandle>,
+    /// Present only for CONNECT-UDP. TCP request bodies remain in quiche under
+    /// stream flow control, while UDP DATAGRAM frames have already left
+    /// quiche's bounded receive queue by the time this state sees them.
+    early_udp_datagrams: Option<EarlyUdpDatagrams>,
 }
 
 impl AwaitingAuth {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(connect_udp: bool, early_udp_budget: EarlyUdpBudget) -> Self {
         Self {
             client_finished: false,
             cancelled: Arc::new(AtomicBool::new(false)),
             task: None,
+            early_udp_datagrams: connect_udp.then(|| EarlyUdpDatagrams::new(early_udp_budget)),
         }
     }
 
@@ -37,6 +49,20 @@ impl AwaitingAuth {
         if let Some(previous) = self.task.replace(task) {
             previous.abort();
         }
+    }
+
+    fn buffer_early_udp_datagram(&mut self, payload: &[u8]) -> Option<bool> {
+        self.early_udp_datagrams
+            .as_mut()
+            .map(|datagrams| datagrams.push(payload))
+    }
+
+    fn accepts_early_udp_datagrams(&self) -> bool {
+        self.early_udp_datagrams.is_some()
+    }
+
+    pub(crate) fn take_early_udp_datagrams(&mut self) -> Option<EarlyUdpDatagrams> {
+        self.early_udp_datagrams.take()
     }
 }
 
@@ -104,6 +130,10 @@ pub struct ClientConnection {
     /// quiche, so an unauthenticated caller cannot make the server buffer
     /// anything; stream flow control bounds them until the tunnel exists.
     pub(crate) awaiting_auth: FxHashMap<u64, AwaitingAuth>,
+    /// One constant-time memory budget shared by every early CONNECT-UDP
+    /// queue on this connection. Queue ownership carries the reservation
+    /// through authentication and target setup.
+    early_udp_budget: EarlyUdpBudget,
     /// Dense index for this connection, used as the `conn_id` in
     /// `TunnelOwner` and to address the connection from background tasks.
     pub index: u64,
@@ -151,6 +181,7 @@ impl ClientConnection {
             udp_tunnels: FxHashMap::default(),
             ip_tunnels: FxHashMap::default(),
             awaiting_auth: FxHashMap::default(),
+            early_udp_budget: EarlyUdpBudget::default(),
             index,
             identity: None,
             deferred_send: DeferredSend::default(),
@@ -165,6 +196,10 @@ impl ClientConnection {
 
     pub(crate) fn source_ip(&self) -> std::net::IpAddr {
         self.source_admission.source()
+    }
+
+    pub(crate) fn early_udp_budget(&self) -> EarlyUdpBudget {
+        self.early_udp_budget.clone()
     }
 
     /// Transfer this connection's source budget after QUIC validates a new
@@ -197,6 +232,47 @@ impl ClientConnection {
 
     pub(crate) fn primary_connection_id_active(&self) -> bool {
         self.primary_connection_id_active
+    }
+
+    /// Buffer a context-zero DATAGRAM for a CONNECT-UDP stream that exists but
+    /// cannot relay yet. This covers both Basic verification and asynchronous
+    /// DNS/socket setup without adding storage to the active-tunnel hot path.
+    pub(crate) fn buffer_early_udp_datagram(
+        &mut self,
+        stream_id: u64,
+        payload: &[u8],
+    ) -> EarlyUdpDatagramResult {
+        let pending_setup = self.pending_udp_tunnels.contains_key(&stream_id);
+        let pending_auth = self
+            .awaiting_auth
+            .get(&stream_id)
+            .is_some_and(AwaitingAuth::accepts_early_udp_datagrams);
+        if !pending_setup && !pending_auth {
+            // Keep unknown-stream floods on the same constant-time path they
+            // had before early buffering was added. Summing the connection's
+            // bounded queues is necessary only for a stream we may retain.
+            return EarlyUdpDatagramResult::UnknownTunnel;
+        }
+
+        if let Some(tunnel) = self.pending_udp_tunnels.get_mut(&stream_id) {
+            return if tunnel.buffer_early_datagram(payload) {
+                EarlyUdpDatagramResult::Buffered
+            } else {
+                EarlyUdpDatagramResult::CapacityExceeded
+            };
+        }
+
+        if let Some(awaiting) = self.awaiting_auth.get_mut(&stream_id)
+            && let Some(buffered) = awaiting.buffer_early_udp_datagram(payload)
+        {
+            return if buffered {
+                EarlyUdpDatagramResult::Buffered
+            } else {
+                EarlyUdpDatagramResult::CapacityExceeded
+            };
+        }
+
+        EarlyUdpDatagramResult::UnknownTunnel
     }
 
     /// The next instant this connection needs the event loop's attention:
@@ -285,7 +361,7 @@ mod tests {
             let _slot = slot;
             std::future::pending::<()>().await;
         });
-        let mut awaiting = AwaitingAuth::new();
+        let mut awaiting = AwaitingAuth::new(false, EarlyUdpBudget::default());
         let cancelled = awaiting.cancellation_flag();
         awaiting.set_task(task.abort_handle());
 
@@ -297,5 +373,16 @@ mod tests {
             .expect_err("dropping auth state must abort its task");
         assert!(error.is_cancelled());
         assert_eq!(slots.available_permits(), 1);
+    }
+
+    #[test]
+    fn only_udp_auth_state_accepts_early_datagrams() {
+        let mut tcp = AwaitingAuth::new(false, EarlyUdpBudget::default());
+        assert_eq!(tcp.buffer_early_udp_datagram(b"ignored"), None);
+
+        let mut udp = AwaitingAuth::new(true, EarlyUdpBudget::default());
+        assert_eq!(udp.buffer_early_udp_datagram(b"first"), Some(true));
+        let buffered = udp.take_early_udp_datagrams().unwrap();
+        assert_eq!(buffered.into_payloads(), vec![b"first".to_vec()]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,12 @@ enum Command {
         #[arg(long)]
         shards: Option<usize>,
 
+        /// Override quic.max_datagram_size for this HTTP/3 listener. Use 1200
+        /// for a low-MTU or nested relay endpoint while leaving direct
+        /// listeners on the global default.
+        #[arg(long)]
+        max_datagram_size: Option<usize>,
+
         /// Basic username.
         #[arg(long)]
         username: Option<String>,
@@ -571,6 +577,7 @@ async fn main() -> anyhow::Result<()> {
         transport,
         mode,
         shards,
+        max_datagram_size,
         username,
         password_hash,
         password_stdin,
@@ -605,6 +612,7 @@ async fn main() -> anyhow::Result<()> {
                 transport: transport.map(Into::into),
                 mode: mode.map(Into::into),
                 shards: *shards,
+                max_datagram_size: *max_datagram_size,
                 username: username.clone(),
                 password_hash: password_hash.clone(),
                 password_stdin: *password_stdin,
@@ -763,13 +771,24 @@ async fn main() -> anyhow::Result<()> {
         // shard count is the resolved one — `shards = 0` means one per core and
         // a large value is capped, neither of which the file shows.
         for listener in listeners {
-            println!(
-                "listener {} transport={} auth={} shards={}",
-                listener.listen_addr,
-                listener.transport.as_str(),
-                auth_label(&listener.auth),
-                listener.shards
-            );
+            if listener.transport == masque::config::ListenerTransport::Http3 {
+                println!(
+                    "listener {} transport={} auth={} shards={} max_datagram_size={}",
+                    listener.listen_addr,
+                    listener.transport.as_str(),
+                    auth_label(&listener.auth),
+                    listener.shards,
+                    listener.effective_quic_max_datagram_size(cfg.quic.max_datagram_size)
+                );
+            } else {
+                println!(
+                    "listener {} transport={} auth={} shards={}",
+                    listener.listen_addr,
+                    listener.transport.as_str(),
+                    auth_label(&listener.auth),
+                    listener.shards
+                );
+            }
         }
         if let Some(addr) = cfg.observability.listen_addr {
             println!("observability {addr} health=/healthz ready=/readyz metrics=/metrics");

--- a/src/server/authentication.rs
+++ b/src/server/authentication.rs
@@ -198,11 +198,12 @@ impl Shard {
                 return;
             };
 
-            let Some(awaiting) = client.awaiting_auth.remove(&stream_id) else {
+            let Some(mut awaiting) = client.awaiting_auth.remove(&stream_id) else {
                 // The stream was reset while the hash was running.
                 return;
             };
             let client_finished = awaiting.client_finished;
+            let early_udp_datagrams = awaiting.take_early_udp_datagrams();
 
             if !authorized {
                 warn!(stream_id, "proxy authentication failed");
@@ -258,7 +259,10 @@ impl Shard {
                 debug_assert_eq!(*pending_stream, stream_id);
                 client.pending_udp_tunnels.insert(
                     stream_id,
-                    crate::tunnel::udp::PendingUdpTunnel::new(*header),
+                    crate::tunnel::udp::PendingUdpTunnel::with_early_datagrams(
+                        *header,
+                        early_udp_datagrams.unwrap_or_default(),
+                    ),
                 );
             }
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use self::authentication::AuthOutcome;
-use self::request::{PendingAuth, PendingConnectSetups, RequestContext};
+use self::request::{ConnectRequest, PendingAuth, PendingConnectSetups, RequestContext};
 use crate::address_pool::{AddressPool, PoolError};
 use crate::admission::SourceAdmissionLimiter;
 use crate::auth::{BasicAuthenticator, SharedBasicAuthenticator};
@@ -31,7 +31,7 @@ use crate::client_identity::{
     ClientIdentity, ClientRegistry, SharedRoster, configure_client_cert_verification,
 };
 use crate::config::{AuthSection, ListenerTransport, ResolvedListener, ServerConfig, TlsSection};
-use crate::connection::{AwaitingAuth, ClientConnection};
+use crate::connection::{AwaitingAuth, ClientConnection, EarlyUdpDatagramResult};
 use crate::datagram;
 use crate::fxhash::FxHashMap;
 use crate::ip_packet;
@@ -481,6 +481,7 @@ fn plan_listeners(config: &ServerConfig) -> anyhow::Result<Vec<ListenerPlan>> {
                 listen_addr: listener.listen_addr,
                 transport: listener.transport,
                 shards,
+                max_datagram_size: listener.max_datagram_size,
                 auth: listener.auth.clone(),
             },
         });
@@ -697,6 +698,26 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
             MAX_DATAGRAM_SIZE
         );
     }
+    for plan in &listeners {
+        let Some(max_datagram_size) = plan.listener.max_datagram_size else {
+            continue;
+        };
+        if plan.listener.transport != ListenerTransport::Http3 {
+            anyhow::bail!(
+                "listener {} max_datagram_size is an HTTP/3-only override; use \
+                 http2.max_datagram_size for an HTTP/2 listener",
+                plan.listener.listen_addr
+            );
+        }
+        if !(quiche::MIN_CLIENT_INITIAL_LEN..=MAX_DATAGRAM_SIZE).contains(&max_datagram_size) {
+            anyhow::bail!(
+                "listener {} max_datagram_size ({max_datagram_size}) must be between {} and {} bytes",
+                plan.listener.listen_addr,
+                quiche::MIN_CLIENT_INITIAL_LEN,
+                MAX_DATAGRAM_SIZE
+            );
+        }
+    }
 
     if !(1..=MAX_HTTP2_STREAM_WINDOW).contains(&config.http2.initial_stream_window) {
         anyhow::bail!(
@@ -789,8 +810,14 @@ fn validate_server_config(config: &ServerConfig) -> anyhow::Result<ValidatedServ
             .then(|| Arc::new(SharedRoster::new(clients.clone())));
         match plan.listener.transport {
             ListenerTransport::Http3 => {
-                build_quic_config(config, client_certs, Arc::clone(&tls))
-                    .with_context(|| format!("listener {}", plan.listener.listen_addr))?;
+                build_quic_config(
+                    config,
+                    plan.listener
+                        .effective_quic_max_datagram_size(config.quic.max_datagram_size),
+                    client_certs,
+                    Arc::clone(&tls),
+                )
+                .with_context(|| format!("listener {}", plan.listener.listen_addr))?;
             }
             ListenerTransport::Http2 => {
                 http2::build_acceptor(client_certs, Arc::clone(&tls))
@@ -847,10 +874,11 @@ async fn open_quic_socket(
     config: &ServerConfig,
     listen_addr: SocketAddr,
     reuseport_shards: usize,
+    max_datagram_size: usize,
 ) -> anyhow::Result<QuicUdpSocket> {
     QuicUdpSocket::bind_shared(
         listen_addr,
-        config.quic.max_datagram_size,
+        max_datagram_size,
         config.quic.enable_udp_gso,
         config.quic.enable_udp_gro,
         reuseport_shards,
@@ -869,10 +897,12 @@ async fn bind_first_listener_socket(
     config: &ServerConfig,
     requested: SocketAddr,
     reuseport_shards: usize,
+    max_datagram_size: usize,
     unavailable: &[SocketAddr],
 ) -> anyhow::Result<(QuicUdpSocket, SocketAddr)> {
     for attempt in 1..=MAX_EPHEMERAL_BIND_ATTEMPTS {
-        let socket = open_quic_socket(config, requested, reuseport_shards).await?;
+        let socket =
+            open_quic_socket(config, requested, reuseport_shards, max_datagram_size).await?;
         let bound = socket.local_addr()?;
 
         if requested.port() != 0 {
@@ -1056,6 +1086,8 @@ impl Server {
                 &config,
                 plan.listener.listen_addr,
                 plan.listener.shards,
+                plan.listener
+                    .effective_quic_max_datagram_size(config.quic.max_datagram_size),
                 &unavailable_http3_addrs,
             )
             .await?;
@@ -1701,6 +1733,7 @@ fn encode_ip_setup_capsules(addresses: &[IpAddr]) -> Vec<u8> {
 /// live shards.
 fn build_quic_config(
     config: &ServerConfig,
+    max_datagram_size: usize,
     client_certs: Option<Arc<SharedRoster>>,
     tls_identity: Arc<tls::SharedTlsIdentity>,
 ) -> anyhow::Result<quiche::Config> {
@@ -1741,8 +1774,8 @@ fn build_quic_config(
 
     // Transport parameters.
     quic_config.set_max_idle_timeout(idle_timeout_ms);
-    quic_config.set_max_recv_udp_payload_size(config.quic.max_datagram_size);
-    quic_config.set_max_send_udp_payload_size(config.quic.max_datagram_size);
+    quic_config.set_max_recv_udp_payload_size(max_datagram_size);
+    quic_config.set_max_send_udp_payload_size(max_datagram_size);
     quic_config.set_initial_max_data(config.quic.initial_max_data);
     quic_config.set_initial_max_stream_data_bidi_local(config.quic.initial_max_stream_data);
     quic_config.set_initial_max_stream_data_bidi_remote(config.quic.initial_max_stream_data);
@@ -2174,6 +2207,10 @@ struct Shard {
     client_certs: Option<Arc<SharedRoster>>,
     tcp_policy: TargetPolicy,
     udp_policy: TargetPolicy,
+    /// Effective QUIC packet ceiling for this listener. This is copied out of
+    /// the resolved listener so the datagram hot path does not repeatedly
+    /// consult an optional override.
+    max_datagram_size: usize,
     config: Arc<ServerConfig>,
     /// Reverse index for routing TUN packets without scanning every connection.
     conn_by_index: FxHashMap<u64, quiche::ConnectionId<'static>>,
@@ -2207,7 +2244,15 @@ impl Shard {
         forward_rx: mpsc::Receiver<ForwardedPacketBatch>,
         tun_rx: mpsc::Receiver<Vec<u8>>,
     ) -> anyhow::Result<Self> {
-        let socket = open_quic_socket(&config, listener.listen_addr, listener.shards).await?;
+        let max_datagram_size =
+            listener.effective_quic_max_datagram_size(config.quic.max_datagram_size);
+        let socket = open_quic_socket(
+            &config,
+            listener.listen_addr,
+            listener.shards,
+            max_datagram_size,
+        )
+        .await?;
         Self::from_socket(
             index,
             listener_shard_index,
@@ -2251,6 +2296,8 @@ impl Shard {
             None
         };
         let bound_addr = socket.local_addr()?;
+        let max_datagram_size =
+            listener.effective_quic_max_datagram_size(config.quic.max_datagram_size);
         metrics.set_udp_offload_state(socket.udp_gso_enabled(), socket.udp_gro_enabled());
         info!(
             shard = index,
@@ -2258,6 +2305,7 @@ impl Shard {
             addr = %bound_addr,
             udp_gso = socket.udp_gso_enabled(),
             udp_gro = socket.udp_gro_enabled(),
+            max_datagram_size,
             reuseport_cid_steering = socket.reuseport_cid_steering_enabled(),
             "listening"
         );
@@ -2271,6 +2319,7 @@ impl Shard {
 
         let quic_config = build_quic_config(
             &config,
+            max_datagram_size,
             client_certs.as_ref().map(Arc::clone),
             Arc::clone(&shared.tls),
         )?;
@@ -2306,6 +2355,7 @@ impl Shard {
             client_certs,
             tcp_policy,
             udp_policy,
+            max_datagram_size,
             config,
             conn_by_index: FxHashMap::default(),
             udp_response_tx,
@@ -3241,6 +3291,7 @@ impl Shard {
         let mut closed_ip_streams: Vec<u64> = Vec::new();
         let mut failed_tcp_streams: Vec<u64> = Vec::new();
         let mut pending_auth: Vec<PendingAuth> = Vec::new();
+        let early_udp_budget = client.early_udp_budget();
 
         // Process HTTP/3 events.
         if let Some(h3) = &mut client.h3 {
@@ -3275,7 +3326,12 @@ impl Shard {
                                     503,
                                 );
                             } else {
-                                client.awaiting_auth.insert(stream_id, AwaitingAuth::new());
+                                let connect_udp =
+                                    matches!(&pending.request, ConnectRequest::Udp { .. });
+                                client.awaiting_auth.insert(
+                                    stream_id,
+                                    AwaitingAuth::new(connect_udp, early_udp_budget.clone()),
+                                );
                                 pending_auth.push(pending);
                             }
                         }
@@ -3291,9 +3347,10 @@ impl Shard {
                             let (pending_stream, _, header) =
                                 pending_setups.udp.last().expect("one UDP setup added");
                             debug_assert_eq!(*pending_stream, stream_id);
-                            client
-                                .pending_udp_tunnels
-                                .insert(stream_id, PendingUdpTunnel::new(*header));
+                            client.pending_udp_tunnels.insert(
+                                stream_id,
+                                PendingUdpTunnel::new(*header, early_udp_budget.clone()),
+                            );
                         }
                     }
                     Ok((stream_id, quiche::h3::Event::Data)) => {
@@ -3437,11 +3494,7 @@ impl Shard {
         // so matching that effective QUIC limit keeps target responses intact
         // without allowing a bad configuration to allocate unbounded buffers
         // per tunnel.
-        let target_datagram_size = self
-            .config
-            .quic
-            .max_datagram_size
-            .clamp(1, MAX_DATAGRAM_SIZE);
+        let target_datagram_size = self.max_datagram_size.clamp(1, MAX_DATAGRAM_SIZE);
         let enable_target_udp_gso = self.config.udp_proxy.enable_udp_gso;
         for (stream_id, target, _header) in pending_udp_setups {
             if !client.pending_udp_tunnels.contains_key(&stream_id) {
@@ -3694,11 +3747,12 @@ impl Shard {
         let Some(client) = self.connections.get_mut(&conn_id) else {
             return;
         };
-        let Some(pending) = client.pending_udp_tunnels.remove(&stream_id) else {
+        let Some(mut pending) = client.pending_udp_tunnels.remove(&stream_id) else {
             // The stream or connection disappeared while DNS was in flight.
             return;
         };
         let header = pending.header();
+        let early_datagrams = pending.take_early_datagrams();
         drop(pending);
         self.dirty.mark(connection_index);
 
@@ -3733,11 +3787,7 @@ impl Shard {
         let (send_socket, socket, target_addr, target_udp_gso) = prepared.into_http3();
         let recv_socket = Arc::clone(&socket);
         let response_tx = self.udp_response_tx.clone();
-        let target_datagram_size = self
-            .config
-            .quic
-            .max_datagram_size
-            .clamp(1, MAX_DATAGRAM_SIZE);
+        let target_datagram_size = self.max_datagram_size.clamp(1, MAX_DATAGRAM_SIZE);
         let recv_task = tokio::spawn(async move {
             // One `recvmmsg` per readiness instead of a `recvfrom` per
             // datagram, and one channel send per batch.
@@ -3771,7 +3821,7 @@ impl Shard {
                 }
             }
         });
-        let tunnel = UdpTunnel::from_socket(
+        let mut tunnel = UdpTunnel::from_socket(
             stream_id,
             target_addr,
             send_socket,
@@ -3779,6 +3829,28 @@ impl Shard {
             recv_task,
             target_udp_gso,
         );
+        let early_datagram_count = early_datagrams.len();
+        let early_datagram_bytes = early_datagrams.bytes();
+        if early_datagram_count > 0 {
+            for payload in early_datagrams.into_payloads() {
+                if tunnel.stage_to_target(&payload)
+                    && let Err(error) = tunnel.flush_to_target()
+                {
+                    debug!(stream_id, %error, "failed to flush early UDP datagrams");
+                }
+            }
+            if tunnel.has_staged()
+                && let Err(error) = tunnel.flush_to_target()
+            {
+                debug!(stream_id, %error, "failed to flush early UDP datagrams");
+            }
+            debug!(
+                stream_id,
+                datagrams = early_datagram_count,
+                bytes = early_datagram_bytes,
+                "relayed buffered early UDP datagrams"
+            );
+        }
         info!(
             stream_id,
             target = %target_addr,
@@ -4149,6 +4221,26 @@ impl Shard {
                         tun_send.push(dgram.payload);
                     }
                     continue;
+                }
+
+                match client.buffer_early_udp_datagram(dgram.stream_id, dgram.payload) {
+                    EarlyUdpDatagramResult::Buffered => {
+                        debug!(
+                            stream_id = dgram.stream_id,
+                            bytes = dgram.payload.len(),
+                            "buffered early UDP datagram"
+                        );
+                        continue;
+                    }
+                    EarlyUdpDatagramResult::CapacityExceeded => {
+                        debug!(
+                            stream_id = dgram.stream_id,
+                            bytes = dgram.payload.len(),
+                            "early UDP datagram buffer full, dropping packet"
+                        );
+                        continue;
+                    }
+                    EarlyUdpDatagramResult::UnknownTunnel => {}
                 }
 
                 debug!(stream_id = dgram.stream_id, "datagram for unknown tunnel");
@@ -4655,6 +4747,7 @@ mod tests {
             listen_addr: addr.parse().unwrap(),
             transport: ListenerTransport::Http3,
             shards: 1,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: true,
                 mode,
@@ -4923,6 +5016,55 @@ mod tests {
             plans[1].listener.listen_addr,
             "127.0.0.1:8444".parse::<std::net::SocketAddr>().unwrap()
         );
+    }
+
+    #[test]
+    fn listener_datagram_size_overrides_only_its_http3_socket() {
+        let mut relay = listener("127.0.0.1:8443", AuthMode::Basic);
+        relay.max_datagram_size = Some(1200);
+        let direct = listener("127.0.0.1:8444", AuthMode::Basic);
+        let config = config_with(vec![relay, direct]);
+
+        let plans = super::plan_listeners(&config).unwrap();
+        assert_eq!(
+            plans[0]
+                .listener
+                .effective_quic_max_datagram_size(config.quic.max_datagram_size),
+            1200
+        );
+        assert_eq!(
+            plans[1]
+                .listener
+                .effective_quic_max_datagram_size(config.quic.max_datagram_size),
+            1350
+        );
+    }
+
+    #[test]
+    fn listener_datagram_size_is_bounded_and_http3_only() {
+        for invalid in [
+            quiche::MIN_CLIENT_INITIAL_LEN - 1,
+            super::MAX_DATAGRAM_SIZE + 1,
+        ] {
+            let mut http3 = listener("127.0.0.1:8443", AuthMode::Basic);
+            http3.auth.enabled = false;
+            http3.max_datagram_size = Some(invalid);
+            let error = match super::validate_server_config(&config_with(vec![http3])) {
+                Ok(_) => panic!("invalid listener datagram size was accepted"),
+                Err(error) => error.to_string(),
+            };
+            assert!(error.contains("max_datagram_size"), "{error}");
+        }
+
+        let mut http2 = listener("127.0.0.1:8443", AuthMode::Basic);
+        http2.auth.enabled = false;
+        http2.transport = ListenerTransport::Http2;
+        http2.max_datagram_size = Some(1200);
+        let error = match super::validate_server_config(&config_with(vec![http2])) {
+            Ok(_) => panic!("HTTP/2 listener accepted a QUIC-only override"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("HTTP/3-only"), "{error}");
     }
 
     /// Not just a bind failure: a multi-shard listener uses SO_REUSEPORT, so a

--- a/src/support.rs
+++ b/src/support.rs
@@ -15,7 +15,7 @@ use anyhow::Context as _;
 use boring::x509::X509;
 use serde::Serialize;
 
-use crate::config::{ResolvedListener, ServerConfig};
+use crate::config::{ListenerTransport, ResolvedListener, ServerConfig};
 use crate::host;
 
 #[derive(Debug, Serialize)]
@@ -74,6 +74,7 @@ struct ListenerSummary {
     listen_addr: String,
     transport: &'static str,
     shards: usize,
+    max_datagram_size: Option<usize>,
     authentication: &'static str,
     stealth: bool,
     basic_user_count: usize,
@@ -194,6 +195,9 @@ pub fn collect(
                     listen_addr: listener.listen_addr.to_string(),
                     transport: listener.transport.as_str(),
                     shards: listener.shards,
+                    max_datagram_size: (listener.transport == ListenerTransport::Http3).then(
+                        || listener.effective_quic_max_datagram_size(config.quic.max_datagram_size),
+                    ),
                     authentication: auth_label(&listener.auth),
                     stealth: listener.auth.stealth_enabled(),
                     basic_user_count: basic_user_count(&listener.auth),
@@ -422,6 +426,7 @@ mod tests {
             listen_addr: config.listeners[0].listen_addr,
             transport: ListenerTransport::Http3,
             shards: 1,
+            max_datagram_size: None,
             auth: config.listeners[0].auth.clone(),
         }];
 

--- a/src/tunnel/udp.rs
+++ b/src/tunnel/udp.rs
@@ -5,6 +5,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::net::UdpSocket;
@@ -21,6 +22,109 @@ use crate::policy::TargetPolicy;
 use crate::uri::UdpTarget;
 
 use super::target::{TargetSetupFailure, resolve_allowed};
+
+/// Early client DATAGRAMs retained while authorization or target setup is in
+/// flight. Surge sends its first packet immediately after the CONNECT headers,
+/// before it has received the successful response, so dropping these packets
+/// makes an otherwise valid CONNECT-UDP tunnel look dead.
+///
+/// The bounds are deliberately small and local to one stream. Basic-auth
+/// requests can enter this state before their password has been verified, so
+/// this storage must never scale with an attacker-controlled datagram burst.
+const MAX_EARLY_DATAGRAMS_PER_TUNNEL: usize = 8;
+const MAX_EARLY_DATAGRAM_BYTES_PER_TUNNEL: usize = 64 * 1024;
+const MAX_EARLY_DATAGRAM_BYTES_PER_CONNECTION: usize = 64 * 1024;
+
+/// Shared allocation budget for every early-DATAGRAM queue on one QUIC
+/// connection. Keeping the counter beside the retained bytes makes stream
+/// reset, authentication failure, and connection teardown release capacity
+/// automatically without scanning all pending tunnels.
+#[derive(Clone, Default)]
+pub(crate) struct EarlyUdpBudget {
+    bytes: Arc<AtomicUsize>,
+}
+
+impl EarlyUdpBudget {
+    fn try_reserve(&self, bytes: usize) -> bool {
+        self.bytes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current
+                    .checked_add(bytes)
+                    .filter(|next| *next <= MAX_EARLY_DATAGRAM_BYTES_PER_CONNECTION)
+            })
+            .is_ok()
+    }
+
+    fn release(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let previous = self.bytes.fetch_sub(bytes, Ordering::Relaxed);
+        debug_assert!(previous >= bytes, "early UDP budget underflow");
+    }
+}
+
+pub(crate) struct EarlyUdpDatagrams {
+    payloads: Vec<Vec<u8>>,
+    bytes: usize,
+    budget: EarlyUdpBudget,
+}
+
+impl EarlyUdpDatagrams {
+    pub(crate) fn new(budget: EarlyUdpBudget) -> Self {
+        Self {
+            payloads: Vec::new(),
+            bytes: 0,
+            budget,
+        }
+    }
+
+    /// Retain one payload if both this stream and its connection still have
+    /// capacity. The shared budget makes this O(1), including when a client
+    /// has many CONNECT requests in flight.
+    pub(crate) fn push(&mut self, payload: &[u8]) -> bool {
+        if self.payloads.len() >= MAX_EARLY_DATAGRAMS_PER_TUNNEL
+            || self.bytes.saturating_add(payload.len()) > MAX_EARLY_DATAGRAM_BYTES_PER_TUNNEL
+            || !self.budget.try_reserve(payload.len())
+        {
+            return false;
+        }
+
+        self.payloads.push(payload.to_vec());
+        self.bytes += payload.len();
+        true
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.payloads.len()
+    }
+
+    pub(crate) fn bytes(&self) -> usize {
+        self.bytes
+    }
+
+    pub(crate) fn into_payloads(mut self) -> Vec<Vec<u8>> {
+        self.release_budget();
+        std::mem::take(&mut self.payloads)
+    }
+
+    fn release_budget(&mut self) {
+        self.budget.release(self.bytes);
+        self.bytes = 0;
+    }
+}
+
+impl Default for EarlyUdpDatagrams {
+    fn default() -> Self {
+        Self::new(EarlyUdpBudget::default())
+    }
+}
+
+impl Drop for EarlyUdpDatagrams {
+    fn drop(&mut self) {
+        self.release_budget();
+    }
+}
 
 /// A connected target socket prepared off the HTTP/3 event loop.
 pub(crate) struct ConnectedUdpTarget {
@@ -61,14 +165,31 @@ pub(crate) struct PendingUdpTunnel {
     header: crate::datagram::DatagramHeader,
     started_at: Instant,
     setup_task: Option<JoinHandle<()>>,
+    early_datagrams: EarlyUdpDatagrams,
 }
 
 impl PendingUdpTunnel {
-    pub(crate) fn new(header: crate::datagram::DatagramHeader) -> Self {
+    pub(crate) fn new(
+        header: crate::datagram::DatagramHeader,
+        early_udp_budget: EarlyUdpBudget,
+    ) -> Self {
         Self {
             header,
             started_at: Instant::now(),
             setup_task: None,
+            early_datagrams: EarlyUdpDatagrams::new(early_udp_budget),
+        }
+    }
+
+    pub(crate) fn with_early_datagrams(
+        header: crate::datagram::DatagramHeader,
+        early_datagrams: EarlyUdpDatagrams,
+    ) -> Self {
+        Self {
+            header,
+            started_at: Instant::now(),
+            setup_task: None,
+            early_datagrams,
         }
     }
 
@@ -79,6 +200,14 @@ impl PendingUdpTunnel {
 
     pub(crate) fn header(&self) -> crate::datagram::DatagramHeader {
         self.header
+    }
+
+    pub(crate) fn buffer_early_datagram(&mut self, payload: &[u8]) -> bool {
+        self.early_datagrams.push(payload)
+    }
+
+    pub(crate) fn take_early_datagrams(&mut self) -> EarlyUdpDatagrams {
+        std::mem::take(&mut self.early_datagrams)
     }
 
     pub(crate) fn is_idle(&self, timeout: Duration) -> bool {
@@ -460,12 +589,48 @@ mod tests {
         });
         tokio::task::yield_now().await;
 
-        let mut pending = PendingUdpTunnel::new(crate::datagram::DatagramHeader::new(0).unwrap());
+        let mut pending = PendingUdpTunnel::new(
+            crate::datagram::DatagramHeader::new(0).unwrap(),
+            EarlyUdpBudget::default(),
+        );
         pending.start_setup(task);
         drop(pending);
         tokio::task::yield_now().await;
 
         assert!(dropped.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn early_udp_datagrams_are_bounded_and_keep_order() {
+        let mut datagrams = EarlyUdpDatagrams::default();
+        for value in 0..MAX_EARLY_DATAGRAMS_PER_TUNNEL {
+            assert!(datagrams.push(&[value as u8]));
+        }
+        assert!(!datagrams.push(b"too many"));
+        assert_eq!(datagrams.len(), MAX_EARLY_DATAGRAMS_PER_TUNNEL);
+        assert_eq!(datagrams.bytes(), MAX_EARLY_DATAGRAMS_PER_TUNNEL);
+        assert_eq!(
+            datagrams.into_payloads(),
+            (0..MAX_EARLY_DATAGRAMS_PER_TUNNEL)
+                .map(|value| vec![value as u8])
+                .collect::<Vec<_>>()
+        );
+
+        let mut bytes = EarlyUdpDatagrams::default();
+        assert!(!bytes.push(&vec![0; MAX_EARLY_DATAGRAM_BYTES_PER_TUNNEL + 1]));
+        assert_eq!(bytes.len(), 0);
+    }
+
+    #[test]
+    fn early_udp_budget_is_shared_and_released_on_drop() {
+        let budget = EarlyUdpBudget::default();
+        let mut first = EarlyUdpDatagrams::new(budget.clone());
+        let mut second = EarlyUdpDatagrams::new(budget);
+
+        assert!(first.push(&vec![0; 40 * 1024]));
+        assert!(!second.push(&vec![0; 32 * 1024]));
+        drop(first);
+        assert!(second.push(&vec![0; 32 * 1024]));
     }
 
     #[tokio::test]

--- a/tests/add_listener.rs
+++ b/tests/add_listener.rs
@@ -238,6 +238,50 @@ fn adds_a_certificate_listener_beside_a_basic_one() {
 }
 
 #[test]
+fn adds_an_http3_listener_with_its_own_datagram_size() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--listen-addr",
+        "127.0.0.1:8468",
+        "--mode",
+        "client-cert",
+        "--max-datagram-size",
+        "1200",
+        "--no-bind-check",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "add-listener failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.config().listeners[1].max_datagram_size, Some(1200));
+    assert!(fixture.text().contains("max_datagram_size = 1200"));
+}
+
+#[test]
+fn refuses_a_quic_datagram_size_on_an_http2_listener() {
+    let fixture = Fixture::new(true);
+    let output = fixture.add_listener(&[
+        "--transport",
+        "http2",
+        "--listen-addr",
+        "127.0.0.1:8469",
+        "--mode",
+        "client-cert",
+        "--max-datagram-size",
+        "1200",
+    ]);
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("--max-datagram-size applies only to an HTTP/3 listener")
+    );
+    fixture.assert_unchanged();
+}
+
+#[test]
 fn adds_a_basic_listener_with_a_password_read_from_stdin() {
     let fixture = Fixture::new(false);
     let mut child = Command::new(env!("CARGO_BIN_EXE_masque-server"))

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -763,6 +763,7 @@ fn dual_fixture_with_stealth(tag: &str, stealth: bool) -> DualFixture {
             listen_addr: ephemeral_addr(),
             transport: ListenerTransport::Http3,
             shards: 1,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::Basic,
@@ -776,6 +777,7 @@ fn dual_fixture_with_stealth(tag: &str, stealth: bool) -> DualFixture {
             listen_addr: ephemeral_addr(),
             transport: ListenerTransport::Http3,
             shards: 1,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: true,
                 mode: AuthMode::ClientCert,

--- a/tests/client_cert_connect_ip.rs
+++ b/tests/client_cert_connect_ip.rs
@@ -906,6 +906,7 @@ fn ephemeral_multi_shard_listeners_share_only_their_own_port() {
             listen_addr: ephemeral_addr(),
             transport: ListenerTransport::Http3,
             shards: 2,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: false,
                 ..Default::default()
@@ -915,6 +916,7 @@ fn ephemeral_multi_shard_listeners_share_only_their_own_port() {
             listen_addr: ephemeral_addr(),
             transport: ListenerTransport::Http3,
             shards: 2,
+            max_datagram_size: None,
             auth: AuthSection {
                 enabled: false,
                 ..Default::default()

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -229,9 +229,9 @@ grep -q '^dual-proxy = masque, proxy.example, 8449, username=proxy-user, passwor
 # The server itself must agree about what those listeners are.
 "$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/dual-check.log" 2>&1 ||
     die "the dual configuration failed check-config"
-grep -q '^listener 0.0.0.0:8449 transport=http3 auth=basic shards=1$' "$TEST_TMP/dual-check.log" ||
+grep -q '^listener 0.0.0.0:8449 transport=http3 auth=basic shards=1 max_datagram_size=1350$' "$TEST_TMP/dual-check.log" ||
     die "the Basic listener was not reported by check-config"
-grep -q '^listener 0.0.0.0:8450 transport=http3 auth=client_cert shards=1$' "$TEST_TMP/dual-check.log" ||
+grep -q '^listener 0.0.0.0:8450 transport=http3 auth=client_cert shards=1 max_datagram_size=1350$' "$TEST_TMP/dual-check.log" ||
     die "the certificate listener was not reported by check-config"
 # The installed binary must be able to add a third listener to the file the
 # installer wrote, in place, without an operator editing TOML.
@@ -254,7 +254,7 @@ grep -q '^\[quic\]$' "$CONFIG_PATH" ||
     die "add-listener changed the configuration file's owner or mode"
 "$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/added-check.log" 2>&1 ||
     die "the configuration failed check-config after add-listener"
-grep -q '^listener 0.0.0.0:8451 transport=http3 auth=client_cert shards=1$' "$TEST_TMP/added-check.log" ||
+grep -q '^listener 0.0.0.0:8451 transport=http3 auth=client_cert shards=1 max_datagram_size=1350$' "$TEST_TMP/added-check.log" ||
     die "the added listener was not reported by check-config"
 
 printf '\n# private-upgrade-log-marker\n' >>"$CONFIG_PATH"
@@ -272,7 +272,7 @@ assert_sha_unchanged "$CONFIG_PATH" "$added_config_sha"
 assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
 assert_upgrade_output_is_summary_only "$TEST_TMP/dual-upgrade.log"
-grep -q '^listener 0.0.0.0:8451 transport=http3 auth=client_cert shards=1$' "$TEST_TMP/dual-upgrade.log" ||
+grep -q '^listener 0.0.0.0:8451 transport=http3 auth=client_cert shards=1 max_datagram_size=1350$' "$TEST_TMP/dual-upgrade.log" ||
     die "the upgrade summary did not report the added listener"
 grep -q 'add-listener' "$TEST_TMP/dual-upgrade.log" ||
     die "the upgrade summary did not name the command that adds a listener"

--- a/tools/masque-e2e/src/main.rs
+++ b/tools/masque-e2e/src/main.rs
@@ -1650,20 +1650,22 @@ fn test_connect_udp_happy_path(server_addr: &str, echo_addr: &str) -> Result<()>
     let (echo_host, echo_port) = echo_addr.rsplit_once(':').context("bad ECHO_SERVER_ADDR")?;
 
     let headers = connect_udp_headers(server_addr, echo_host, echo_port)?;
-    let stream_id = client.send_request(&headers, false)?;
-
-    let (_sid, status) = client.poll_response(Duration::from_secs(5))?;
-    if status != 200 {
-        bail!("expected 200, got {status}");
-    }
-
-    // Give the server a moment to set up the UDP tunnel socket.
-    std::thread::sleep(Duration::from_millis(100));
-
-    // Send a datagram through the tunnel and verify echo.
     let payload = b"hello masque e2e";
+    let stream_id = client.send_request(&headers, false)?;
+    // Surge sends its probe immediately after the request rather than waiting
+    // for the 200. Flush it as a separate flight so it reaches the server while
+    // Argon2 and target setup are still pending.
     client.send_dgram(stream_id, payload)?;
 
+    let (response_stream_id, status) = client.poll_response(Duration::from_secs(5))?;
+    if response_stream_id != stream_id || status != 200 {
+        bail!(
+            "expected stream {stream_id} status 200, got stream {response_stream_id} status {status}"
+        );
+    }
+
+    // The packet sent before the response must have survived Basic password
+    // verification plus asynchronous DNS/socket setup.
     let dgram = client.recv_dgram(Duration::from_secs(5))?;
     if dgram.payload != payload {
         bail!(


### PR DESCRIPTION
## Summary

- retain bounded CONNECT-UDP datagrams while Basic authentication and asynchronous DNS/socket setup are pending
- relay retained datagrams in order after the target socket is established, while keeping the successful response gated on socket setup
- add an optional HTTP/3 `max_datagram_size` override to each listener while preserving the global 1350-byte default
- expose the override through `add-listener`, config checks, support bundles, documentation, and regression tests

## Resource bounds

- at most 8 early datagrams and 64 KiB per tunnel
- at most 64 KiB across one QUIC connection
- constant-time shared budget accounting; reset, authentication failure, setup failure, and disconnect release reservations automatically

## Validation

- `cargo test --workspace`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- real local HTTP/3 smoke test with the first CONNECT-UDP datagram sent before waiting for status 200
- 3-second release benchmark: 64B 0.181 Gbit/s and 1200B 1.569 Gbit/s MASQUE application goodput, both with 0% response shortfall

The preceding local 1200B baseline was 1.562 Gbit/s, so the change shows no measurable steady-state throughput regression. The Docker Compose suite was not run locally because Docker is unavailable on this host; the equivalent native HTTP/3 path passed.