### PR TITLE
Release v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ pre-1.0.
 
 ## Unreleased
 
+## 0.12.2 - 2026-09-01
+
 ### Added
 
 - HTTP/3 listeners may override the global `quic.max_datagram_size`, allowing a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "masque-probe"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "masque-server"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ undocumented_unsafe_blocks = "deny"
 
 [package]
 name = "masque-server"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 rust-version = "1.88"
 description = "High-performance MASQUE proxy for CONNECT, CONNECT-UDP, and CONNECT-IP over HTTP/2 and HTTP/3"

--- a/tools/masque-probe/Cargo.toml
+++ b/tools/masque-probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "masque-probe"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 rust-version = "1.88"
 description = "End-to-end connectivity diagnostics for MASQUE proxies"


### PR DESCRIPTION
## Release v0.12.2

Promotes the current Unreleased changes:

- retain bounded early CONNECT-UDP datagrams during authentication and asynchronous target setup
- support per-listener HTTP/3 `max_datagram_size` overrides

## Validation

- `scripts/validate-release.sh v0.12.2`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --release --locked`
- preceding protocol PR CI passed on Ubuntu, macOS, and Rust 1.88 MSRV

After merge, tag `v0.12.2` will trigger the signed release workflow and Linux x86_64/aarch64 archive publication.