### PR TITLE
feat: add guarded bootstrap and macOS probe releases

### DIFF
--- a/.agents/skills/masque-ops/SKILL.md
+++ b/.agents/skills/masque-ops/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: masque-ops
+description: Safely bootstrap, inspect, diagnose, deploy, roll out, and roll back a masque-server fleet through the repository's deterministic operations CLI. Use when an operator asks Codex to install an empty MASQUE host, check fleet health, execute a release upgrade, collect bounded diagnostics, or recover a prior version. Do not use for ordinary source-code changes, release creation, or editing remote network and authentication configuration.
+---
+
+# MASQUE operations
+
+Operate the fleet through `scripts/masque-ops.py`; do not replace its checks with
+ad hoc SSH commands.
+
+## Workflow
+
+1. Locate the repository root and private inventory path. Use the path supplied
+   by the operator or the default `~/.config/masque-server/fleet.toml`. Never
+   open or print that file; pass its path only to `scripts/masque-ops.py`, which
+   owns parsing and secret handling.
+2. Read [references/inventory.md](references/inventory.md) when creating or
+   validating inventory, SSH, probes, or sudo access.
+3. Run `validate`, then the read-only `status` command. If validation reports a
+   missing local probe and the operator authorized tool installation, run the
+   repository's `install-probe.sh` for the exact target version; do not fetch or
+   construct another installer.
+4. Before any upgrade, run `plan --version vX.Y.Z`. Before a fresh installation,
+   run `bootstrap HOST --version vX.Y.Z` without `--apply`. Report blockers from
+   the CLI's sanitized output only.
+5. Read [references/runbooks.md](references/runbooks.md) before executing a
+   deployment, rollout, rollback, or diagnosis.
+6. Use a mutating command only when the operator explicitly authorized that
+   mutation. `--apply` is the final execution gate; never infer authorization
+   from a request to inspect, review, plan, benchmark, or diagnose.
+7. Report each host's resulting version and health. Stop on a failed canary,
+   failed verification, partial rollout, or failed rollback.
+
+## Safety boundaries
+
+- Use exact release tags for mutations. Do not deploy a branch, commit, local
+  binary, draft release, or unverified archive.
+- Keep inventory, SSH keys, probe passwords, client enrollment files, state,
+  and audit logs outside the repository and out of responses.
+- Do not use shell commands, file readers, or tool output to inspect inventory,
+  SSH configuration, keys, probe credentials, or generated client files. The
+  operations CLI receives their paths and reads or writes them internally.
+- Do not print or read raw server configuration, password contents, client
+  private keys, environment variables, or unfiltered journals.
+- Do not disable SSH host-key checking, use agent forwarding, or trust a newly
+  discovered host key without out-of-band verification.
+- Do not edit remote configuration, TLS files, routes, forwarding, firewall,
+  NAT, systemd policy, or sudoers as part of a release rollout.
+- Use `--bootstrap` only for the one-time migration from a release that lacks
+  `masque-maintain`, and only after explicit authorization for root SSH.
+- Use the `bootstrap` subcommand only for an unconfigured Linux host with the
+  private `[hosts.bootstrap]` profile, and only after explicit authorization.
+  It transmits credentials through SSH standard input and never reports them.
+- Never continue past a CLI blocker or manually bypass its preflight, external
+  probe, architecture, checksum, configuration, or rollback checks.

--- a/.agents/skills/masque-ops/agents/openai.yaml
+++ b/.agents/skills/masque-ops/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MASQUE Operations"
+  short_description: "Safely inspect, deploy, and roll back MASQUE fleets"
+  default_prompt: "Use $masque-ops to inspect my fleet and prepare a safe upgrade plan."

--- a/.agents/skills/masque-ops/references/inventory.md
+++ b/.agents/skills/masque-ops/references/inventory.md
@@ -1,0 +1,83 @@
+# Private fleet inventory
+
+The operations CLI requires Python 3.11 or newer. Copy
+`deploy/config/fleet.example.toml` to a location outside the repository:
+
+```sh
+install -d -m 0700 ~/.config/masque-server ~/.config/masque-server/secrets
+install -m 0600 deploy/config/fleet.example.toml \
+  ~/.config/masque-server/fleet.toml
+```
+
+Replace every example address and probe endpoint. Keep the inventory, SSH
+identity, Basic password file, and client-certificate enrollment JSON owned by
+the invoking user with mode `0600`. The CLI rejects symlinked inventory and
+secret files, inline passwords, unknown keys, duplicate hosts, and unsupported
+release repositories.
+
+An AI agent must pass the inventory path to the CLI without opening the file.
+Successful CLI output deliberately omits SSH addresses, identity paths, remote
+certificate paths, usernames, passwords, and generated client-file paths.
+
+The CLI targets the official package layout (`masque.service`,
+`/etc/masque/masque.toml`, and `/usr/local/bin/masque-server`). These paths are
+not inventory options because allowing them to diverge from the fixed remote
+helper would make preflight results ambiguous.
+
+Record each SSH host key only after verifying its fingerprint through an
+independent channel. Point `known_hosts_file` at that file. Do not turn off
+strict host-key verification and do not use an unverified `ssh-keyscan` result
+as the trust decision.
+
+## Remote privilege boundary
+
+Release archives install the root-owned `/usr/local/sbin/masque-maintain`
+entrypoint. It accepts only:
+
+```text
+masque-maintain status
+masque-maintain diagnose [1..500]
+masque-maintain upgrade vVERSION
+```
+
+It cannot edit MASQUE configuration, TLS material, forwarding, routes,
+firewall, or NAT. A dedicated SSH user can receive only these commands through
+sudo. Validate the policy with `visudo -cf` before installing it; a suitable
+policy is:
+
+```sudoers
+Cmnd_Alias MASQUE_STATUS = /usr/local/sbin/masque-maintain status
+Cmnd_Alias MASQUE_DIAGNOSE = /usr/local/sbin/masque-maintain diagnose, /usr/local/sbin/masque-maintain diagnose [0-9]*
+Cmnd_Alias MASQUE_UPGRADE = /usr/local/sbin/masque-maintain upgrade v[0-9]*
+masque-deploy ALL=(root) NOPASSWD: MASQUE_STATUS, MASQUE_DIAGNOSE, MASQUE_UPGRADE
+```
+
+Set `user = "masque-deploy"` and `sudo = true` in the inventory. The helper
+also validates argument count, the diagnostic range, and the complete semantic
+version syntax, so the sudo wildcard cannot turn it into an arbitrary command
+runner. Ensure the helper and its parent directories remain root-owned and not
+writable by the deployment user.
+
+For the initial transition from a release without the helper, temporarily use
+an explicit root inventory entry and the CLI's `deploy --bootstrap` flag. This
+one-time path sends the repository's audited installer over SSH; subsequent
+operations should use the dedicated account and omit `--bootstrap`.
+
+For a truly unconfigured host, add a private `[hosts.bootstrap]` table and use
+the separate `bootstrap` subcommand. It requires an explicit root SSH entry,
+normalized absolute paths to existing remote TLS files, an authentication mode,
+and local credential destinations under a private directory. Inline passwords
+are not accepted. Basic mode reads an existing mode-`0600` password file or
+creates it before connecting; certificate mode retrieves the generated client
+configuration directly into a new mode-`0600` file. If the probe uses those
+credentials, its paths must match the bootstrap paths exactly. See
+`deploy/config/fleet.example.toml` for all fields.
+
+## External probes
+
+A host's optional `[hosts.probe]` runs `masque-probe` on the administration
+machine after a deployment. Basic authentication uses `username` plus a
+`password_file`; the password file is connected directly to probe stdin and is
+never placed in the process arguments or parsed by `masque-ops`. Certificate
+authentication uses `client_config`. A rollout requires a canary probe unless
+the operator explicitly accepts the weaker `--allow-no-probe` check.

--- a/.agents/skills/masque-ops/references/runbooks.md
+++ b/.agents/skills/masque-ops/references/runbooks.md
@@ -1,0 +1,106 @@
+# Fleet operation runbooks
+
+Set the private inventory path once for the examples:
+
+```sh
+inventory="$HOME/.config/masque-server/fleet.toml"
+```
+
+Place global options before the subcommand. Add `--json` when machine-readable
+output is useful.
+
+## Inspect and plan
+
+These commands are read-only:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" validate
+scripts/masque-ops.py --inventory "$inventory" status
+scripts/masque-ops.py --inventory "$inventory" diagnose edge-a --journal-lines 100
+scripts/masque-ops.py --inventory "$inventory" plan --version vX.Y.Z
+```
+
+Diagnostics are bounded and filter authentication material, but journals can
+still contain client or destination metadata. Review them before sharing.
+
+## Deploy one host
+
+Run and inspect `plan` first, then execute only after explicit authorization:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" \
+  deploy edge-a --version vX.Y.Z --apply
+```
+
+For a pre-operations release that does not yet contain `masque-maintain`, use
+the one-time root-only bootstrap after the operator approves it:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" \
+  deploy edge-a --version vX.Y.Z --bootstrap --apply
+```
+
+The exact target Release must contain the archive and SHA-256 sidecar for the
+remote architecture. The currently installed Release must contain them too, so
+automatic rollback remains possible. The remote installer checks the existing
+configuration with the candidate before replacement and restores the previous
+release-managed files if activation fails. Post-deploy verification also
+requires the configuration SHA-256 to match its preflight value.
+
+## Install an empty host
+
+Keep the SSH destination, key, verified host-key file, remote TLS paths, and
+credential output paths in the private inventory. Do not open that inventory in
+an AI session. Validate it, inspect the empty host, and run the bootstrap
+preflight without mutation:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" validate
+scripts/masque-ops.py --inventory "$inventory" status edge-new
+scripts/masque-ops.py --inventory "$inventory" \
+  bootstrap edge-new --version vX.Y.Z
+```
+
+After the operator explicitly authorizes the fresh installation:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" \
+  bootstrap edge-new --version vX.Y.Z --apply
+```
+
+The CLI checks Linux architecture, release assets, remote dependencies, absence
+of an existing MASQUE install, readable TLS files, local secret destinations,
+and the optional probe before changing the host. The Basic password is read or
+created in its mode-`0600` local file and sent only over SSH standard input.
+Generated Surge or certificate-client configuration streams directly into new
+local mode-`0600` files. The model sees only the host alias, status, blockers,
+version, and probe result. A fresh host has no prior release to restore, so stop
+and inspect status if post-install verification fails.
+
+## Fleet rollout
+
+Select exactly one canary in inventory or with `--canary`. The canary is
+upgraded and externally probed before the remaining hosts are changed, one at a
+time:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" \
+  rollout --version vX.Y.Z --apply
+```
+
+On any failure, stop and report which hosts changed and which did not. The
+failing host is automatically restored when possible; earlier successful hosts
+are not silently rolled back as a group.
+
+## Roll back one host
+
+The local mode-`0600` state file records the previous version after each
+successful deployment. Restore it with:
+
+```sh
+scripts/masque-ops.py --inventory "$inventory" rollback edge-a --apply
+```
+
+Do not edit the state file to force a rollback. If state and the running
+version disagree, investigate and recover manually rather than bypassing the
+guard.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,17 @@ jobs:
 
       - name: Check shell scripts
         run: |
-          sh -n install-latest.sh deploy/install.sh \
+          sh -n install-latest.sh install-probe.sh deploy/install.sh deploy/masque-maintain \
             scripts/validate-release.sh tests/install-upgrade.sh \
-            tests/release-metadata.sh tests/systemd-shutdown.sh
+            tests/install-probe.sh tests/release-metadata.sh tests/systemd-shutdown.sh
+          sh tests/install-probe.sh
           sh tests/release-metadata.sh
-          shellcheck install-latest.sh deploy/install.sh scripts/*.sh \
+          shellcheck install-latest.sh install-probe.sh deploy/install.sh \
+            deploy/masque-maintain scripts/*.sh \
             tests/*.sh tests/e2e/*.sh
+
+      - name: Test fleet operations CLI
+        run: python3 -m unittest -v tests/test_masque_ops.py
 
   msrv:
     name: Check MSRV (1.88.0)
@@ -201,11 +206,16 @@ jobs:
           ARCH: ${{ matrix.arch }}
           USE_ZIGBUILD: "1"
           VERSION: ci-${{ github.sha }}
-        run: scripts/package-linux.sh
+        run: |
+          scripts/package-linux.sh
+          SKIP_BUILD=1 scripts/package-probe.sh
 
       - name: Inspect archive
         run: |
           tar tzf "dist/masque-vci-${GITHUB_SHA}-linux-${{ matrix.arch }}.tar.gz"
+          tar tzf "dist/masque-probe-vci-${GITHUB_SHA}-linux-${{ matrix.arch }}.tar.gz"
           cd dist
           sha256sum --check \
             "masque-vci-${GITHUB_SHA}-linux-${{ matrix.arch }}.tar.gz.sha256"
+          sha256sum --check \
+            "masque-probe-vci-${GITHUB_SHA}-linux-${{ matrix.arch }}.tar.gz.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
             export VERSION="${GITHUB_SHA::12}"
           fi
           scripts/package-linux.sh
+          SKIP_BUILD=1 scripts/package-probe.sh
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -116,10 +117,66 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  build-probe-macos:
+    name: Build macOS probe ${{ matrix.arch }}
+    needs: verify
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            target: aarch64-apple-darwin
+            runner: macos-15
+          - arch: x86_64
+            target: x86_64-apple-darwin
+            runner: macos-15-intel
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust target
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal
+          rustup default 1.97.1
+          rustup target add "${{ matrix.target }}"
+
+      - name: Restore Cargo cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-1.97.1-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ runner.arch }}-1.97.1-${{ matrix.target }}-
+
+      - name: Build standalone probe archive
+        env:
+          TARGET: ${{ matrix.target }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            export VERSION="${GITHUB_REF_NAME#v}"
+          else
+            export VERSION="${GITHUB_SHA::12}"
+          fi
+          scripts/package-probe.sh
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: masque-probe-macos-${{ matrix.arch }}
+          path: dist/*
+          if-no-files-found: error
+
   publish:
     name: Publish GitHub Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    needs: [build, build-probe-macos]
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -130,7 +187,7 @@ jobs:
       - name: Download release archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: masque-server-linux-*
+          pattern: masque-*
           path: dist
           merge-multiple: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 /target
 /dist
 certs/
+# Operations inventory and state belong outside the repository. These names
+# are ignored as a last line of defense if an operator copies them here.
+fleet.toml
+ops-state.json
+ops-audit.jsonl
 /fuzz/artifacts
 /fuzz/corpus
 /fuzz/target
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ pre-1.0.
 
 ## Unreleased
 
+### Added
+
+- A guarded fleet operations CLI and repo-scoped AI Skill provide read-only
+  status and diagnostics, exact-release planning, externally verified canary
+  rollout, and recorded rollback. Release packages include a root-owned,
+  command-limited maintenance entrypoint and verified bootstrap copy so a
+  dedicated SSH account does not need arbitrary root shell access.
+- Standalone `masque-probe` archives are released for Linux and macOS on
+  x86_64 and ARM64. The probe installer detects the local platform and
+  architecture and verifies the downloaded archive against its SHA-256.
+- Fleet operations can preflight and install a pinned release on an empty Linux
+  host from a private bootstrap profile. The deterministic CLI—not the AI
+  agent—reads SSH and credential files, sends Basic secrets only through SSH
+  standard input, suppresses installer secret output, and streams generated
+  client credentials directly into local mode-`0600` files.
+
 ## 0.12.2 - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ a staging environment.
   keep the Entry at 1350 and use a dedicated 1200-byte Exit listener for the
   nested QUIC connection
 - Static Linux x86_64 and ARM64 release archives with a systemd installer
+- Standalone Linux and macOS x86_64/ARM64 probe archives with automatic,
+  SHA-256-verified installation
+- Optional guarded fleet operations CLI and repo-scoped AI Skill for status,
+  secret-isolated empty-host bootstrap, canary rollout, external verification,
+  and recorded rollback
 
 ## Quick start
 
@@ -168,6 +173,14 @@ HTTP/3 first and falls back to HTTP/2, then establishes a real upstream TCP
 CONNECT and performs a DNS-over-UDP round trip through the proxy:
 
 ```sh
+curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/install-probe.sh | sh
+```
+
+The installer detects Linux/macOS and x86_64/ARM64, verifies the selected
+release archive's SHA-256, and installs to `~/.local/bin` for an unprivileged
+user or `/usr/local/bin` for root. Then run:
+
+```sh
 printf '%s' 'a-strong-password' | masque-probe proxy.example.com:8449 \
   --username phone --password-stdin
 masque-probe proxy.example.com:4443 --client-config laptop.json --connect-ip
@@ -223,8 +236,9 @@ variables, certificate requirements, and installing a specific release.
 ## Install a downloaded release on Linux
 
 Release archives contain `masque-server`, `masque-probe`, an example
-configuration, a hardened systemd unit, Prometheus rules, a Grafana dashboard,
-and an installer. Replace `ARCH` with `x86_64` or `aarch64`:
+configuration, a restricted maintenance entrypoint, a hardened systemd unit,
+Prometheus rules, a Grafana dashboard, and an installer. Replace `ARCH` with
+`x86_64` or `aarch64`:
 
 ```sh
 tar xzf masque-vVERSION-linux-ARCH.tar.gz
@@ -250,6 +264,7 @@ upgrades, and diagnostics.
 | [Architecture](docs/architecture.md) | Runtime components, data flow, sharding, and resource bounds |
 | [Configuration](docs/configuration.md) | TOML sections, authentication, policy, and tuning |
 | [Deployment](docs/deployment.md) | Linux installation, systemd, certificates, and upgrades |
+| [Operations](docs/operations.md) | Secret-isolated bootstrap, fleet rollout, rollback, and optional AI Skill |
 | [Protocols](docs/protocols.md) | Supported RFCs and CONNECT request behavior |
 | [Performance](docs/performance.md) | Benchmark methodology and Linux fast paths |
 | [Observability](docs/observability.md) | Health/readiness, metrics, alerts, dashboard, and structured logs |
@@ -272,6 +287,7 @@ fuzz/                   Scheduled libFuzzer targets for public protocol parsers
 deploy/                 Example config, installer, systemd unit, and monitoring assets
 docs/                   Operator and contributor documentation
 scripts/                Test, benchmark, certificate, and packaging helpers
+.agents/skills/          Optional repository-scoped agent runbooks
 .github/workflows/      CI and release automation
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,42 @@ a staging environment.
   secret-isolated empty-host bootstrap, canary rollout, external verification,
   and recorded rollback
 
+## AI-assisted operations with the `masque-ops` Skill
+
+The repository ships a Codex-compatible operations Skill alongside the
+deterministic CLI it controls. There is nothing to install on a proxy server:
+clone the repository on the administration machine, start Codex from its root,
+and the repo-scoped Skill is discovered automatically:
+
+```sh
+git clone https://github.com/Vincent-bin/masque-server.git
+cd masque-server
+codex
+```
+
+Then invoke it explicitly in Codex:
+
+```text
+$masque-ops validate the fleet and inspect its current status
+```
+
+To make the Skill available outside this checkout, ask Codex's built-in
+installer to install it directly from the repository:
+
+```text
+$skill-installer install the masque-ops skill from https://github.com/Vincent-bin/masque-server/tree/main/.agents/skills/masque-ops
+```
+
+Copy [`deploy/config/fleet.example.toml`](deploy/config/fleet.example.toml) to
+the private inventory location, replace its documentation values, and keep it
+mode `0600`. The AI passes only that path and host aliases to
+[`scripts/masque-ops.py`](scripts/masque-ops.py); the CLI—not the AI—reads the
+inventory, SSH identity, passwords, or generated client credentials. It can
+inspect an existing fleet or bootstrap an explicitly configured empty Linux
+host. Start with a read-only request, review the plan, and authorize `--apply`
+separately. See [AI-assisted fleet operations](docs/operations.md) for setup,
+bootstrap, rollout, and rollback instructions.
+
 ## Quick start
 
 Build the server:

--- a/deploy/config/fleet.example.toml
+++ b/deploy/config/fleet.example.toml
@@ -1,0 +1,73 @@
+# Copy this file outside the repository, normally to
+# ~/.config/masque-server/fleet.toml, replace every example value, and chmod
+# the file and each referenced private file to 0600.
+schema_version = 1
+repository = "Vincent-bin/masque-server"
+state_path = "~/.local/state/masque-server/ops-state.json"
+probe_binary = "masque-probe"
+
+[defaults]
+user = "masque-deploy"
+port = 22
+identity_file = "~/.ssh/id_ed25519_masque"
+known_hosts_file = "~/.ssh/known_hosts"
+sudo = true
+connect_timeout_secs = 10
+command_timeout_secs = 60
+deploy_timeout_secs = 900
+
+# Exactly one selected host should normally be the rollout canary. The address
+# is used only for SSH and is never written to the operations state or audit.
+[[hosts]]
+name = "edge-a"
+address = "203.0.113.10"
+canary = true
+# A truly empty server is bootstrapped through an explicit root entry. After
+# the first install, replace this with the restricted masque-deploy account and
+# remove the bootstrap table.
+user = "root"
+sudo = false
+
+[hosts.bootstrap]
+auth_mode = "basic"
+listen_port = 8449
+tls_cert_path = "/root/.acme.sh/proxy-a.example.com_ecc/fullchain.cer"
+tls_key_path = "/root/.acme.sh/proxy-a.example.com_ecc/proxy-a.example.com.key"
+basic_username = "probe-user"
+basic_stealth = true
+basic_password_file = "secrets/edge-a.password"
+basic_client_endpoint = "proxy-a.example.com:8449"
+basic_client_name = "edge-a"
+basic_client_config = "secrets/edge-a.surge.conf"
+# For auth_mode = "client_cert" or "dual":
+# client_name = "laptop"
+# client_endpoint = "proxy-a.example.com:4443"
+# client_ipv4 = "10.89.0.2"       # use "none" to omit one family
+# client_ipv6 = "fd00:abcd::2"
+# client_config = "secrets/edge-a-client.json"
+# For auth_mode = "dual" only:
+# cert_listen_port = 4443
+
+# This optional probe runs on the administration machine after installation.
+# Password contents are read directly by masque-probe, never by masque-ops and
+# never from a command-line argument.
+[hosts.probe]
+endpoint = "proxy-a.example.com:8449"
+transport = "http3"
+username = "probe-user"
+password_file = "secrets/edge-a.password"
+timeout_secs = 8
+
+[[hosts]]
+name = "edge-b"
+address = "2001:db8::20"
+port = 2222
+
+# A certificate-authenticated probe references the enrollment JSON without
+# copying its private key into this inventory.
+[hosts.probe]
+endpoint = "proxy-b.example.com:4443"
+transport = "http3"
+client_config = "secrets/edge-b-client.json"
+connect_ip = true
+timeout_secs = 10

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -9,8 +9,13 @@ fi
 PACKAGE_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 CANDIDATE_BIN=$PACKAGE_DIR/bin/masque-server
 CANDIDATE_PROBE=$PACKAGE_DIR/bin/masque-probe
+CANDIDATE_MAINTENANCE=$PACKAGE_DIR/maintenance/masque-maintain
+CANDIDATE_BOOTSTRAP=$PACKAGE_DIR/maintenance/install-latest.sh
 BIN_PATH=/usr/local/bin/masque-server
 PROBE_PATH=/usr/local/bin/masque-probe
+MAINTENANCE_PATH=/usr/local/sbin/masque-maintain
+LIBEXEC_DIR=/usr/local/libexec/masque-server
+BOOTSTRAP_PATH=$LIBEXEC_DIR/install-latest.sh
 CONFIG_PATH=/etc/masque/masque.toml
 TLS_CERT_PATH=/etc/masque/certs/server.crt
 TLS_KEY_PATH=/etc/masque/certs/server.key
@@ -36,6 +41,8 @@ BASIC_CLIENT_CONFIG_OUT=
 BASIC_CLIENT_CONFIG_CREATED=0
 BINARY_INSTALL_TMP=
 PROBE_INSTALL_TMP=
+MAINTENANCE_INSTALL_TMP=
+BOOTSTRAP_INSTALL_TMP=
 UNIT_INSTALL_TMP=
 PROMETHEUS_RULES_INSTALL_TMP=
 GRAFANA_DASHBOARD_INSTALL_TMP=
@@ -43,6 +50,8 @@ UPGRADE_BACKUP_DIR=
 ROLLBACK_PENDING=0
 HAD_BINARY=0
 HAD_PROBE=0
+HAD_MAINTENANCE=0
+HAD_BOOTSTRAP=0
 HAD_UNIT=0
 HAD_PROMETHEUS_RULES=0
 HAD_GRAFANA_DASHBOARD=0
@@ -51,6 +60,7 @@ WAS_SERVICE_ENABLED=0
 SERVICE_RESULT="enabled, not started"
 RUN_HOST_DIAGNOSTICS=1
 HOST_DIAGNOSTICS_RESULT="not run"
+PRINT_SECRETS=1
 
 cleanup() {
     cleanup_status=$?
@@ -66,6 +76,8 @@ cleanup() {
     [ -z "$CLIENT_BLOCK_TMP" ] || rm -f -- "$CLIENT_BLOCK_TMP"
     [ -z "$BINARY_INSTALL_TMP" ] || rm -f -- "$BINARY_INSTALL_TMP"
     [ -z "$PROBE_INSTALL_TMP" ] || rm -f -- "$PROBE_INSTALL_TMP"
+    [ -z "$MAINTENANCE_INSTALL_TMP" ] || rm -f -- "$MAINTENANCE_INSTALL_TMP"
+    [ -z "$BOOTSTRAP_INSTALL_TMP" ] || rm -f -- "$BOOTSTRAP_INSTALL_TMP"
     [ -z "$UNIT_INSTALL_TMP" ] || rm -f -- "$UNIT_INSTALL_TMP"
     [ -z "$PROMETHEUS_RULES_INSTALL_TMP" ] || rm -f -- "$PROMETHEUS_RULES_INSTALL_TMP"
     [ -z "$GRAFANA_DASHBOARD_INSTALL_TMP" ] || rm -f -- "$GRAFANA_DASHBOARD_INSTALL_TMP"
@@ -103,6 +115,26 @@ rollback_installation() {
         fi
     elif ! rm -f -- "$PROBE_PATH"; then
         echo "error: could not remove the newly installed $PROBE_PATH" >&2
+        rollback_ok=0
+    fi
+
+    if [ "$HAD_MAINTENANCE" -eq 1 ]; then
+        if ! cp -p -- "$UPGRADE_BACKUP_DIR/masque-maintain" "$MAINTENANCE_PATH"; then
+            echo "error: could not restore $MAINTENANCE_PATH" >&2
+            rollback_ok=0
+        fi
+    elif ! rm -f -- "$MAINTENANCE_PATH"; then
+        echo "error: could not remove the newly installed $MAINTENANCE_PATH" >&2
+        rollback_ok=0
+    fi
+
+    if [ "$HAD_BOOTSTRAP" -eq 1 ]; then
+        if ! cp -p -- "$UPGRADE_BACKUP_DIR/install-latest.sh" "$BOOTSTRAP_PATH"; then
+            echo "error: could not restore $BOOTSTRAP_PATH" >&2
+            rollback_ok=0
+        fi
+    elif ! rm -f -- "$BOOTSTRAP_PATH"; then
+        echo "error: could not remove the newly installed $BOOTSTRAP_PATH" >&2
         rollback_ok=0
     fi
 
@@ -163,7 +195,7 @@ rollback_installation() {
 
     ROLLBACK_PENDING=0
     if [ "$rollback_ok" -eq 1 ]; then
-        echo "Previous binaries, systemd unit, monitoring assets, and service state restored." >&2
+        echo "Previous release-managed files and service state restored." >&2
     else
         echo "error: rollback was incomplete; inspect the paths and service above" >&2
     fi
@@ -209,6 +241,20 @@ parse_host_diagnostics_requested() {
             ;;
         *)
             die "MASQUE_RUN_HOST_DIAGNOSTICS must be 0 or 1"
+            ;;
+    esac
+}
+
+parse_secret_output_requested() {
+    case "${MASQUE_PRINT_SECRETS:-1}" in
+        1|true|yes)
+            PRINT_SECRETS=1
+            ;;
+        0|false|no)
+            PRINT_SECRETS=0
+            ;;
+        *)
+            die "MASQUE_PRINT_SECRETS must be 0 or 1"
             ;;
     esac
 }
@@ -681,6 +727,14 @@ snapshot_installed_files() {
         cp -p -- "$PROBE_PATH" "$UPGRADE_BACKUP_DIR/masque-probe"
         HAD_PROBE=1
     fi
+    if [ -e "$MAINTENANCE_PATH" ]; then
+        cp -p -- "$MAINTENANCE_PATH" "$UPGRADE_BACKUP_DIR/masque-maintain"
+        HAD_MAINTENANCE=1
+    fi
+    if [ -e "$BOOTSTRAP_PATH" ]; then
+        cp -p -- "$BOOTSTRAP_PATH" "$UPGRADE_BACKUP_DIR/install-latest.sh"
+        HAD_BOOTSTRAP=1
+    fi
     if [ -e "$UNIT_PATH" ]; then
         cp -p -- "$UNIT_PATH" "$UPGRADE_BACKUP_DIR/masque.service"
         HAD_UNIT=1
@@ -704,11 +758,15 @@ snapshot_installed_files() {
 install_program_and_unit() {
     BINARY_INSTALL_TMP=$(mktemp /usr/local/bin/.masque-server.install.XXXXXX)
     PROBE_INSTALL_TMP=$(mktemp /usr/local/bin/.masque-probe.install.XXXXXX)
+    MAINTENANCE_INSTALL_TMP=$(mktemp /usr/local/sbin/.masque-maintain.install.XXXXXX)
+    BOOTSTRAP_INSTALL_TMP=$(mktemp "$LIBEXEC_DIR/.install-latest.install.XXXXXX")
     UNIT_INSTALL_TMP=$(mktemp /etc/systemd/system/.masque.service.install.XXXXXX)
     PROMETHEUS_RULES_INSTALL_TMP=$(mktemp "$MONITORING_DIR/.prometheus-rules.install.XXXXXX")
     GRAFANA_DASHBOARD_INSTALL_TMP=$(mktemp "$MONITORING_DIR/.grafana-dashboard.install.XXXXXX")
     install -m 0755 "$CANDIDATE_BIN" "$BINARY_INSTALL_TMP"
     install -m 0755 "$CANDIDATE_PROBE" "$PROBE_INSTALL_TMP"
+    install -m 0755 "$CANDIDATE_MAINTENANCE" "$MAINTENANCE_INSTALL_TMP"
+    install -m 0755 "$CANDIDATE_BOOTSTRAP" "$BOOTSTRAP_INSTALL_TMP"
     install -m 0644 "$PACKAGE_DIR/systemd/masque.service" "$UNIT_INSTALL_TMP"
     install -m 0644 "$PACKAGE_DIR/monitoring/prometheus-rules.yml" \
         "$PROMETHEUS_RULES_INSTALL_TMP"
@@ -722,6 +780,10 @@ install_program_and_unit() {
     BINARY_INSTALL_TMP=
     mv -f -- "$PROBE_INSTALL_TMP" "$PROBE_PATH"
     PROBE_INSTALL_TMP=
+    mv -f -- "$MAINTENANCE_INSTALL_TMP" "$MAINTENANCE_PATH"
+    MAINTENANCE_INSTALL_TMP=
+    mv -f -- "$BOOTSTRAP_INSTALL_TMP" "$BOOTSTRAP_PATH"
+    BOOTSTRAP_INSTALL_TMP=
     mv -f -- "$UNIT_INSTALL_TMP" "$UNIT_PATH"
     UNIT_INSTALL_TMP=
     mv -f -- "$PROMETHEUS_RULES_INSTALL_TMP" "$PROMETHEUS_RULES_PATH"
@@ -769,6 +831,12 @@ run_host_diagnostics() {
 
 [ -x "$CANDIDATE_BIN" ] || die "release package is missing executable $CANDIDATE_BIN"
 [ -x "$CANDIDATE_PROBE" ] || die "release package is missing executable $CANDIDATE_PROBE"
+[ -x "$CANDIDATE_MAINTENANCE" ] ||
+    die "release package is missing executable $CANDIDATE_MAINTENANCE"
+[ -x "$CANDIDATE_BOOTSTRAP" ] ||
+    die "release package is missing executable $CANDIDATE_BOOTSTRAP"
+sh -n "$CANDIDATE_MAINTENANCE" || die "packaged maintenance helper has invalid shell syntax"
+sh -n "$CANDIDATE_BOOTSTRAP" || die "packaged bootstrap has invalid shell syntax"
 if ! CANDIDATE_VERSION_OUTPUT=$("$CANDIDATE_BIN" --version); then
     die "the packaged server binary cannot run on this host"
 fi
@@ -784,6 +852,7 @@ fi
     "packaged binary versions differ: server $CANDIDATE_VERSION, probe $CANDIDATE_PROBE_VERSION"
 parse_start_requested
 parse_host_diagnostics_requested
+parse_secret_output_requested
 
 if [ -e "$CONFIG_PATH" ]; then
     check_config_compatibility "$CONFIG_PATH"
@@ -802,8 +871,9 @@ if ! id masque >/dev/null 2>&1; then
         --create-home --shell /usr/sbin/nologin masque
 fi
 
-install -d -m 0755 /usr/local/bin /etc/masque /etc/systemd/system \
-    /usr/local/share/masque-server "$MONITORING_DIR"
+install -d -m 0755 /usr/local/bin /usr/local/sbin "$LIBEXEC_DIR" \
+    /etc/masque /etc/systemd/system /usr/local/share/masque-server \
+    "$MONITORING_DIR"
 install -d -o root -g masque -m 0750 /etc/masque/certs
 
 if [ "$FRESH_CONFIG" -eq 1 ]; then
@@ -841,6 +911,7 @@ echo "MASQUE installation result"
 echo "  Version:        $("$BIN_PATH" --version)"
 echo "  Binary:         $BIN_PATH"
 echo "  Probe:          $PROBE_PATH"
+echo "  Maintenance:    $MAINTENANCE_PATH"
 echo "  Configuration:  $CONFIG_PATH"
 echo "  Authentication: $AUTH_MODE"
 echo "  Service:        $SERVICE_RESULT"
@@ -861,7 +932,7 @@ fi
 # CONFIG_CHANGED first: only a freshly rendered configuration has credentials to
 # print, and on an upgrade AUTH_MODE is a summary of what was found rather than
 # one of the modes this installer writes.
-if [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
+if [ "$PRINT_SECRETS" -eq 1 ] && [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
     echo
     echo "Basic client credentials:"
     echo "  Stealth mode: $BASIC_STEALTH"
@@ -877,14 +948,17 @@ if [ "$CONFIG_CHANGED" -eq 1 ] && mode_uses_basic; then
     fi
 fi
 
-if [ "$CONFIG_CHANGED" -eq 1 ]; then
+if [ "$PRINT_SECRETS" -eq 0 ] && [ "$CONFIG_CHANGED" -eq 1 ]; then
+    echo
+    echo "Credential and generated configuration output was suppressed."
+elif [ "$CONFIG_CHANGED" -eq 1 ]; then
     print_redacted_config
 else
     echo
     echo "Existing configuration was preserved and is not printed during upgrades."
 fi
 
-if [ -n "$ENROLL_OUTPUT" ]; then
+if [ "$PRINT_SECRETS" -eq 1 ] && [ -n "$ENROLL_OUTPUT" ]; then
     echo
     echo "Client-certificate enrollment result"
     echo "  Secret usque JSON: $CLIENT_CONFIG_OUT"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -419,7 +419,10 @@ generate_basic_client_config() {
         basic_client_endpoint=$(prompt_value \
             "Public Basic endpoint (host:port; leave empty to skip)" "")
     fi
-    [ -n "$basic_client_endpoint" ] || return
+    # Skipping this optional artifact is a successful fresh installation.
+    # A bare `return` here would preserve the failed `[ -n ... ]` status and,
+    # under `set -e`, terminate unattended installs without an error message.
+    [ -n "$basic_client_endpoint" ] || return 0
 
     BASIC_CLIENT_CONFIG_OUT=${MASQUE_BASIC_CLIENT_CONFIG_OUT:-}
     if [ -z "$BASIC_CLIENT_CONFIG_OUT" ]; then

--- a/deploy/masque-maintain
+++ b/deploy/masque-maintain
@@ -1,0 +1,129 @@
+#!/usr/bin/env sh
+set -eu
+
+# This root-owned entrypoint is intentionally narrow enough to grant through a
+# dedicated sudoers rule. It never edits the server configuration, TLS files,
+# routing, firewall, or NAT.
+REPOSITORY=Vincent-bin/masque-server
+BOOTSTRAP=/usr/local/libexec/masque-server/install-latest.sh
+BIN=/usr/local/bin/masque-server
+CONFIG=/etc/masque/masque.toml
+CERT=/etc/masque/certs/server.crt
+SERVICE=masque.service
+LOCK=/run/lock/masque-maintain.lock
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+require_root() {
+    [ "$(id -u)" -eq 0 ] || die "masque-maintain must run as root"
+}
+
+status() {
+    version=$("$BIN" --version 2>/dev/null | sed -n '1p' || true)
+    arch=$(uname -m 2>/dev/null || true)
+    active=$(systemctl is-active "$SERVICE" 2>/dev/null || true)
+    enabled=$(systemctl is-enabled "$SERVICE" 2>/dev/null || true)
+    config_exists=no
+    config_check=missing
+    config_sha256=
+    if [ -f "$CONFIG" ]; then
+        config_exists=yes
+        if "$BIN" --config "$CONFIG" check-config >/dev/null 2>&1; then
+            config_check=ok
+        else
+            config_check=failed
+        fi
+        config_sha256=$(sha256sum "$CONFIG" 2>/dev/null | awk 'NR == 1 { print $1 }')
+    fi
+    cert_not_after=$(openssl x509 -in "$CERT" -noout -enddate 2>/dev/null |
+        sed -n 's/^notAfter=//p' || true)
+    disk_available_kb=$(df -Pk / 2>/dev/null | awk 'NR == 2 { print $4 }')
+    disk_used_percent=$(df -Pk / 2>/dev/null | awk 'NR == 2 { print $5 }')
+
+    printf '%s\n' \
+        'masque_ops_status=1' \
+        "version=$version" \
+        "arch=$arch" \
+        "service_active=$active" \
+        "service_enabled=$enabled" \
+        "config_exists=$config_exists" \
+        "config_check=$config_check" \
+        "config_sha256=$config_sha256" \
+        "cert_not_after=$cert_not_after" \
+        "disk_available_kb=$disk_available_kb" \
+        "disk_used_percent=$disk_used_percent"
+}
+
+diagnose() {
+    lines=${1:-100}
+    case "$lines" in
+        ''|*[!0-9]*) die "diagnostic line count must be an integer" ;;
+    esac
+    [ "$lines" -ge 1 ] && [ "$lines" -le 500 ] ||
+        die "diagnostic line count must be between 1 and 500"
+
+    echo '== version =='
+    "$BIN" --version 2>&1 || true
+    echo '== service =='
+    systemctl status "$SERVICE" --no-pager -l 2>&1 || true
+    echo '== configuration check =='
+    "$BIN" --config "$CONFIG" check-config 2>&1 || true
+    echo '== host prerequisites =='
+    "$BIN" --config "$CONFIG" doctor 2>&1 || true
+    echo '== certificate expiry =='
+    openssl x509 -in "$CERT" -noout -enddate 2>&1 || true
+    echo '== root filesystem =='
+    df -h / 2>&1 || true
+    echo '== listening sockets =='
+    ss -H -lntu 2>&1 || true
+    echo '== recent warning journal =='
+    journalctl -u "$SERVICE" -p warning -n "$lines" --no-pager 2>&1 || true
+}
+
+validate_version() {
+    version=$1
+    printf '%s\n' "$version" |
+        grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$' ||
+        die "invalid release version: $version"
+}
+
+upgrade() {
+    version=$1
+    validate_version "$version"
+    [ -x "$BOOTSTRAP" ] || die "installed bootstrap is missing: $BOOTSTRAP"
+    command -v flock >/dev/null 2>&1 || die "required command not found: flock"
+    install -d -m 0755 /run/lock
+    exec 9>"$LOCK"
+    flock -n 9 || die "another MASQUE maintenance operation is running"
+
+    MASQUE_VERSION=$version
+    MASQUE_GITHUB_REPOSITORY=$REPOSITORY
+    MASQUE_START_SERVICE=1
+    MASQUE_RUN_HOST_DIAGNOSTICS=0
+    export MASQUE_VERSION MASQUE_GITHUB_REPOSITORY MASQUE_START_SERVICE
+    export MASQUE_RUN_HOST_DIAGNOSTICS
+    "$BOOTSTRAP"
+}
+
+require_root
+command=${1:-}
+case "$command" in
+    status)
+        [ "$#" -eq 1 ] || die "usage: masque-maintain status"
+        status
+        ;;
+    diagnose)
+        [ "$#" -le 2 ] || die "usage: masque-maintain diagnose [LINES]"
+        diagnose "${2:-100}"
+        ;;
+    upgrade)
+        [ "$#" -eq 2 ] || die "usage: masque-maintain upgrade vVERSION"
+        upgrade "$2"
+        ;;
+    *)
+        die "usage: masque-maintain status | diagnose [LINES] | upgrade vVERSION"
+        ;;
+esac

--- a/deploy/masque-maintain
+++ b/deploy/masque-maintain
@@ -62,8 +62,9 @@ diagnose() {
     case "$lines" in
         ''|*[!0-9]*) die "diagnostic line count must be an integer" ;;
     esac
-    [ "$lines" -ge 1 ] && [ "$lines" -le 500 ] ||
+    if [ "$lines" -lt 1 ] || [ "$lines" -gt 500 ]; then
         die "diagnostic line count must be between 1 and 500"
+    fi
 
     echo '== version =='
     "$BIN" --version 2>&1 || true

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,10 @@
 - [Architecture](architecture.md): components, event loops, data flow, and
   resource bounds.
 - [Configuration](configuration.md): configuration reference and policy.
-- [Deployment](deployment.md): Linux installation and systemd operation.
+- [Deployment](deployment.md): Linux installation, macOS/Linux probe packages,
+  and systemd operation.
+- [Operations](operations.md): guarded fleet inspection, rollout, and rollback,
+  with an optional repo-scoped AI Skill.
 - [Protocols](protocols.md): supported MASQUE, HTTP/2, and HTTP/3 behavior.
 - [Performance](performance.md): fast paths, tuning, and benchmark rules.
 - [Observability](observability.md): health, readiness, Prometheus, Grafana,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,6 +9,8 @@ GitHub Actions builds static `x86_64-unknown-linux-musl` and
 bin/masque-server
 bin/masque-probe
 config/masque.toml
+maintenance/masque-maintain
+maintenance/install-latest.sh
 monitoring/prometheus-rules.yml
 monitoring/grafana-dashboard.json
 systemd/masque.service
@@ -21,6 +23,10 @@ Verify the archive before extraction:
 ```sh
 sha256sum --check masque-vVERSION-linux-ARCH.tar.gz.sha256
 ```
+
+Releases also publish standalone `masque-probe` archives for Linux and macOS,
+on both x86_64 and ARM64. `install-probe.sh` detects the local pair and verifies
+the archive SHA-256 before installing it.
 
 ## One-command install
 
@@ -83,6 +89,7 @@ The following environment variables make provisioning non-interactive:
 | `MASQUE_CLIENT_CONFIG_OUT` | Absolute secret JSON output path; defaults to `/root/masque-client.json` |
 | `MASQUE_START_SERVICE` | `1` to start/restart, `0` to stage only; bootstrap default is `1` |
 | `MASQUE_RUN_HOST_DIAGNOSTICS` | `1` to run the read-only CONNECT-IP host check after installation (default), `0` to skip |
+| `MASQUE_PRINT_SECRETS` | `0` suppresses credentials, client private keys, and the rendered fresh configuration for automation; default `1` |
 
 For example, a non-interactive client-certificate installation is:
 
@@ -111,12 +118,16 @@ The same one-command installer is safe to reuse for later releases. If the
 configuration already exists, the downloaded candidate runs `check-config`
 against it before any installed file is replaced. A failed check leaves the
 server/probe binaries, systemd unit, monitoring assets, configuration, TLS
-files, and running service untouched. On success, both binaries, the packaged systemd unit, Prometheus
+files, and running service untouched. On success, both binaries, the restricted
+maintenance helper, its pinned bootstrap, the packaged systemd unit, Prometheus
 rules, and Grafana dashboard are upgraded; the TOML and every TLS path it
 references remain unchanged. If the requested service restart then fails, the
 installer restores the previous release-managed files, enabled state, and
 active state. Upgrade output reports the resolved listener and authentication
 summary but does not print the existing configuration contents.
+
+For guarded multi-host planning, canary rollout, external protocol checks, and
+recorded rollback, see [AI-assisted fleet operations](operations.md).
 
 ## Install a downloaded archive
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,168 @@
+# AI-assisted fleet operations
+
+The repository includes an optional operations layer for repeatable MASQUE
+fleet installation and upgrades. An AI coding agent can interpret an operator's request through
+the repo-scoped `masque-ops` Skill, but all privileged work is performed by the
+deterministic, tested `scripts/masque-ops.py` CLI. No model, API key, or AI
+runtime is installed on a proxy server.
+
+This is deliberately bounded release operations rather than general configuration
+management. It can bootstrap an explicitly described empty host, inspect status,
+collect bounded diagnostics, validate an upgrade plan, deploy an exact GitHub
+Release, run an external protocol probe, and restore the previously recorded
+version. Outside the fresh-install profile, it does not edit configuration,
+certificates, users, routes, forwarding, firewall, NAT, or monitoring services.
+It targets the paths and service name used by the official Linux installer;
+custom installation layouts are intentionally outside its scope.
+
+## Set up an inventory
+
+Python 3.11 or newer and OpenSSH are required on the administration machine.
+Copy the example outside the repository and protect it:
+
+```sh
+install -d -m 0700 ~/.config/masque-server ~/.config/masque-server/secrets
+install -m 0600 deploy/config/fleet.example.toml \
+  ~/.config/masque-server/fleet.toml
+```
+
+Replace all documentation addresses and endpoints. The default location is
+`~/.config/masque-server/fleet.toml`; set `MASQUE_OPS_INVENTORY` or pass
+`--inventory` to use another file. The inventory only accepts the official
+`Vincent-bin/masque-server` release source and must not contain inline
+passwords. Referenced SSH identities, probe passwords, and client enrollment
+files are checked separately and must be private regular files rather than
+symlinks.
+
+AI agents must not open the inventory or any referenced file. They pass only
+the inventory path and a host alias to `masque-ops`; its output omits SSH
+addresses, key paths, remote TLS paths, usernames, passwords, and generated
+client-file paths. The deterministic CLI is the only component that parses the
+private inventory or handles secret bytes.
+
+Install the release-matched probe on Linux or macOS x86_64/ARM64 with automatic
+platform and architecture detection:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/install-probe.sh | sh
+```
+
+An unprivileged install goes to `~/.local/bin`; root installs to
+`/usr/local/bin`. Every archive is verified against its release SHA-256 before
+replacement. `masque-ops` also checks `~/.local/bin` when `masque-probe` is not
+already in `PATH`.
+
+Verify SSH host fingerprints out of band before placing them in the configured
+`known_hosts_file`. The tool enables strict host-key checking, disables ambient
+SSH configuration, password and keyboard-interactive login, forwarding, agent
+forwarding, local commands, and shared control sockets.
+
+## Read-only inspection
+
+```sh
+scripts/masque-ops.py validate
+scripts/masque-ops.py status
+scripts/masque-ops.py plan --version vX.Y.Z
+scripts/masque-ops.py diagnose edge-a --journal-lines 100
+```
+
+`status` checks the installed version, architecture, service state,
+configuration validity, certificate expiry, and disk availability. `plan`
+also verifies that both the target and current releases have a checksummed
+archive for the host architecture; retaining the current artifact is required
+for automatic rollback.
+
+Diagnostics never read raw TOML and filter lines that could contain account,
+authorization, password, or private-key material. They can still contain
+client IP or destination metadata from the journal, so review output before
+sharing it. Place `--json` before the subcommand for structured output.
+
+## Deploy and roll back
+
+Mutations require an exact version and the explicit `--apply` gate:
+
+```sh
+scripts/masque-ops.py plan --version vX.Y.Z
+scripts/masque-ops.py deploy edge-a --version vX.Y.Z --apply
+scripts/masque-ops.py rollout --version vX.Y.Z --apply
+scripts/masque-ops.py rollback edge-a --apply
+```
+
+`rollout` requires exactly one selected canary and normally requires an
+external `masque-probe` for it. It deploys the canary first and then proceeds
+sequentially. A host is considered upgraded only after systemd is active, the
+new binary version matches, the live configuration passes `check-config`, and
+its SHA-256 still matches the preflight snapshot, and the optional external
+TCP/UDP/IP probe succeeds. A failed host is restored to its prior version when
+possible, and the rollout stops without touching later hosts.
+
+## Bootstrap an empty Linux host
+
+Add `[hosts.bootstrap]` to the host's private inventory entry. It describes the
+authentication mode, ports, existing remote ACME certificate paths, and local
+mode-`0600` destinations for generated credentials. The repository example
+shows Basic mode; `client_cert` and `dual` additionally require
+`client_endpoint` and `client_config`. Inline passwords are rejected.
+
+First run the non-mutating preflight:
+
+```sh
+scripts/masque-ops.py bootstrap edge-new --version vX.Y.Z
+```
+
+After explicit approval, the same command performs the install:
+
+```sh
+scripts/masque-ops.py bootstrap edge-new --version vX.Y.Z --apply
+```
+
+The CLI requires a verified root SSH entry for this one operation. It confirms
+that the host is Linux and unconfigured, all required commands and release
+assets exist, and the configured remote TLS files are readable. A Basic
+password is read or generated only inside the CLI and sent in encrypted SSH
+standard input, never in a process argument. Generated Surge and certificate
+client files stream directly from SSH into new local files with mode `0600`;
+their contents and paths are not emitted. The installer suppresses credential,
+client-key, and rendered-configuration output, then the CLI checks systemd,
+configuration validity, version, and the optional external probe.
+
+Fresh installation has no previous Release to restore if an external
+post-install check fails. The CLI stops and records that state instead of
+deleting a potentially working installation. Inspect `status` before retrying.
+
+State and an append-only audit are stored next to `state_path`, with mode
+`0600`. They contain host aliases, versions, result categories, timestamps,
+configuration hashes, and probe status—not SSH addresses or authentication
+material.
+
+## Remote maintenance boundary
+
+Release installation puts a root-owned helper at
+`/usr/local/sbin/masque-maintain` and a pinned copy of the verified bootstrap at
+`/usr/local/libexec/masque-server/install-latest.sh`. The helper exposes only
+`status`, bounded `diagnose`, and an exact-version `upgrade`. Upgrade downloads
+from the official repository, verifies the archive SHA-256, serializes changes
+with `flock`, validates the existing configuration with the candidate binary,
+and relies on the package installer for atomic replacement and service-state
+rollback.
+
+This narrow command can be granted to a dedicated SSH account with sudo. See
+the repo Skill's
+[`inventory.md`](../.agents/skills/masque-ops/references/inventory.md) for the
+sudoers example and probe configuration. A server running an older release
+does not yet have the helper; its first transition requires the explicit,
+root-only `deploy --bootstrap` path. Remove root SSH from the inventory after
+that transition.
+
+## Using the Skill
+
+Codex-compatible agents discover the repo-scoped
+`.agents/skills/masque-ops/SKILL.md` automatically when working in this
+repository. A typical request is: “Use `$masque-ops` to inspect the fleet and
+prepare an upgrade plan for `vX.Y.Z`.” Inspection and planning do not authorize
+deployment; ask explicitly to execute the reviewed plan before the agent may
+add `--apply`.
+
+The CLI is the supported interface and works without an AI agent. Treat the
+Skill as a guarded natural-language runbook, not as an independent source of
+privilege or release truth.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,12 +14,13 @@
 | Docker E2E | `scripts/e2e-test.sh` | TCP, UDP, IP/TUN, and container networking |
 | Client interop | `cargo test --test client_cert_connect_ip` | Cloudflare-compatible certificate auth, CONNECT-IP setup, mixed authentication, and live HTTP/3 TLS reload/rollback |
 | HTTP/2 interop | `cargo test --test http2_connect` | Real TLS/H2 CONNECT variants, multiple Basic accounts, both authentication modes, and credential/TLS reload rollback without dropping an established connection |
-| End-user probe | `cargo test -p masque-probe` | Basic/certificate authentication over H2/H3 with live TCP CONNECT and CONNECT-UDP echo round trips, plus stable result/error handling |
+| End-user probe | `cargo test -p masque-probe` | Basic/certificate authentication over H2/H3 with live TCP CONNECT and CONNECT-UDP echo round trips, plus stable result/error handling on Linux and macOS |
 | Observability assets | `cargo test --test monitoring_assets` | Prometheus metric references and importable Grafana JSON |
 | Service shutdown | `tests/systemd-shutdown.sh` | Real SIGTERM/SIGINT handling and every-shard drain; Linux exercises two shards |
 | Config and host diagnostics | `cargo test --test check_config` | `check-config` accepts what a server accepts; `doctor` remains read-only; support bundles omit credential/identity sentinels |
 | Config editing | `cargo test --test add_listener` | Listener and Basic-account edits are validated, atomic, and preserve deployed comments and secrets |
 | Client config | `cargo test --test client_config` | Surge output is importable, private, secret-aware, and never overwritten |
+| Fleet operations | `python3 -m unittest -v tests/test_masque_ops.py` | Inventory validation, SSH hardening, release guards, secret filtering, deploy verification, and automatic rollback |
 | Linux package | `scripts/package-linux.sh` | Artifact layout and static binary build |
 | Parser fuzzing | `cargo +nightly fuzz run protocol_parsers` | Incremental capsule, datagram, varint, IP, and URI parser safety |
 | Dependency security | `cargo audit && cargo deny --workspace --locked check licenses sources bans` | RustSec, license, duplicate-version, and source policy |
@@ -32,6 +33,7 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo +1.88.0 check --workspace --locked
 cargo test --workspace --locked
+python3 -m unittest -v tests/test_masque_ops.py
 ```
 
 macOS covers HTTP/2 CONNECT-IP setup plus portable HTTP/2 and HTTP/3 CONNECT,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,9 +7,16 @@ without changing it.
 
 ## Client-side connectivity probe
 
-Release archives install `/usr/local/bin/masque-probe` beside the server. Copy
-that binary to the affected Linux client if necessary, and run it from the same
-network and interface as the application that fails.
+Install the standalone probe on a Linux or macOS x86_64/ARM64 client; the
+installer selects the local architecture and verifies the release SHA-256:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Vincent-bin/masque-server/main/install-probe.sh | sh
+```
+
+Linux server archives also install `/usr/local/bin/masque-probe` beside the
+service. Run it from the same network and interface as the application that
+fails.
 
 For Basic authentication, pass the password on stdin so it never appears in
 the process list:

--- a/install-probe.sh
+++ b/install-probe.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env sh
+set -eu
+
+REPOSITORY=${MASQUE_GITHUB_REPOSITORY:-Vincent-bin/masque-server}
+DOWNLOAD_DIR=
+INSTALL_TMP=
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    [ -z "$INSTALL_TMP" ] || rm -f -- "$INSTALL_TMP"
+    if [ -n "$DOWNLOAD_DIR" ] && [ -d "$DOWNLOAD_DIR" ]; then
+        rm -rf -- "$DOWNLOAD_DIR"
+    fi
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+case "$(uname -s)" in
+    Linux) PLATFORM=linux ;;
+    Darwin) PLATFORM=macos ;;
+    *) die "masque-probe prebuilt binaries support Linux and macOS only" ;;
+esac
+case "$(uname -m)" in
+    x86_64|amd64) ARCH=x86_64 ;;
+    aarch64|arm64) ARCH=aarch64 ;;
+    *) die "masque-probe prebuilt binaries support x86_64 and ARM64 only" ;;
+esac
+
+for required_command in curl tar awk grep mktemp install; do
+    command -v "$required_command" >/dev/null 2>&1 ||
+        die "required command not found: $required_command"
+done
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA256_COMMAND=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+    SHA256_COMMAND='shasum -a 256'
+else
+    die "required SHA-256 command not found (sha256sum or shasum)"
+fi
+
+if ! printf '%s\n' "$REPOSITORY" |
+    grep -Eq '^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$'; then
+    die "MASQUE_GITHUB_REPOSITORY must be in owner/repository form"
+fi
+
+if [ -n "${MASQUE_VERSION:-}" ]; then
+    case "$MASQUE_VERSION" in
+        v*) RELEASE_TAG=$MASQUE_VERSION ;;
+        *) RELEASE_TAG=v$MASQUE_VERSION ;;
+    esac
+else
+    LATEST_URL=https://github.com/$REPOSITORY/releases/latest
+    if ! RESOLVED_URL=$(curl -fsSL --retry 3 -o /dev/null \
+        -w '%{url_effective}' "$LATEST_URL"); then
+        die "no stable GitHub release is available; set MASQUE_VERSION to a published tag"
+    fi
+    case "$RESOLVED_URL" in
+        */tag/v*) RELEASE_TAG=${RESOLVED_URL##*/tag/} ;;
+        */releases) die "no stable GitHub release is available; set MASQUE_VERSION to a published tag" ;;
+        *) die "could not determine the latest release tag from $RESOLVED_URL" ;;
+    esac
+fi
+
+case "$RELEASE_TAG" in
+    v[0-9A-Za-z]*) ;;
+    *) die "invalid release tag: $RELEASE_TAG" ;;
+esac
+case "$RELEASE_TAG" in
+    *[!0-9A-Za-z._-]*) die "invalid release tag: $RELEASE_TAG" ;;
+esac
+
+VERSION=${RELEASE_TAG#v}
+ARCHIVE_NAME=masque-probe-v${VERSION}-${PLATFORM}-${ARCH}.tar.gz
+CHECKSUM_NAME=$ARCHIVE_NAME.sha256
+DOWNLOAD_BASE=https://github.com/$REPOSITORY/releases/download/$RELEASE_TAG
+
+DOWNLOAD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/masque-probe-install.XXXXXX")
+chmod 0700 "$DOWNLOAD_DIR"
+ARCHIVE_PATH=$DOWNLOAD_DIR/$ARCHIVE_NAME
+CHECKSUM_PATH=$DOWNLOAD_DIR/$CHECKSUM_NAME
+
+echo "Downloading masque-probe $RELEASE_TAG for $PLATFORM/$ARCH ..."
+curl -fL --retry 3 -o "$ARCHIVE_PATH" "$DOWNLOAD_BASE/$ARCHIVE_NAME"
+curl -fL --retry 3 -o "$CHECKSUM_PATH" "$DOWNLOAD_BASE/$CHECKSUM_NAME"
+
+EXPECTED_SHA256=$(awk 'NF >= 1 { print $1; exit }' "$CHECKSUM_PATH")
+if ! printf '%s\n' "$EXPECTED_SHA256" | grep -Eq '^[0-9A-Fa-f]{64}$'; then
+    die "the release checksum file is malformed"
+fi
+ACTUAL_SHA256=$($SHA256_COMMAND "$ARCHIVE_PATH" | awk '{ print $1 }')
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    die "SHA-256 verification failed for $ARCHIVE_NAME"
+fi
+
+if tar tzf "$ARCHIVE_PATH" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+    die "the release archive contains an unsafe path"
+fi
+tar xzf "$ARCHIVE_PATH" -C "$DOWNLOAD_DIR"
+
+PACKAGE_DIR=$DOWNLOAD_DIR/masque-probe-v${VERSION}-${PLATFORM}-${ARCH}
+CANDIDATE=$PACKAGE_DIR/bin/masque-probe
+[ -x "$CANDIDATE" ] || die "the release archive does not contain masque-probe"
+CANDIDATE_VERSION=$($CANDIDATE --version 2>/dev/null) ||
+    die "the downloaded masque-probe cannot run on this machine"
+case "$CANDIDATE_VERSION" in
+    *" $VERSION") ;;
+    *) die "the downloaded probe version does not match $RELEASE_TAG" ;;
+esac
+
+if [ -n "${MASQUE_PROBE_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR=$MASQUE_PROBE_INSTALL_DIR
+elif [ "$(id -u)" -eq 0 ]; then
+    INSTALL_DIR=/usr/local/bin
+else
+    INSTALL_DIR=${HOME:?HOME is required}/.local/bin
+fi
+case "$INSTALL_DIR" in
+    /*) ;;
+    *) die "MASQUE_PROBE_INSTALL_DIR must be an absolute path" ;;
+esac
+
+install -d -m 0755 "$INSTALL_DIR"
+INSTALL_TMP=$(mktemp "$INSTALL_DIR/.masque-probe.install.XXXXXX")
+install -m 0755 "$CANDIDATE" "$INSTALL_TMP"
+mv -f -- "$INSTALL_TMP" "$INSTALL_DIR/masque-probe"
+INSTALL_TMP=
+
+echo "Verified SHA-256: $ACTUAL_SHA256"
+echo "Installed $CANDIDATE_VERSION at $INSTALL_DIR/masque-probe"
+case ":${PATH:-}:" in
+    *":$INSTALL_DIR:"*) ;;
+    *) echo "Add $INSTALL_DIR to PATH, or set probe_binary to this absolute path." ;;
+esac

--- a/scripts/masque-ops.py
+++ b/scripts/masque-ops.py
@@ -1,0 +1,2696 @@
+#!/usr/bin/env python3
+"""Safe, deterministic fleet operations for masque-server.
+
+The script deliberately keeps inventory and credentials outside the repository.
+Mutating commands require both an exact release tag and an explicit --apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import dataclasses
+import datetime as dt
+import ipaddress
+import json
+import os
+import posixpath
+import re
+import secrets
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+SCHEMA_VERSION = 1
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_INVENTORY = Path(
+    os.environ.get(
+        "MASQUE_OPS_INVENTORY",
+        str(Path.home() / ".config" / "masque-server" / "fleet.toml"),
+    )
+).expanduser()
+DEFAULT_STATE = Path.home() / ".local" / "state" / "masque-server" / "ops-state.json"
+DEFAULT_REPOSITORY = "Vincent-bin/masque-server"
+VERSION_RE = re.compile(
+    r"^v(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)"
+    r"(?P<prerelease>-(?:"
+    r"0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*"
+    r")(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?$"
+)
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+USER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]{0,63}$")
+AUTH_USER_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+HOST_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+REMOTE_SERVICE = "masque.service"
+REMOTE_CONFIG = "/etc/masque/masque.toml"
+REMOTE_BINARY = "/usr/local/bin/masque-server"
+REMOTE_CERT = "/etc/masque/certs/server.crt"
+REMOTE_MAINTENANCE = "/usr/local/sbin/masque-maintain"
+
+
+class OpsError(RuntimeError):
+    """A user-facing operational failure."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def require_mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise OpsError(f"{label} must be a TOML table")
+    return value
+
+
+def reject_unknown(mapping: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(mapping) - allowed)
+    if unknown:
+        raise OpsError(f"unknown {label} key(s): {', '.join(unknown)}")
+
+
+def require_string(value: object, label: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        raise OpsError(f"{label} must be a non-empty string")
+    if any(character in value for character in ("\0", "\n", "\r")):
+        raise OpsError(f"{label} must not contain control characters")
+    return value
+
+
+def require_bool(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise OpsError(f"{label} must be true or false")
+    return value
+
+
+def require_int(value: object, label: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise OpsError(f"{label} must be an integer")
+    if not minimum <= value <= maximum:
+        raise OpsError(f"{label} must be between {minimum} and {maximum}")
+    return value
+
+
+def resolve_local_path(value: str, inventory_dir: Path) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = inventory_dir / path
+    # Normalize relative components without resolving symlinks. Secret and
+    # inventory files are checked with lstat() so a symlink cannot bypass the
+    # ownership and mode checks by resolving to its target first.
+    return Path(os.path.abspath(path))
+
+
+def ensure_private_file(path: Path, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise OpsError(f"{label} does not exist: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode):
+        raise OpsError(f"{label} must not be a symbolic link: {path}")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OpsError(f"{label} is not a regular file: {path}")
+    if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+        raise OpsError(f"{label} is not owned by the current user: {path}")
+    if metadata.st_mode & 0o077:
+        raise OpsError(f"{label} must not be accessible by group or others: {path}")
+
+
+def ensure_integrity_file(path: Path, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise OpsError(f"{label} does not exist: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode):
+        raise OpsError(f"{label} must not be a symbolic link: {path}")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise OpsError(f"{label} is not a regular file: {path}")
+    allowed_owners = {0}
+    if hasattr(os, "getuid"):
+        allowed_owners.add(os.getuid())
+    if metadata.st_uid not in allowed_owners:
+        raise OpsError(f"{label} has an untrusted owner: {path}")
+    if metadata.st_mode & 0o022:
+        raise OpsError(f"{label} must not be writable by group or others: {path}")
+
+
+def ensure_private_parent(path: Path, label: str) -> None:
+    parent = path.parent
+    try:
+        metadata = parent.lstat()
+    except FileNotFoundError as error:
+        raise OpsError(f"{label} parent directory does not exist") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise OpsError(f"{label} parent must be a real directory")
+    if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+        raise OpsError(f"{label} parent is not owned by the current user")
+    if metadata.st_mode & 0o077:
+        raise OpsError(f"{label} parent must not be accessible by group or others")
+    try:
+        resolved_destination = parent.resolve(strict=True) / path.name
+    except OSError as error:
+        raise OpsError(f"could not resolve {label} parent") from error
+    try:
+        resolved_destination.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        pass
+    else:
+        raise OpsError(f"{label} must be stored outside the repository")
+
+
+def ensure_secret_destination(path: Path, label: str, *, allow_existing: bool) -> None:
+    ensure_private_parent(path, label)
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    if not allow_existing:
+        raise OpsError(f"{label} already exists; refusing to overwrite it")
+    ensure_private_file(path, label)
+
+
+def write_private_file(path: Path, data: bytes, label: str) -> None:
+    ensure_secret_destination(path, label, allow_existing=False)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise OpsError(f"could not create {label}") from error
+    succeeded = False
+    try:
+        remaining = memoryview(data)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written == 0:
+                raise OSError("short write")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        succeeded = True
+    except OSError as error:
+        raise OpsError(f"could not write {label}") from error
+    finally:
+        os.close(descriptor)
+        if not succeeded:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+
+
+def read_private_password(path: Path, label: str) -> str:
+    ensure_private_file(path, label)
+    try:
+        raw = path.read_bytes()
+    except OSError as error:
+        raise OpsError(f"could not read {label}") from error
+    if raw.endswith(b"\n"):
+        raw = raw[:-1]
+    if not raw or len(raw) > 1024 or b"\0" in raw or b"\n" in raw or b"\r" in raw:
+        raise OpsError(f"{label} must contain exactly one non-empty line")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise OpsError(f"{label} must be UTF-8") from error
+
+
+def normalize_version(value: str) -> str:
+    tag = value if value.startswith("v") else f"v{value}"
+    if not VERSION_RE.fullmatch(tag):
+        raise OpsError(f"invalid release version: {value}")
+    return tag
+
+
+def installed_version(value: str | None) -> str | None:
+    if not value:
+        return None
+    match = re.search(
+        r"(?<![0-9A-Za-z])([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?)",
+        value,
+    )
+    if not match:
+        return None
+    try:
+        return normalize_version(match.group(1))
+    except OpsError:
+        return None
+
+
+def version_order(
+    tag: str,
+) -> tuple[int, int, int, int, tuple[tuple[int, int, str], ...]]:
+    match = VERSION_RE.fullmatch(normalize_version(tag))
+    if match is None:
+        raise OpsError(f"invalid release version: {tag}")
+    prerelease = match.group("prerelease")
+    identifiers: tuple[tuple[int, int, str], ...] = tuple(
+        (0, int(identifier), "") if identifier.isdigit() else (1, 0, identifier)
+        for identifier in (prerelease or "").lstrip("-").split(".")
+        if identifier
+    )
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        1 if prerelease is None else 0,
+        identifiers,
+    )
+
+
+def safe_tail(stdout: str, stderr: str) -> str:
+    sensitive = re.compile(
+        r"password|password_hash|private[_ -]?key|authorization|username|"
+        r"client-certificate enrollment|effective server configuration",
+        re.IGNORECASE,
+    )
+    lines: list[str] = []
+    for line in (stdout + "\n" + stderr).splitlines():
+        if sensitive.search(line):
+            continue
+        cleaned = line.strip()
+        if cleaned:
+            lines.append(cleaned[:240])
+    return " | ".join(lines[-6:]) or "no non-sensitive remote error was returned"
+
+
+def sanitize_diagnostics(output: str) -> str:
+    """Remove authentication material from otherwise bounded diagnostics."""
+    sensitive = re.compile(
+        r"password|password_hash|proxy-authorization|authorization:|"
+        r"username|(?:client|identity|account)\s*=|private[_ -]?key|"
+        r"client[_ -]?key|basic\s+[A-Za-z0-9+/=]+",
+        re.IGNORECASE,
+    )
+    pem_begin = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+    pem_end = re.compile(r"-----END [A-Z0-9 ]*PRIVATE KEY-----")
+    redacted: list[str] = []
+    inside_private_key = False
+    for line in output.splitlines():
+        if pem_begin.search(line):
+            inside_private_key = True
+            redacted.append("[redacted private key material]")
+            continue
+        if inside_private_key:
+            if pem_end.search(line):
+                inside_private_key = False
+            continue
+        if sensitive.search(line):
+            redacted.append("[redacted sensitive diagnostic line]")
+        else:
+            redacted.append(line)
+    return "\n".join(redacted) + ("\n" if output.endswith("\n") else "")
+
+
+@dataclasses.dataclass(frozen=True)
+class ProbeConfig:
+    endpoint: str
+    transport: str = "auto"
+    username: str | None = None
+    password_file: Path | None = None
+    client_config: Path | None = None
+    server_name: str | None = None
+    resolve: str | None = None
+    interface: str | None = None
+    connect_ip: bool = False
+    skip_tcp: bool = False
+    skip_udp: bool = False
+    tcp_target: str | None = None
+    udp_target: str | None = None
+    udp_mode: str = "dns"
+    timeout_secs: int = 8
+    ca_cert: Path | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class BootstrapConfig:
+    auth_mode: str
+    listen_port: int
+    cert_listen_port: int | None
+    tls_cert_path: str
+    tls_key_path: str
+    basic_username: str | None = None
+    basic_stealth: bool = False
+    basic_password_file: Path | None = None
+    basic_client_endpoint: str | None = None
+    basic_client_name: str | None = None
+    basic_client_config: Path | None = None
+    client_name: str | None = None
+    client_endpoint: str | None = None
+    client_ipv4: str | None = None
+    client_ipv6: str | None = None
+    client_config: Path | None = None
+
+    @property
+    def uses_basic(self) -> bool:
+        return self.auth_mode in {"basic", "dual"}
+
+    @property
+    def uses_client_certs(self) -> bool:
+        return self.auth_mode in {"client_cert", "dual"}
+
+
+@dataclasses.dataclass(frozen=True)
+class Host:
+    name: str
+    address: str
+    user: str
+    port: int
+    identity_file: Path | None
+    known_hosts_file: Path | None
+    use_sudo: bool
+    service: str
+    config_path: str
+    binary_path: str
+    cert_path: str
+    maintenance_path: str
+    connect_timeout_secs: int
+    command_timeout_secs: int
+    deploy_timeout_secs: int
+    canary: bool
+    probe: ProbeConfig | None
+    bootstrap: BootstrapConfig | None
+
+
+@dataclasses.dataclass(frozen=True)
+class Inventory:
+    path: Path
+    repository: str
+    state_path: Path
+    probe_binary: str
+    hosts: tuple[Host, ...]
+
+    def select(
+        self, names: Sequence[str], *, require_names: bool = False
+    ) -> tuple[Host, ...]:
+        if not names:
+            if require_names:
+                raise OpsError("select an explicit host for this command")
+            return self.hosts
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise OpsError(f"host selected more than once: {', '.join(duplicates)}")
+        by_name = {host.name: host for host in self.hosts}
+        unknown = [name for name in names if name not in by_name]
+        if unknown:
+            raise OpsError(f"unknown host(s): {', '.join(unknown)}")
+        return tuple(by_name[name] for name in names)
+
+
+TOP_LEVEL_KEYS = {
+    "schema_version",
+    "repository",
+    "state_path",
+    "probe_binary",
+    "defaults",
+    "hosts",
+}
+CONNECTION_KEYS = {
+    "user",
+    "port",
+    "identity_file",
+    "known_hosts_file",
+    "sudo",
+    "connect_timeout_secs",
+    "command_timeout_secs",
+    "deploy_timeout_secs",
+}
+HOST_KEYS = CONNECTION_KEYS | {"name", "address", "canary", "probe", "bootstrap"}
+PROBE_KEYS = {
+    "endpoint",
+    "transport",
+    "username",
+    "password_file",
+    "client_config",
+    "server_name",
+    "resolve",
+    "interface",
+    "connect_ip",
+    "skip_tcp",
+    "skip_udp",
+    "tcp_target",
+    "udp_target",
+    "udp_mode",
+    "timeout_secs",
+    "ca_cert",
+}
+BOOTSTRAP_KEYS = {
+    "auth_mode",
+    "listen_port",
+    "cert_listen_port",
+    "tls_cert_path",
+    "tls_key_path",
+    "basic_username",
+    "basic_stealth",
+    "basic_password_file",
+    "basic_client_endpoint",
+    "basic_client_name",
+    "basic_client_config",
+    "client_name",
+    "client_endpoint",
+    "client_ipv4",
+    "client_ipv6",
+    "client_config",
+}
+
+
+def optional_path(
+    mapping: dict[str, Any], key: str, inventory_dir: Path
+) -> Path | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    return resolve_local_path(require_string(value, key), inventory_dir)
+
+
+def merged_value(
+    host: dict[str, Any], defaults: dict[str, Any], key: str, fallback: object
+) -> object:
+    if key in host:
+        return host[key]
+    return defaults.get(key, fallback)
+
+
+def parse_probe(raw: object, inventory_dir: Path, host_name: str) -> ProbeConfig:
+    table = require_mapping(raw, f"hosts[{host_name}].probe")
+    reject_unknown(table, PROBE_KEYS, f"hosts[{host_name}].probe")
+    endpoint = require_string(
+        table.get("endpoint"), f"hosts[{host_name}].probe.endpoint"
+    )
+    if any(character.isspace() for character in endpoint):
+        raise OpsError(f"hosts[{host_name}].probe.endpoint must not contain whitespace")
+    transport = require_string(table.get("transport", "auto"), "probe.transport")
+    if transport not in {"auto", "http3", "http2"}:
+        raise OpsError("probe.transport must be auto, http3, or http2")
+    udp_mode = require_string(table.get("udp_mode", "dns"), "probe.udp_mode")
+    if udp_mode not in {"dns", "echo"}:
+        raise OpsError("probe.udp_mode must be dns or echo")
+
+    username_raw = table.get("username")
+    username = (
+        None if username_raw is None else require_string(username_raw, "probe.username")
+    )
+    if username is not None and (
+        ":" in username or any(character.isspace() for character in username)
+    ):
+        raise OpsError("probe.username must not contain a colon or whitespace")
+    password_file = optional_path(table, "password_file", inventory_dir)
+    client_config = optional_path(table, "client_config", inventory_dir)
+    if (username is None) != (password_file is None):
+        raise OpsError(
+            "probe.username and probe.password_file must be configured together"
+        )
+    if client_config is not None and username is not None:
+        raise OpsError("probe.client_config cannot be combined with Basic credentials")
+
+    def optional_text(key: str) -> str | None:
+        value = table.get(key)
+        return None if value is None else require_string(value, f"probe.{key}")
+
+    return ProbeConfig(
+        endpoint=endpoint,
+        transport=transport,
+        username=username,
+        password_file=password_file,
+        client_config=client_config,
+        server_name=optional_text("server_name"),
+        resolve=optional_text("resolve"),
+        interface=optional_text("interface"),
+        connect_ip=require_bool(table.get("connect_ip", False), "probe.connect_ip"),
+        skip_tcp=require_bool(table.get("skip_tcp", False), "probe.skip_tcp"),
+        skip_udp=require_bool(table.get("skip_udp", False), "probe.skip_udp"),
+        tcp_target=optional_text("tcp_target"),
+        udp_target=optional_text("udp_target"),
+        udp_mode=udp_mode,
+        timeout_secs=require_int(
+            table.get("timeout_secs", 8), "probe.timeout_secs", 1, 60
+        ),
+        ca_cert=optional_path(table, "ca_cert", inventory_dir),
+    )
+
+
+def require_endpoint(value: object, label: str) -> str:
+    endpoint = require_string(value, label)
+    if any(character.isspace() for character in endpoint):
+        raise OpsError(f"{label} must not contain whitespace")
+    return endpoint
+
+
+def require_remote_path(value: object, label: str) -> str:
+    path = require_string(value, label)
+    if not path.startswith("/") or posixpath.normpath(path) != path:
+        raise OpsError(f"{label} must be a normalized absolute path")
+    return path
+
+
+def optional_bootstrap_address(
+    table: dict[str, Any], key: str, version: int
+) -> str | None:
+    raw = table.get(key)
+    if raw is None:
+        return "10.89.0.2" if version == 4 else "fd00:abcd::2"
+    value = require_string(raw, f"bootstrap.{key}")
+    if value.lower() in {"none", "-"}:
+        return None
+    try:
+        parsed = ipaddress.ip_address(value)
+    except ValueError as error:
+        raise OpsError(
+            f"bootstrap.{key} must be an IPv{version} address or 'none'"
+        ) from error
+    if parsed.version != version:
+        raise OpsError(f"bootstrap.{key} must be an IPv{version} address or 'none'")
+    return str(parsed)
+
+
+def parse_bootstrap(
+    raw: object, inventory_dir: Path, host_name: str
+) -> BootstrapConfig:
+    table = require_mapping(raw, f"hosts[{host_name}].bootstrap")
+    reject_unknown(table, BOOTSTRAP_KEYS, f"hosts[{host_name}].bootstrap")
+    auth_mode = require_string(
+        table.get("auth_mode"), f"hosts[{host_name}].bootstrap.auth_mode"
+    )
+    if auth_mode not in {"basic", "client_cert", "dual"}:
+        raise OpsError("bootstrap.auth_mode must be basic, client_cert, or dual")
+    uses_basic = auth_mode in {"basic", "dual"}
+    uses_client_certs = auth_mode in {"client_cert", "dual"}
+    listen_port = require_int(
+        table.get("listen_port", 443), "bootstrap.listen_port", 1, 65535
+    )
+    cert_listen_port = None
+    if auth_mode == "dual":
+        cert_listen_port = require_int(
+            table.get("cert_listen_port", 4443),
+            "bootstrap.cert_listen_port",
+            1,
+            65535,
+        )
+        if cert_listen_port == listen_port:
+            raise OpsError("bootstrap listener ports must be different")
+    elif "cert_listen_port" in table:
+        raise OpsError("bootstrap.cert_listen_port is valid only for dual mode")
+
+    basic_username = None
+    basic_password_file = None
+    basic_client_endpoint = None
+    basic_client_name = None
+    basic_client_config = None
+    if uses_basic:
+        basic_username = require_string(
+            table.get("basic_username", "masque"), "bootstrap.basic_username"
+        )
+        if not AUTH_USER_RE.fullmatch(basic_username):
+            raise OpsError(
+                "bootstrap.basic_username may contain only letters, digits, '.', '_', and '-'"
+            )
+        basic_password_file = optional_path(table, "basic_password_file", inventory_dir)
+        if basic_password_file is None:
+            raise OpsError("bootstrap.basic_password_file is required for Basic mode")
+        if "basic_client_endpoint" in table:
+            basic_client_endpoint = require_endpoint(
+                table["basic_client_endpoint"], "bootstrap.basic_client_endpoint"
+            )
+        basic_client_name_raw = table.get("basic_client_name")
+        if basic_client_name_raw is not None:
+            basic_client_name = require_string(
+                basic_client_name_raw, "bootstrap.basic_client_name"
+            )
+        basic_client_config = optional_path(table, "basic_client_config", inventory_dir)
+        if (basic_client_endpoint is None) != (basic_client_config is None):
+            raise OpsError(
+                "bootstrap.basic_client_endpoint and basic_client_config must be configured together"
+            )
+    elif any(key.startswith("basic_") for key in table):
+        raise OpsError("bootstrap Basic settings require basic or dual auth_mode")
+
+    client_name = None
+    client_endpoint = None
+    client_ipv4 = None
+    client_ipv6 = None
+    client_config = None
+    if uses_client_certs:
+        client_name = require_string(
+            table.get("client_name", "client"), "bootstrap.client_name"
+        )
+        client_endpoint = require_endpoint(
+            table.get("client_endpoint"), "bootstrap.client_endpoint"
+        )
+        client_ipv4 = optional_bootstrap_address(table, "client_ipv4", 4)
+        client_ipv6 = optional_bootstrap_address(table, "client_ipv6", 6)
+        if client_ipv4 is None and client_ipv6 is None:
+            raise OpsError(
+                "bootstrap certificate client needs at least one pinned address"
+            )
+        client_config = optional_path(table, "client_config", inventory_dir)
+        if client_config is None:
+            raise OpsError("bootstrap.client_config is required for certificate mode")
+    elif any(key.startswith("client_") for key in table):
+        raise OpsError(
+            "bootstrap certificate-client settings require client_cert or dual auth_mode"
+        )
+
+    return BootstrapConfig(
+        auth_mode=auth_mode,
+        listen_port=listen_port,
+        cert_listen_port=cert_listen_port,
+        tls_cert_path=require_remote_path(
+            table.get("tls_cert_path"), "bootstrap.tls_cert_path"
+        ),
+        tls_key_path=require_remote_path(
+            table.get("tls_key_path"), "bootstrap.tls_key_path"
+        ),
+        basic_username=basic_username,
+        basic_stealth=require_bool(
+            table.get("basic_stealth", False), "bootstrap.basic_stealth"
+        ),
+        basic_password_file=basic_password_file,
+        basic_client_endpoint=basic_client_endpoint,
+        basic_client_name=basic_client_name,
+        basic_client_config=basic_client_config,
+        client_name=client_name,
+        client_endpoint=client_endpoint,
+        client_ipv4=client_ipv4,
+        client_ipv6=client_ipv6,
+        client_config=client_config,
+    )
+
+
+def load_inventory(path: Path) -> Inventory:
+    path = Path(os.path.abspath(path.expanduser()))
+    ensure_private_file(path, "inventory")
+    try:
+        with path.open("rb") as handle:
+            raw = tomllib.load(handle)
+    except tomllib.TOMLDecodeError as error:
+        raise OpsError(f"invalid inventory TOML: {error}") from error
+    except OSError as error:
+        raise OpsError(f"could not read inventory: {path}") from error
+    reject_unknown(raw, TOP_LEVEL_KEYS, "top-level inventory")
+    if (
+        type(raw.get("schema_version")) is not int
+        or raw["schema_version"] != SCHEMA_VERSION
+    ):
+        raise OpsError(f"inventory schema_version must be {SCHEMA_VERSION}")
+    repository = require_string(raw.get("repository", DEFAULT_REPOSITORY), "repository")
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise OpsError("repository must be in owner/name form")
+    if repository != DEFAULT_REPOSITORY:
+        raise OpsError(
+            f"repository must be {DEFAULT_REPOSITORY}; the remote maintenance "
+            "entrypoint is pinned to that release source"
+        )
+    inventory_dir = path.parent
+    state_path_value = require_string(
+        raw.get("state_path", str(DEFAULT_STATE)), "state_path"
+    )
+    state_path = resolve_local_path(state_path_value, inventory_dir)
+    probe_binary = require_string(
+        raw.get("probe_binary", "masque-probe"), "probe_binary"
+    )
+    defaults = require_mapping(raw.get("defaults", {}), "defaults")
+    reject_unknown(defaults, CONNECTION_KEYS, "defaults")
+
+    raw_hosts = raw.get("hosts")
+    if not isinstance(raw_hosts, list) or not raw_hosts:
+        raise OpsError("inventory must contain at least one [[hosts]] entry")
+    hosts: list[Host] = []
+    seen_names: set[str] = set()
+    seen_destinations: set[tuple[str, str, int]] = set()
+    for index, raw_host in enumerate(raw_hosts):
+        table = require_mapping(raw_host, f"hosts[{index}]")
+        reject_unknown(table, HOST_KEYS, f"hosts[{index}]")
+        name = require_string(table.get("name"), f"hosts[{index}].name")
+        if not NAME_RE.fullmatch(name):
+            raise OpsError(f"invalid host name: {name}")
+        if name in seen_names:
+            raise OpsError(f"duplicate host name: {name}")
+        seen_names.add(name)
+        address = require_string(table.get("address"), f"hosts[{name}].address")
+        if not HOST_RE.fullmatch(address):
+            raise OpsError(f"invalid SSH address for host {name}: {address}")
+        user = require_string(
+            merged_value(table, defaults, "user", "root"), f"hosts[{name}].user"
+        )
+        if not USER_RE.fullmatch(user):
+            raise OpsError(f"invalid SSH user for host {name}: {user}")
+        port = require_int(
+            merged_value(table, defaults, "port", 22), f"hosts[{name}].port", 1, 65535
+        )
+        destination = (user, address, port)
+        if destination in seen_destinations:
+            raise OpsError(f"duplicate SSH destination for host {name}")
+        seen_destinations.add(destination)
+
+        identity_raw = merged_value(table, defaults, "identity_file", None)
+        identity_file = (
+            None
+            if identity_raw is None
+            else resolve_local_path(
+                require_string(identity_raw, "identity_file"), inventory_dir
+            )
+        )
+        known_hosts_raw = merged_value(table, defaults, "known_hosts_file", None)
+        known_hosts_file = (
+            None
+            if known_hosts_raw is None
+            else resolve_local_path(
+                require_string(known_hosts_raw, "known_hosts_file"), inventory_dir
+            )
+        )
+        use_sudo = require_bool(
+            merged_value(table, defaults, "sudo", user != "root"), f"hosts[{name}].sudo"
+        )
+        probe = None
+        if "probe" in table:
+            probe = parse_probe(table["probe"], inventory_dir, name)
+        bootstrap = None
+        if "bootstrap" in table:
+            bootstrap = parse_bootstrap(table["bootstrap"], inventory_dir, name)
+        if bootstrap is not None and probe is not None:
+            if probe.password_file is not None and (
+                not bootstrap.uses_basic
+                or probe.username != bootstrap.basic_username
+                or probe.password_file != bootstrap.basic_password_file
+            ):
+                raise OpsError(
+                    f"hosts[{name}] Basic probe must use the bootstrap username and password file"
+                )
+            if probe.client_config is not None and (
+                not bootstrap.uses_client_certs
+                or probe.client_config != bootstrap.client_config
+            ):
+                raise OpsError(
+                    f"hosts[{name}] certificate probe must use the bootstrap client configuration"
+                )
+        hosts.append(
+            Host(
+                name=name,
+                address=address,
+                user=user,
+                port=port,
+                identity_file=identity_file,
+                known_hosts_file=known_hosts_file,
+                use_sudo=use_sudo,
+                service=REMOTE_SERVICE,
+                config_path=REMOTE_CONFIG,
+                binary_path=REMOTE_BINARY,
+                cert_path=REMOTE_CERT,
+                maintenance_path=REMOTE_MAINTENANCE,
+                connect_timeout_secs=require_int(
+                    merged_value(table, defaults, "connect_timeout_secs", 10),
+                    f"hosts[{name}].connect_timeout_secs",
+                    1,
+                    60,
+                ),
+                command_timeout_secs=require_int(
+                    merged_value(table, defaults, "command_timeout_secs", 60),
+                    f"hosts[{name}].command_timeout_secs",
+                    5,
+                    600,
+                ),
+                deploy_timeout_secs=require_int(
+                    merged_value(table, defaults, "deploy_timeout_secs", 900),
+                    f"hosts[{name}].deploy_timeout_secs",
+                    60,
+                    3600,
+                ),
+                canary=require_bool(
+                    table.get("canary", False), f"hosts[{name}].canary"
+                ),
+                probe=probe,
+                bootstrap=bootstrap,
+            )
+        )
+    return Inventory(path, repository, state_path, probe_binary, tuple(hosts))
+
+
+def remote_argv(host: Host, arguments: Sequence[str], *, admin: bool) -> str:
+    command = list(arguments)
+    if admin and host.use_sudo:
+        command = ["sudo", "-n", "--", *command]
+    return " ".join(shlex.quote(argument) for argument in command)
+
+
+class SshClient:
+    def __init__(self) -> None:
+        configured = os.environ.get("MASQUE_OPS_SSH", "ssh")
+        resolved = shutil.which(configured) if "/" not in configured else configured
+        if not resolved or not os.access(resolved, os.X_OK):
+            raise OpsError(f"SSH client is not executable: {configured}")
+        self.executable = resolved
+
+    def arguments(self, host: Host, command: str) -> list[str]:
+        arguments = [
+            self.executable,
+            "-F",
+            "/dev/null",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "PasswordAuthentication=no",
+            "-o",
+            "KbdInteractiveAuthentication=no",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "ClearAllForwardings=yes",
+            "-o",
+            "ForwardAgent=no",
+            "-o",
+            "PermitLocalCommand=no",
+            "-o",
+            "RequestTTY=no",
+            "-o",
+            "ControlMaster=no",
+            "-o",
+            "LogLevel=ERROR",
+            "-o",
+            f"ConnectTimeout={host.connect_timeout_secs}",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=2",
+            "-p",
+            str(host.port),
+        ]
+        if host.identity_file is not None:
+            ensure_private_file(host.identity_file, f"SSH identity for {host.name}")
+            arguments.extend(
+                ["-o", "IdentitiesOnly=yes", "-i", str(host.identity_file)]
+            )
+        if host.known_hosts_file is not None:
+            ensure_integrity_file(
+                host.known_hosts_file, f"known_hosts file for {host.name}"
+            )
+            arguments.extend(["-o", f"UserKnownHostsFile={host.known_hosts_file}"])
+        arguments.extend([f"{host.user}@{host.address}", command])
+        return arguments
+
+    def run(
+        self,
+        host: Host,
+        command: str,
+        *,
+        input_text: str | None = None,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(
+                self.arguments(host, command),
+                input=input_text,
+                stdin=subprocess.DEVNULL if input_text is None else None,
+                text=True,
+                capture_output=True,
+                timeout=timeout or host.command_timeout_secs,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise OpsError(f"SSH command timed out on {host.name}") from error
+        except OSError as error:
+            raise OpsError(f"could not start SSH for {host.name}: {error}") from error
+
+    def download_private(
+        self, host: Host, command: str, destination: Path, label: str
+    ) -> None:
+        """Stream a remote secret directly to a new mode-0600 local file."""
+        ensure_secret_destination(destination, label, allow_existing=False)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(destination, flags, 0o600)
+        except OSError as error:
+            raise OpsError(f"could not create {label}") from error
+        succeeded = False
+        try:
+            with os.fdopen(descriptor, "wb", closefd=True) as output:
+                try:
+                    completed = subprocess.run(
+                        self.arguments(host, command),
+                        stdin=subprocess.DEVNULL,
+                        stdout=output,
+                        stderr=subprocess.PIPE,
+                        timeout=host.command_timeout_secs,
+                        check=False,
+                    )
+                except subprocess.TimeoutExpired as error:
+                    raise OpsError(
+                        f"secret retrieval timed out on {host.name}"
+                    ) from error
+                except OSError as error:
+                    raise OpsError(
+                        f"could not start SSH for {host.name}: {error}"
+                    ) from error
+                output.flush()
+                os.fsync(output.fileno())
+            if completed.returncode != 0:
+                stderr = completed.stderr.decode("utf-8", errors="replace")
+                raise OpsError(
+                    f"could not retrieve {label} from {host.name}: "
+                    f"{safe_tail('', stderr)}"
+                )
+            size = destination.stat().st_size
+            if size == 0:
+                raise OpsError(f"{host.name} returned an empty {label}")
+            if size > 1024 * 1024:
+                raise OpsError(f"{host.name} returned an oversized {label}")
+            succeeded = True
+        finally:
+            if not succeeded:
+                try:
+                    destination.unlink()
+                except OSError:
+                    pass
+
+
+STATUS_SCRIPT = r"""# MASQUE_OPS_STATUS_V1
+set -u
+binary=$1
+config=$2
+service=$3
+cert=$4
+use_sudo=$5
+
+admin() {
+    if [ "$use_sudo" = 1 ]; then
+        sudo -n -- "$@"
+    else
+        "$@"
+    fi
+}
+
+version=$("$binary" --version 2>/dev/null | sed -n '1p')
+arch=$(uname -m 2>/dev/null || true)
+active=$(systemctl is-active "$service" 2>/dev/null || true)
+enabled=$(systemctl is-enabled "$service" 2>/dev/null || true)
+config_exists=no
+config_check=missing
+config_sha256=
+if admin test -f "$config" 2>/dev/null; then
+    config_exists=yes
+    if admin "$binary" --config "$config" check-config >/dev/null 2>&1; then
+        config_check=ok
+    else
+        config_check=failed
+    fi
+    config_sha256=$(admin sha256sum "$config" 2>/dev/null | awk 'NR == 1 { print $1 }')
+fi
+cert_not_after=$(admin openssl x509 -in "$cert" -noout -enddate 2>/dev/null |
+    sed -n 's/^notAfter=//p')
+disk_available_kb=$(df -Pk / 2>/dev/null | awk 'NR == 2 { print $4 }')
+disk_used_percent=$(df -Pk / 2>/dev/null | awk 'NR == 2 { print $5 }')
+
+printf '%s\n' \
+    'masque_ops_status=1' \
+    "version=$version" \
+    "arch=$arch" \
+    "service_active=$active" \
+    "service_enabled=$enabled" \
+    "config_exists=$config_exists" \
+    "config_check=$config_check" \
+    "config_sha256=$config_sha256" \
+    "cert_not_after=$cert_not_after" \
+    "disk_available_kb=$disk_available_kb" \
+    "disk_used_percent=$disk_used_percent"
+"""
+
+
+DIAGNOSE_SCRIPT = r"""# MASQUE_OPS_DIAGNOSE_V1
+set -u
+binary=$1
+config=$2
+service=$3
+cert=$4
+use_sudo=$5
+lines=$6
+
+admin() {
+    if [ "$use_sudo" = 1 ]; then
+        sudo -n -- "$@"
+    else
+        "$@"
+    fi
+}
+
+echo '== version =='
+"$binary" --version 2>&1 || true
+echo '== service =='
+systemctl status "$service" --no-pager -l 2>&1 || true
+echo '== configuration check =='
+admin "$binary" --config "$config" check-config 2>&1 || true
+echo '== host prerequisites =='
+admin "$binary" --config "$config" doctor 2>&1 || true
+echo '== certificate expiry =='
+admin openssl x509 -in "$cert" -noout -enddate 2>&1 || true
+echo '== root filesystem =='
+df -h / 2>&1 || true
+echo '== listening sockets =='
+ss -H -lntu 2>&1 || true
+echo '== recent warning journal =='
+admin journalctl -u "$service" -p warning -n "$lines" --no-pager 2>&1 || true
+"""
+
+
+BOOTSTRAP_PREFLIGHT_SCRIPT = r"""# MASQUE_OPS_BOOTSTRAP_PREFLIGHT_V1
+set -u
+cert=$1
+key=$2
+binary=$3
+config=$4
+
+missing=
+for required in curl tar sha256sum awk grep head mktemp install systemctl openssl getent groupadd useradd; do
+    if ! command -v "$required" >/dev/null 2>&1; then
+        if [ -n "$missing" ]; then
+            missing="$missing,$required"
+        else
+            missing=$required
+        fi
+    fi
+done
+
+printf '%s\n' \
+    'masque_ops_bootstrap_preflight=1' \
+    "os=$(uname -s 2>/dev/null || true)" \
+    "arch=$(uname -m 2>/dev/null || true)" \
+    "binary_exists=$([ -e "$binary" ] && printf yes || printf no)" \
+    "config_exists=$([ -e "$config" ] && printf yes || printf no)" \
+    "tls_cert_readable=$([ -r "$cert" ] && printf yes || printf no)" \
+    "tls_key_readable=$([ -r "$key" ] && printf yes || printf no)" \
+    "missing_commands=$missing"
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class BootstrapPreflight:
+    reachable: bool
+    os: str | None = None
+    arch: str | None = None
+    binary_exists: bool = False
+    config_exists: bool = False
+    tls_cert_readable: bool = False
+    tls_key_readable: bool = False
+    missing_commands: tuple[str, ...] = ()
+    error: str | None = None
+
+
+def parse_bootstrap_preflight(output: str) -> BootstrapPreflight:
+    fields: dict[str, str] = {}
+    for line in output.splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            fields[key] = value
+    if fields.get("masque_ops_bootstrap_preflight") != "1":
+        raise OpsError("remote returned an unsupported bootstrap preflight format")
+    missing = tuple(
+        item for item in fields.get("missing_commands", "").split(",") if item
+    )
+    return BootstrapPreflight(
+        reachable=True,
+        os=fields.get("os") or None,
+        arch=fields.get("arch") or None,
+        binary_exists=fields.get("binary_exists") == "yes",
+        config_exists=fields.get("config_exists") == "yes",
+        tls_cert_readable=fields.get("tls_cert_readable") == "yes",
+        tls_key_readable=fields.get("tls_key_readable") == "yes",
+        missing_commands=missing,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class HostStatus:
+    name: str
+    reachable: bool
+    version_output: str | None = None
+    version: str | None = None
+    arch: str | None = None
+    service_active: str | None = None
+    service_enabled: str | None = None
+    config_exists: bool = False
+    config_check: str | None = None
+    config_sha256: str | None = None
+    cert_not_after: str | None = None
+    cert_days_remaining: int | None = None
+    disk_available_kb: int | None = None
+    disk_used_percent: str | None = None
+    error: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return (
+            self.reachable
+            and self.version is not None
+            and self.service_active == "active"
+            and self.config_exists
+            and self.config_check == "ok"
+            and self.config_sha256 is not None
+            and re.fullmatch(r"[0-9a-fA-F]{64}", self.config_sha256) is not None
+        )
+
+    def public_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+def parse_cert_days(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        expires = dt.datetime.strptime(value, "%b %d %H:%M:%S %Y %Z").replace(
+            tzinfo=dt.timezone.utc
+        )
+    except ValueError:
+        return None
+    return int((expires - dt.datetime.now(dt.timezone.utc)).total_seconds() // 86400)
+
+
+def parse_status(name: str, output: str) -> HostStatus:
+    fields: dict[str, str] = {}
+    for line in output.splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            fields[key] = value
+    if fields.get("masque_ops_status") != "1":
+        raise OpsError(f"{name} returned an unsupported maintenance status format")
+
+    def optional_int(key: str) -> int | None:
+        value = fields.get(key, "")
+        try:
+            return int(value) if value else None
+        except ValueError:
+            return None
+
+    version_output = fields.get("version") or None
+    cert_not_after = fields.get("cert_not_after") or None
+    return HostStatus(
+        name=name,
+        reachable=True,
+        version_output=version_output,
+        version=installed_version(version_output),
+        arch=fields.get("arch") or None,
+        service_active=fields.get("service_active") or None,
+        service_enabled=fields.get("service_enabled") or None,
+        config_exists=fields.get("config_exists") == "yes",
+        config_check=fields.get("config_check") or None,
+        config_sha256=fields.get("config_sha256") or None,
+        cert_not_after=cert_not_after,
+        cert_days_remaining=parse_cert_days(cert_not_after),
+        disk_available_kb=optional_int("disk_available_kb"),
+        disk_used_percent=fields.get("disk_used_percent") or None,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class Release:
+    tag: str
+    prerelease: bool
+    published_at: str | None
+    assets: frozenset[str]
+
+    def required_assets(self, architecture: str) -> tuple[str, str]:
+        mapped = {
+            "x86_64": "x86_64",
+            "amd64": "x86_64",
+            "aarch64": "aarch64",
+            "arm64": "aarch64",
+        }.get(architecture)
+        if mapped is None:
+            raise OpsError(f"unsupported remote architecture: {architecture}")
+        version = self.tag.removeprefix("v")
+        archive = f"masque-v{version}-linux-{mapped}.tar.gz"
+        return archive, f"{archive}.sha256"
+
+    def supports(self, architecture: str) -> bool:
+        try:
+            required = self.required_assets(architecture)
+        except OpsError:
+            return False
+        return all(name in self.assets for name in required)
+
+
+class ReleaseClient:
+    def __init__(self, repository: str) -> None:
+        self.repository = repository
+
+    def fetch(self, version: str | None) -> Release:
+        if version is None:
+            suffix = "latest"
+            requested_tag = None
+        else:
+            requested_tag = normalize_version(version)
+            suffix = f"tags/{urllib.parse.quote(requested_tag, safe='')}"
+        url = f"https://api.github.com/repos/{self.repository}/releases/{suffix}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "masque-ops/1",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            # The origin is a literal and inventory loading fixes the repository
+            # to DEFAULT_REPOSITORY, so urlopen cannot receive another scheme.
+            with urllib.request.urlopen(request, timeout=20) as response:  # nosec B310
+                payload = json.load(response)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+            requested = version or "latest stable release"
+            raise OpsError(
+                f"could not read {requested} metadata from GitHub"
+            ) from error
+        if not isinstance(payload, dict):
+            raise OpsError("GitHub returned malformed release metadata")
+        if payload.get("draft"):
+            raise OpsError("refusing to deploy a draft GitHub release")
+        tag = normalize_version(
+            require_string(payload.get("tag_name"), "release tag_name")
+        )
+        if requested_tag is not None and tag != requested_tag:
+            raise OpsError(
+                f"GitHub returned release {tag} when {requested_tag} was requested"
+            )
+        assets_raw = payload.get("assets", [])
+        if not isinstance(assets_raw, list):
+            raise OpsError(f"GitHub release {tag} has malformed assets")
+        assets = frozenset(
+            asset.get("name")
+            for asset in assets_raw
+            if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+        )
+        return Release(
+            tag=tag,
+            prerelease=bool(payload.get("prerelease")),
+            published_at=payload.get("published_at"),
+            assets=assets,
+        )
+
+
+class ProbeRunner:
+    def __init__(self, configured_binary: str, inventory_dir: Path) -> None:
+        self.configured_binary = configured_binary
+        self.inventory_dir = inventory_dir
+
+    def resolve_binary(self) -> str:
+        configured = self.configured_binary
+        if "/" in configured:
+            candidate = resolve_local_path(configured, self.inventory_dir)
+            if not candidate.is_file() or not os.access(candidate, os.X_OK):
+                raise OpsError(f"masque-probe is not executable: {candidate}")
+            return str(candidate)
+        resolved = shutil.which(configured)
+        if resolved is None and configured == "masque-probe":
+            local_candidate = Path.home() / ".local" / "bin" / configured
+            if local_candidate.is_file() and os.access(local_candidate, os.X_OK):
+                resolved = str(local_candidate)
+        if resolved is None:
+            raise OpsError(
+                "masque-probe was not found; run install-probe.sh or set probe_binary"
+            )
+        return resolved
+
+    def preflight(
+        self, probe: ProbeConfig | None, *, allow_missing: frozenset[Path] = frozenset()
+    ) -> None:
+        if probe is None:
+            return
+        self.resolve_binary()
+        if probe.password_file is not None and (
+            probe.password_file not in allow_missing or probe.password_file.exists()
+        ):
+            ensure_private_file(probe.password_file, "probe password file")
+        if probe.client_config is not None and (
+            probe.client_config not in allow_missing or probe.client_config.exists()
+        ):
+            ensure_private_file(probe.client_config, "probe client configuration")
+        if probe.ca_cert is not None:
+            ensure_integrity_file(probe.ca_cert, "probe CA certificate")
+
+    def run(self, host: Host) -> dict[str, object]:
+        probe = host.probe
+        if probe is None:
+            return {"status": "not_configured"}
+        self.preflight(probe)
+        command = [
+            self.resolve_binary(),
+            probe.endpoint,
+            "--transport",
+            probe.transport,
+            "--timeout",
+            str(probe.timeout_secs),
+            "--udp-mode",
+            probe.udp_mode,
+            "--json",
+        ]
+        for option, value in (
+            ("--server-name", probe.server_name),
+            ("--resolve", probe.resolve),
+            ("--interface", probe.interface),
+            ("--tcp-target", probe.tcp_target),
+            ("--udp-target", probe.udp_target),
+        ):
+            if value is not None:
+                command.extend([option, value])
+        if probe.connect_ip:
+            command.append("--connect-ip")
+        if probe.skip_tcp:
+            command.append("--skip-tcp")
+        if probe.skip_udp:
+            command.append("--skip-udp")
+        if probe.ca_cert is not None:
+            command.extend(["--ca-cert", str(probe.ca_cert)])
+        stdin_handle: Any = subprocess.DEVNULL
+        password_handle = None
+        if probe.username is not None:
+            command.extend(["--username", probe.username, "--password-stdin"])
+            if probe.password_file is None:
+                raise OpsError(f"probe password file is missing for {host.name}")
+            try:
+                password_handle = probe.password_file.open("rb")
+            except OSError as error:
+                raise OpsError(
+                    f"could not open probe password file for {host.name}"
+                ) from error
+            stdin_handle = password_handle
+        elif probe.client_config is not None:
+            command.extend(["--client-config", str(probe.client_config)])
+        try:
+            completed = subprocess.run(
+                command,
+                stdin=stdin_handle,
+                capture_output=True,
+                timeout=probe.timeout_secs * 6 + 15,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise OpsError(
+                f"external MASQUE probe timed out for {host.name}"
+            ) from error
+        except OSError as error:
+            raise OpsError(
+                f"could not start masque-probe for {host.name}: {error}"
+            ) from error
+        finally:
+            if password_handle is not None:
+                password_handle.close()
+        try:
+            report = json.loads(completed.stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise OpsError(
+                f"masque-probe returned invalid JSON for {host.name}"
+            ) from error
+        if not isinstance(report, dict):
+            raise OpsError(f"masque-probe returned invalid JSON for {host.name}")
+        checks = report.get("checks", [])
+        if not isinstance(checks, list) or type(report.get("success")) is not bool:
+            raise OpsError(f"masque-probe returned invalid JSON for {host.name}")
+        failed_codes = [
+            check.get("code", "UNKNOWN")
+            for check in checks
+            if isinstance(check, dict) and check.get("status") == "fail"
+        ]
+        summary: dict[str, object] = {
+            "status": "passed" if report.get("success") else "failed",
+            "transport": report.get("selected_transport"),
+            "failed_codes": failed_codes,
+        }
+        if completed.returncode != 0 or not report.get("success"):
+            codes = ", ".join(str(code) for code in failed_codes) or "UNKNOWN"
+            raise OpsError(f"external MASQUE probe failed for {host.name}: {codes}")
+        return summary
+
+
+class StateStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.audit_path = path.with_name("ops-audit.jsonl")
+
+    def _prepare_parent(self) -> None:
+        try:
+            self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        except OSError as error:
+            raise OpsError(
+                f"could not prepare operations state directory: {self.path.parent}"
+            ) from error
+
+    def load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"schema_version": SCHEMA_VERSION, "hosts": {}}
+        ensure_private_file(self.path, "operations state")
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise OpsError(f"invalid operations state: {self.path}") from error
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != SCHEMA_VERSION
+            or not isinstance(payload.get("hosts"), dict)
+        ):
+            raise OpsError(f"unsupported operations state schema: {self.path}")
+        return payload
+
+    def save_transition(self, host: str, old: str, new: str) -> None:
+        payload = self.load()
+        payload["hosts"][host] = {
+            "current_version": new,
+            "rollback_version": old,
+            "updated_at": utc_now(),
+        }
+        self._prepare_parent()
+        try:
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{self.path.name}.", dir=self.path.parent
+            )
+        except OSError as error:
+            raise OpsError(f"could not create operations state: {self.path}") from error
+        temporary = Path(temporary_name)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+        except OSError as error:
+            raise OpsError(f"could not write operations state: {self.path}") from error
+        finally:
+            if temporary.exists():
+                try:
+                    temporary.unlink()
+                except OSError:
+                    pass
+
+    def rollback_target(self, host: str, current: str) -> str:
+        payload = self.load()
+        entry = payload["hosts"].get(host)
+        if not isinstance(entry, dict):
+            raise OpsError(f"no successful deployment history exists for {host}")
+        if entry.get("current_version") != current:
+            raise OpsError(
+                f"rollback state for {host} expects {entry.get('current_version')}, "
+                f"but the server runs {current}"
+            )
+        return normalize_version(
+            require_string(entry.get("rollback_version"), "rollback_version")
+        )
+
+    def audit(self, event: str, host: str, **fields: object) -> None:
+        self._prepare_parent()
+        record = {"timestamp": utc_now(), "event": event, "host": host, **fields}
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NONBLOCK
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(self.audit_path, flags, 0o600)
+        except OSError as error:
+            raise OpsError(
+                f"could not open operations audit: {self.audit_path}"
+            ) from error
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise OpsError(
+                    f"operations audit is not a regular file: {self.audit_path}"
+                )
+            if hasattr(os, "getuid") and metadata.st_uid != os.getuid():
+                raise OpsError(
+                    f"operations audit is not owned by the current user: {self.audit_path}"
+                )
+            if metadata.st_mode & 0o077:
+                raise OpsError(f"operations audit is not private: {self.audit_path}")
+            os.write(descriptor, (json.dumps(record, sort_keys=True) + "\n").encode())
+            os.fsync(descriptor)
+        except OSError as error:
+            raise OpsError(
+                f"could not write operations audit: {self.audit_path}"
+            ) from error
+        finally:
+            os.close(descriptor)
+
+
+class FleetOperator:
+    def __init__(self, inventory: Inventory, ssh: SshClient | None = None) -> None:
+        self.inventory = inventory
+        self.ssh = ssh or SshClient()
+        self.probes = ProbeRunner(inventory.probe_binary, inventory.path.parent)
+        self.state = StateStore(inventory.state_path)
+
+    def _audit_best_effort(self, event: str, host: str, **fields: object) -> bool:
+        try:
+            self.state.audit(event, host, **fields)
+            return True
+        except OpsError:
+            return False
+
+    def _maintenance(
+        self, host: Host, *arguments: str, timeout: int | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        command = remote_argv(host, [host.maintenance_path, *arguments], admin=True)
+        return self.ssh.run(host, command, timeout=timeout or host.command_timeout_secs)
+
+    def status(self, host: Host) -> HostStatus:
+        maintenance = self._maintenance(host, "status")
+        if maintenance.returncode == 0:
+            try:
+                return parse_status(host.name, maintenance.stdout)
+            except OpsError:
+                pass
+        command = remote_argv(
+            host,
+            [
+                "sh",
+                "-s",
+                "--",
+                host.binary_path,
+                host.config_path,
+                host.service,
+                host.cert_path,
+                "1" if host.use_sudo else "0",
+            ],
+            admin=False,
+        )
+        completed = self.ssh.run(host, command, input_text=STATUS_SCRIPT)
+        if completed.returncode != 0:
+            return HostStatus(
+                name=host.name,
+                reachable=False,
+                error=safe_tail(completed.stdout, completed.stderr),
+            )
+        try:
+            return parse_status(host.name, completed.stdout)
+        except OpsError as error:
+            return HostStatus(name=host.name, reachable=False, error=str(error))
+
+    def bootstrap_preflight(self, host: Host) -> BootstrapPreflight:
+        bootstrap = host.bootstrap
+        if bootstrap is None:
+            return BootstrapPreflight(
+                reachable=False, error="bootstrap settings are not configured"
+            )
+        command = remote_argv(
+            host,
+            [
+                "sh",
+                "-s",
+                "--",
+                bootstrap.tls_cert_path,
+                bootstrap.tls_key_path,
+                host.binary_path,
+                host.config_path,
+            ],
+            admin=False,
+        )
+        completed = self.ssh.run(
+            host,
+            command,
+            input_text=BOOTSTRAP_PREFLIGHT_SCRIPT,
+            timeout=host.command_timeout_secs,
+        )
+        if completed.returncode != 0:
+            return BootstrapPreflight(
+                reachable=False,
+                error=safe_tail(completed.stdout, completed.stderr),
+            )
+        try:
+            return parse_bootstrap_preflight(completed.stdout)
+        except OpsError as error:
+            return BootstrapPreflight(reachable=False, error=str(error))
+
+    def statuses(self, hosts: Sequence[Host]) -> list[HostStatus]:
+        results: dict[str, HostStatus] = {}
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(8, len(hosts))
+        ) as executor:
+            futures = {executor.submit(self.status, host): host for host in hosts}
+            for future, host in ((future, futures[future]) for future in futures):
+                try:
+                    results[host.name] = future.result()
+                except OpsError as error:
+                    results[host.name] = HostStatus(
+                        name=host.name, reachable=False, error=str(error)
+                    )
+        return [results[host.name] for host in hosts]
+
+    @staticmethod
+    def _bootstrap_missing_probe_credentials(host: Host) -> frozenset[Path]:
+        bootstrap = host.bootstrap
+        probe = host.probe
+        if bootstrap is None or probe is None:
+            return frozenset()
+        generated = {
+            path
+            for path in (
+                bootstrap.basic_password_file,
+                bootstrap.client_config,
+            )
+            if path is not None
+        }
+        return frozenset(
+            path
+            for path in (probe.password_file, probe.client_config)
+            if path is not None and path in generated and not path.exists()
+        )
+
+    def preflight_bootstrap_local(self, host: Host) -> None:
+        bootstrap = host.bootstrap
+        if bootstrap is None:
+            raise OpsError(f"bootstrap settings are not configured for {host.name}")
+        if bootstrap.basic_password_file is not None:
+            ensure_secret_destination(
+                bootstrap.basic_password_file,
+                "bootstrap Basic password file",
+                allow_existing=True,
+            )
+            if bootstrap.basic_password_file.exists():
+                read_private_password(
+                    bootstrap.basic_password_file, "bootstrap Basic password file"
+                )
+        for path, label in (
+            (bootstrap.basic_client_config, "bootstrap Basic client configuration"),
+            (bootstrap.client_config, "bootstrap certificate client configuration"),
+        ):
+            if path is not None:
+                ensure_secret_destination(path, label, allow_existing=False)
+        self.probes.preflight(
+            host.probe,
+            allow_missing=self._bootstrap_missing_probe_credentials(host),
+        )
+
+    @staticmethod
+    def _bootstrap_environment(
+        bootstrap: BootstrapConfig,
+        version: str,
+        repository: str,
+        password: str | None,
+        remote_basic_config: str | None,
+        remote_client_config: str | None,
+    ) -> dict[str, str]:
+        environment = {
+            "MASQUE_VERSION": version,
+            "MASQUE_GITHUB_REPOSITORY": repository,
+            "MASQUE_START_SERVICE": "1",
+            "MASQUE_RUN_HOST_DIAGNOSTICS": "0",
+            "MASQUE_PRINT_SECRETS": "0",
+            "MASQUE_AUTH_MODE": bootstrap.auth_mode,
+            "MASQUE_LISTEN_PORT": str(bootstrap.listen_port),
+            "MASQUE_TLS_CERT": bootstrap.tls_cert_path,
+            "MASQUE_TLS_KEY": bootstrap.tls_key_path,
+        }
+        if bootstrap.uses_basic:
+            if bootstrap.basic_username is None or password is None:
+                raise OpsError("internal Basic bootstrap credentials are incomplete")
+            environment.update(
+                {
+                    "MASQUE_AUTH_USERNAME": bootstrap.basic_username,
+                    "MASQUE_AUTH_PASSWORD": password,
+                    "MASQUE_BASIC_STEALTH": ("1" if bootstrap.basic_stealth else "0"),
+                }
+            )
+            if bootstrap.basic_client_endpoint is not None:
+                if remote_basic_config is None:
+                    raise OpsError("internal Basic client output is incomplete")
+                environment["MASQUE_BASIC_CLIENT_ENDPOINT"] = (
+                    bootstrap.basic_client_endpoint
+                )
+                environment["MASQUE_BASIC_CLIENT_CONFIG_OUT"] = remote_basic_config
+                if bootstrap.basic_client_name is not None:
+                    environment["MASQUE_BASIC_CLIENT_NAME"] = (
+                        bootstrap.basic_client_name
+                    )
+        if bootstrap.auth_mode == "dual":
+            if bootstrap.cert_listen_port is None:
+                raise OpsError("internal dual-listener bootstrap is incomplete")
+            environment["MASQUE_CERT_LISTEN_PORT"] = str(bootstrap.cert_listen_port)
+        if bootstrap.uses_client_certs:
+            if (
+                bootstrap.client_name is None
+                or bootstrap.client_endpoint is None
+                or remote_client_config is None
+            ):
+                raise OpsError("internal certificate bootstrap settings are incomplete")
+            environment.update(
+                {
+                    "MASQUE_CLIENT_NAME": bootstrap.client_name,
+                    "MASQUE_CLIENT_ENDPOINT": bootstrap.client_endpoint,
+                    "MASQUE_CLIENT_IPV4": bootstrap.client_ipv4 or "none",
+                    "MASQUE_CLIENT_IPV6": bootstrap.client_ipv6 or "none",
+                    "MASQUE_CLIENT_CONFIG_OUT": remote_client_config,
+                }
+            )
+        return environment
+
+    def _run_fresh_install(
+        self, host: Host, version: str, password: str | None
+    ) -> tuple[str | None, str | None]:
+        bootstrap = host.bootstrap
+        if bootstrap is None:
+            raise OpsError(f"bootstrap settings are not configured for {host.name}")
+        installer = REPO_ROOT / "install-latest.sh"
+        if not installer.is_file():
+            raise OpsError("repository bootstrap installer is missing")
+        try:
+            installer_text = installer.read_text(encoding="utf-8")
+        except OSError as error:
+            raise OpsError(
+                "repository bootstrap installer could not be read"
+            ) from error
+
+        token = secrets.token_hex(16)
+        remote_basic_config = (
+            f"/root/.masque-ops-{token}.surge.conf"
+            if bootstrap.basic_client_config is not None
+            else None
+        )
+        remote_client_config = (
+            f"/root/.masque-ops-{token}.client.json"
+            if bootstrap.client_config is not None
+            else None
+        )
+        environment = self._bootstrap_environment(
+            bootstrap,
+            version,
+            self.inventory.repository,
+            password,
+            remote_basic_config,
+            remote_client_config,
+        )
+        prefix = "\n".join(
+            f"export {name}={shlex.quote(value)}" for name, value in environment.items()
+        )
+        # Values, including the Basic password, travel only in encrypted SSH
+        # standard input. They never appear in local or remote process argv.
+        payload = f"{prefix}\n{installer_text}"
+        command = remote_argv(host, ["sh", "-s"], admin=False)
+        completed = self.ssh.run(
+            host,
+            command,
+            input_text=payload,
+            timeout=host.deploy_timeout_secs,
+        )
+        if completed.returncode != 0:
+            for remote_path in (remote_basic_config, remote_client_config):
+                if remote_path is not None:
+                    self._remove_remote_secret_best_effort(host, remote_path)
+            raise OpsError(
+                f"fresh installer failed on {host.name}: "
+                f"{safe_tail(completed.stdout, completed.stderr)}"
+            )
+        return remote_basic_config, remote_client_config
+
+    def _remove_remote_secret_best_effort(self, host: Host, path: str) -> bool:
+        command = remote_argv(host, ["rm", "-f", "--", path], admin=False)
+        try:
+            completed = self.ssh.run(host, command)
+        except OpsError:
+            return False
+        return completed.returncode == 0
+
+    def _retrieve_bootstrap_secret(
+        self, host: Host, remote_path: str, destination: Path, label: str
+    ) -> None:
+        command = remote_argv(
+            host, ["head", "-c", "1048577", "--", remote_path], admin=False
+        )
+        self.ssh.download_private(host, command, destination, label)
+        if not self._remove_remote_secret_best_effort(host, remote_path):
+            raise OpsError(
+                f"{label} was saved, but its remote temporary file could not be removed"
+            )
+
+    def verify_bootstrap(self, host: Host, expected: str) -> HostStatus:
+        last: HostStatus | None = None
+        for attempt in range(4):
+            if attempt:
+                time.sleep(1)
+            maintenance = self._maintenance(host, "status")
+            if maintenance.returncode != 0:
+                continue
+            try:
+                last = parse_status(host.name, maintenance.stdout)
+            except OpsError:
+                continue
+            if last.healthy and last.version == expected:
+                return last
+        if last is None:
+            raise OpsError(
+                f"post-install verification could not run the maintenance helper on {host.name}"
+            )
+        raise OpsError(
+            f"post-install verification failed for {host.name}: expected {expected}, "
+            f"got version={last.version or 'unknown'} active={last.service_active or 'unknown'} "
+            f"config={last.config_check or 'unknown'}"
+        )
+
+    def bootstrap_one(self, host: Host, release: Release) -> dict[str, object]:
+        plan = plan_bootstrap(self, host, release)
+        if not plan["ready"]:
+            blockers = plan.get("blockers", [])
+            raise OpsError(f"bootstrap preflight failed: {'; '.join(blockers)}")
+        bootstrap = host.bootstrap
+        if bootstrap is None:
+            raise OpsError(f"bootstrap settings are not configured for {host.name}")
+
+        self.state.audit("bootstrap_started", host.name, to_version=release.tag)
+        password = None
+        password_created = False
+        try:
+            if bootstrap.basic_password_file is not None:
+                if bootstrap.basic_password_file.exists():
+                    password = read_private_password(
+                        bootstrap.basic_password_file,
+                        "bootstrap Basic password file",
+                    )
+                else:
+                    password = secrets.token_urlsafe(32)
+                    write_private_file(
+                        bootstrap.basic_password_file,
+                        f"{password}\n".encode(),
+                        "bootstrap Basic password file",
+                    )
+                    password_created = True
+            remote_basic, remote_client = self._run_fresh_install(
+                host, release.tag, password
+            )
+            if remote_basic is not None and bootstrap.basic_client_config is not None:
+                self._retrieve_bootstrap_secret(
+                    host,
+                    remote_basic,
+                    bootstrap.basic_client_config,
+                    "bootstrap Basic client configuration",
+                )
+            if remote_client is not None and bootstrap.client_config is not None:
+                self._retrieve_bootstrap_secret(
+                    host,
+                    remote_client,
+                    bootstrap.client_config,
+                    "bootstrap certificate client configuration",
+                )
+            after = self.verify_bootstrap(host, release.tag)
+            probe = self.probes.run(host)
+        except OpsError as error:
+            self._audit_best_effort(
+                "bootstrap_failed",
+                host.name,
+                to_version=release.tag,
+                error=type(error).__name__,
+            )
+            raise OpsError(
+                f"bootstrap did not complete cleanly on {host.name}; inspect status "
+                "before retrying because a first install has no previous release to restore"
+            ) from error
+        try:
+            self.state.audit(
+                "bootstrap_succeeded",
+                host.name,
+                to_version=release.tag,
+                config_sha256=after.config_sha256,
+                probe=probe.get("status"),
+            )
+        except OpsError as audit_error:
+            raise OpsError(
+                f"bootstrap succeeded on {host.name}, but audit finalization failed; "
+                "stop further operations"
+            ) from audit_error
+        return {
+            "host": host.name,
+            "status": "installed",
+            "version": release.tag,
+            "probe": probe,
+            "basic_password_created": password_created,
+            "credential_files_saved": sum(
+                path is not None
+                for path in (
+                    bootstrap.basic_password_file,
+                    bootstrap.basic_client_config,
+                    bootstrap.client_config,
+                )
+            ),
+        }
+
+    def diagnose(self, host: Host, lines: int) -> str:
+        completed = self._maintenance(host, "diagnose", str(lines))
+        if completed.returncode == 0:
+            return sanitize_diagnostics(completed.stdout)
+        command = remote_argv(
+            host,
+            [
+                "sh",
+                "-s",
+                "--",
+                host.binary_path,
+                host.config_path,
+                host.service,
+                host.cert_path,
+                "1" if host.use_sudo else "0",
+                str(lines),
+            ],
+            admin=False,
+        )
+        fallback = self.ssh.run(host, command, input_text=DIAGNOSE_SCRIPT)
+        if fallback.returncode != 0:
+            raise OpsError(
+                f"diagnostics failed on {host.name}: "
+                f"{safe_tail(fallback.stdout, fallback.stderr)}"
+            )
+        return sanitize_diagnostics(fallback.stdout)
+
+    def verify_remote(
+        self, host: Host, expected: str, expected_config_sha256: str
+    ) -> HostStatus:
+        last: HostStatus | None = None
+        for attempt in range(4):
+            if attempt:
+                time.sleep(1)
+            last = self.status(host)
+            if (
+                last.healthy
+                and last.version == expected
+                and last.config_sha256 == expected_config_sha256
+            ):
+                return last
+        if last is None:
+            raise OpsError(f"post-deploy verification did not run for {host.name}")
+        raise OpsError(
+            f"post-deploy verification failed for {host.name}: expected {expected}, "
+            f"got version={last.version or 'unknown'} active={last.service_active or 'unknown'} "
+            f"config={last.config_check or 'unknown'} "
+            f"config_unchanged={last.config_sha256 == expected_config_sha256}"
+        )
+
+    @staticmethod
+    def ensure_release(host: Host, status: HostStatus, release: Release) -> None:
+        if not status.reachable:
+            raise OpsError(f"{host.name} is unreachable: {status.error}")
+        if not status.healthy:
+            raise OpsError(
+                f"{host.name} is not healthy before deployment: "
+                f"active={status.service_active or 'unknown'} "
+                f"config={status.config_check or 'unknown'}"
+            )
+        if status.arch is None or not release.supports(status.arch):
+            raise OpsError(
+                f"release {release.tag} has no verified archive and checksum for "
+                f"{host.name} architecture {status.arch or 'unknown'}"
+            )
+
+    def _run_upgrade(self, host: Host, target: str, *, bootstrap: bool) -> None:
+        if bootstrap:
+            if host.user != "root" or host.use_sudo:
+                raise OpsError(
+                    "--bootstrap is restricted to an explicit root SSH inventory entry"
+                )
+            installer = REPO_ROOT / "install-latest.sh"
+            if not installer.is_file():
+                raise OpsError(f"bootstrap installer not found: {installer}")
+            try:
+                installer_text = installer.read_text(encoding="utf-8")
+            except OSError as error:
+                raise OpsError(
+                    f"bootstrap installer could not be read: {installer}"
+                ) from error
+            command = remote_argv(
+                host,
+                [
+                    "env",
+                    f"MASQUE_VERSION={target}",
+                    f"MASQUE_GITHUB_REPOSITORY={self.inventory.repository}",
+                    "MASQUE_START_SERVICE=1",
+                    "MASQUE_RUN_HOST_DIAGNOSTICS=0",
+                    "sh",
+                    "-s",
+                ],
+                admin=False,
+            )
+            completed = self.ssh.run(
+                host,
+                command,
+                input_text=installer_text,
+                timeout=host.deploy_timeout_secs,
+            )
+        else:
+            completed = self._maintenance(
+                host, "upgrade", target, timeout=host.deploy_timeout_secs
+            )
+        if completed.returncode != 0:
+            raise OpsError(
+                f"installer failed on {host.name}: "
+                f"{safe_tail(completed.stdout, completed.stderr)}"
+            )
+
+    def _restore(
+        self,
+        host: Host,
+        version: str,
+        expected_config_sha256: str,
+        *,
+        bootstrap: bool,
+    ) -> None:
+        self._run_upgrade(host, version, bootstrap=bootstrap)
+        self.verify_remote(host, version, expected_config_sha256)
+
+    def deploy_one(
+        self,
+        host: Host,
+        release: Release,
+        releases: ReleaseClient,
+        *,
+        bootstrap: bool = False,
+    ) -> dict[str, object]:
+        before = self.status(host)
+        self.ensure_release(host, before, release)
+        previous_version = before.version
+        config_sha256 = before.config_sha256
+        if previous_version is None or config_sha256 is None:
+            raise OpsError(
+                f"installed version or configuration hash is unknown on {host.name}"
+            )
+        if previous_version == release.tag:
+            probe = self.probes.run(host)
+            return {
+                "host": host.name,
+                "status": "already_current",
+                "version": release.tag,
+                "probe": probe,
+            }
+        previous_release = releases.fetch(previous_version)
+        self.ensure_release(host, before, previous_release)
+        self.probes.preflight(host.probe)
+        self.state.audit(
+            "deploy_started",
+            host.name,
+            from_version=previous_version,
+            to_version=release.tag,
+        )
+        try:
+            self._run_upgrade(host, release.tag, bootstrap=bootstrap)
+            after = self.verify_remote(host, release.tag, config_sha256)
+            probe = self.probes.run(host)
+            self.state.save_transition(host.name, previous_version, release.tag)
+        except OpsError as deploy_error:
+            audit_ok = self._audit_best_effort(
+                "deploy_failed",
+                host.name,
+                from_version=previous_version,
+                to_version=release.tag,
+                error=type(deploy_error).__name__,
+            )
+            try:
+                current = self.status(host)
+                if not (
+                    current.healthy
+                    and current.version == previous_version
+                    and current.config_sha256 == config_sha256
+                ):
+                    self._restore(
+                        host,
+                        previous_version,
+                        config_sha256,
+                        bootstrap=bootstrap,
+                    )
+            except OpsError as rollback_error:
+                self._audit_best_effort(
+                    "automatic_rollback_failed",
+                    host.name,
+                    intended_version=previous_version,
+                    error=type(rollback_error).__name__,
+                )
+                suffix = "" if audit_ok else "; audit logging also failed"
+                raise OpsError(
+                    f"deployment and automatic rollback both failed on {host.name}; "
+                    f"manual recovery is required{suffix}"
+                ) from rollback_error
+            audit_ok = (
+                self._audit_best_effort(
+                    "automatic_rollback_succeeded",
+                    host.name,
+                    restored_version=previous_version,
+                )
+                and audit_ok
+            )
+            suffix = "" if audit_ok else "; audit logging also failed"
+            raise OpsError(
+                f"deployment failed on {host.name}; {previous_version} was restored: "
+                f"{deploy_error}{suffix}"
+            ) from deploy_error
+        try:
+            self.state.audit(
+                "deploy_succeeded",
+                host.name,
+                from_version=previous_version,
+                to_version=release.tag,
+                config_sha256=after.config_sha256,
+                probe=probe.get("status"),
+            )
+        except OpsError as audit_error:
+            raise OpsError(
+                f"deployment succeeded on {host.name} and local state was recorded, "
+                "but audit finalization failed; stop the rollout"
+            ) from audit_error
+        return {
+            "host": host.name,
+            "status": "deployed",
+            "from_version": previous_version,
+            "version": release.tag,
+            "probe": probe,
+        }
+
+    def rollback_one(self, host: Host, releases: ReleaseClient) -> dict[str, object]:
+        before = self.status(host)
+        if not before.healthy or before.version is None or before.config_sha256 is None:
+            raise OpsError(f"{host.name} is not healthy enough to roll back safely")
+        config_sha256 = before.config_sha256
+        target = self.state.rollback_target(host.name, before.version)
+        release = releases.fetch(target)
+        self.ensure_release(host, before, release)
+        self.probes.preflight(host.probe)
+        self.state.audit(
+            "rollback_started",
+            host.name,
+            from_version=before.version,
+            to_version=target,
+        )
+        try:
+            self._run_upgrade(host, target, bootstrap=False)
+            self.verify_remote(host, target, config_sha256)
+            probe = self.probes.run(host)
+            self.state.save_transition(host.name, before.version, target)
+        except OpsError as rollback_error:
+            audit_ok = self._audit_best_effort(
+                "rollback_failed",
+                host.name,
+                from_version=before.version,
+                to_version=target,
+                error=type(rollback_error).__name__,
+            )
+            try:
+                self._restore(host, before.version, config_sha256, bootstrap=False)
+            except OpsError as recovery_error:
+                self._audit_best_effort(
+                    "rollback_recovery_failed",
+                    host.name,
+                    intended_version=before.version,
+                    error=type(recovery_error).__name__,
+                )
+                suffix = "" if audit_ok else "; audit logging also failed"
+                raise OpsError(
+                    f"rollback and recovery both failed on {host.name}; "
+                    f"manual recovery is required{suffix}"
+                ) from recovery_error
+            audit_ok = (
+                self._audit_best_effort(
+                    "rollback_recovery_succeeded",
+                    host.name,
+                    restored_version=before.version,
+                )
+                and audit_ok
+            )
+            suffix = "" if audit_ok else "; audit logging also failed"
+            raise OpsError(
+                f"rollback failed on {host.name}; {before.version} was restored: "
+                f"{rollback_error}{suffix}"
+            ) from rollback_error
+        try:
+            self.state.audit(
+                "rollback_succeeded",
+                host.name,
+                from_version=before.version,
+                to_version=target,
+                probe=probe.get("status"),
+            )
+        except OpsError as audit_error:
+            raise OpsError(
+                f"rollback succeeded on {host.name} and local state was recorded, "
+                "but audit finalization failed; stop further operations"
+            ) from audit_error
+        return {
+            "host": host.name,
+            "status": "rolled_back",
+            "from_version": before.version,
+            "version": target,
+            "probe": probe,
+        }
+
+
+def plan_bootstrap(
+    operator: FleetOperator, host: Host, release: Release
+) -> dict[str, object]:
+    blockers: list[str] = []
+    if host.bootstrap is None:
+        blockers.append("bootstrap settings are not configured")
+    if host.user != "root" or host.use_sudo:
+        blockers.append("fresh bootstrap requires an explicit root SSH inventory entry")
+    try:
+        operator.preflight_bootstrap_local(host)
+    except OpsError as error:
+        blockers.append(str(error))
+
+    remote = operator.bootstrap_preflight(host)
+    if not remote.reachable:
+        blockers.append(
+            f"remote bootstrap preflight failed: {remote.error or 'unknown'}"
+        )
+    else:
+        if remote.os != "Linux":
+            blockers.append("target host is not Linux")
+        if remote.binary_exists or remote.config_exists:
+            blockers.append("MASQUE is already installed or partially configured")
+        if not remote.tls_cert_readable or not remote.tls_key_readable:
+            blockers.append("configured remote TLS material is not readable")
+        if remote.missing_commands:
+            blockers.append(
+                "target is missing required commands: "
+                + ", ".join(remote.missing_commands)
+            )
+        if remote.arch is None or not release.supports(remote.arch):
+            blockers.append(
+                "target release assets are missing for the remote architecture"
+            )
+    return {
+        "host": host.name,
+        "target_version": release.tag,
+        "action": "fresh_install",
+        "ready": not blockers,
+        "blockers": blockers,
+        "probe_configured": host.probe is not None,
+    }
+
+
+def plan_upgrade(
+    operator: FleetOperator,
+    hosts: Sequence[Host],
+    release: Release,
+    releases: ReleaseClient,
+) -> dict[str, object]:
+    statuses = operator.statuses(hosts)
+    plans: list[dict[str, object]] = []
+    previous_cache: dict[str, bool] = {}
+    for host, status in zip(hosts, statuses, strict=True):
+        blockers: list[str] = []
+        if not status.reachable:
+            blockers.append("unreachable")
+        elif not status.healthy:
+            blockers.append("pre-deploy health check failed")
+        if status.arch is None or not release.supports(status.arch):
+            blockers.append("target release assets missing for architecture")
+        if status.version is None:
+            blockers.append("installed version is unknown")
+        elif status.version != release.tag:
+            if status.version not in previous_cache:
+                try:
+                    old_release = releases.fetch(status.version)
+                    previous_cache[status.version] = bool(
+                        status.arch and old_release.supports(status.arch)
+                    )
+                except OpsError:
+                    previous_cache[status.version] = False
+            if not previous_cache[status.version]:
+                blockers.append("current release is unavailable for automatic rollback")
+        if host.probe is not None:
+            try:
+                operator.probes.preflight(host.probe)
+            except OpsError as error:
+                blockers.append(str(error))
+        if status.version == release.tag:
+            action = "verify"
+        elif status.version and version_order(status.version) > version_order(
+            release.tag
+        ):
+            action = "downgrade"
+        else:
+            action = "upgrade"
+        plans.append(
+            {
+                "host": host.name,
+                "current_version": status.version,
+                "target_version": release.tag,
+                "action": action,
+                "canary": host.canary,
+                "probe_configured": host.probe is not None,
+                "ready": not blockers,
+                "blockers": blockers,
+            }
+        )
+    return {
+        "target_version": release.tag,
+        "prerelease": release.prerelease,
+        "published_at": release.published_at,
+        "ready": all(plan["ready"] for plan in plans),
+        "hosts": plans,
+    }
+
+
+def format_statuses(statuses: Sequence[HostStatus]) -> None:
+    print(
+        f"{'HOST':<18} {'VERSION':<14} {'ACTIVE':<10} {'CONFIG':<9} {'ARCH':<10} {'DISK':<8} CERT"
+    )
+    for status in statuses:
+        if not status.reachable:
+            print(
+                f"{status.name:<18} {'-':<14} {'-':<10} {'-':<9} {'-':<10} {'-':<8} ERROR"
+            )
+            continue
+        disk = status.disk_used_percent or "-"
+        cert = (
+            f"{status.cert_days_remaining}d"
+            if status.cert_days_remaining is not None
+            else "unknown"
+        )
+        print(
+            f"{status.name:<18} {(status.version or 'unknown'):<14} "
+            f"{(status.service_active or 'unknown'):<10} "
+            f"{(status.config_check or 'unknown'):<9} "
+            f"{(status.arch or 'unknown'):<10} {disk:<8} {cert}"
+        )
+
+
+def print_plan(plan: dict[str, object]) -> None:
+    print(f"Target release: {plan['target_version']}")
+    print(f"Fleet ready:   {'yes' if plan['ready'] else 'no'}")
+    print()
+    hosts = plan.get("hosts")
+    if not isinstance(hosts, list):
+        raise OpsError("invalid internal upgrade plan")
+    for host in hosts:
+        if not isinstance(host, dict):
+            raise OpsError("invalid internal host upgrade plan")
+        blockers = host["blockers"]
+        suffix = "" if not blockers else f" — blocked: {'; '.join(blockers)}"
+        marker = "canary" if host["canary"] else "node"
+        print(
+            f"[{marker}] {host['host']}: {host['current_version'] or 'unknown'} "
+            f"-> {host['target_version']} ({host['action']}){suffix}"
+        )
+
+
+def emit(payload: object, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="masque-ops",
+        description="Inspect and safely operate a masque-server fleet over SSH",
+    )
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=DEFAULT_INVENTORY,
+        help=f"private fleet TOML (default: {DEFAULT_INVENTORY})",
+    )
+    parser.add_argument("--json", action="store_true", help="emit stable JSON output")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    subcommands.add_parser(
+        "validate", help="validate local inventory and secret file permissions"
+    )
+
+    status = subcommands.add_parser(
+        "status", help="read fleet version and health state"
+    )
+    status.add_argument("hosts", nargs="*")
+
+    plan = subcommands.add_parser(
+        "plan", help="prepare a non-mutating release upgrade plan"
+    )
+    plan.add_argument("hosts", nargs="*")
+    plan.add_argument("--version", help="exact tag; omit for latest stable release")
+
+    deploy = subcommands.add_parser(
+        "deploy", help="deploy one exact release to one host"
+    )
+    deploy.add_argument("host")
+    deploy.add_argument("--version", required=True, help="exact release tag")
+    deploy.add_argument(
+        "--apply", action="store_true", help="authorize the remote mutation"
+    )
+    deploy.add_argument(
+        "--bootstrap",
+        action="store_true",
+        help="one-time root install of masque-maintain on a pre-operations release",
+    )
+
+    bootstrap = subcommands.add_parser(
+        "bootstrap",
+        help="preflight or install an exact release on one unconfigured Linux host",
+    )
+    bootstrap.add_argument("host")
+    bootstrap.add_argument("--version", required=True, help="exact release tag")
+    bootstrap.add_argument(
+        "--apply", action="store_true", help="authorize the fresh installation"
+    )
+
+    rollout = subcommands.add_parser(
+        "rollout",
+        help="deploy canary first, then the remaining selected hosts sequentially",
+    )
+    rollout.add_argument("hosts", nargs="*")
+    rollout.add_argument("--version", required=True, help="exact release tag")
+    rollout.add_argument(
+        "--canary", help="override the inventory canary for this rollout"
+    )
+    rollout.add_argument(
+        "--apply", action="store_true", help="authorize remote mutations"
+    )
+    rollout.add_argument(
+        "--allow-no-probe",
+        action="store_true",
+        help="allow canary verification without an external masque-probe",
+    )
+
+    rollback = subcommands.add_parser(
+        "rollback", help="restore the prior successful version recorded for one host"
+    )
+    rollback.add_argument("host")
+    rollback.add_argument(
+        "--apply", action="store_true", help="authorize the remote mutation"
+    )
+
+    diagnose = subcommands.add_parser(
+        "diagnose",
+        help="collect bounded read-only diagnostics without reading raw configuration",
+    )
+    diagnose.add_argument("hosts", nargs="*")
+    diagnose.add_argument("--journal-lines", type=int, default=100)
+    return parser
+
+
+def require_apply(enabled: bool) -> None:
+    if not enabled:
+        raise OpsError(
+            "mutation not authorized; inspect the plan, then repeat with --apply"
+        )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    inventory = load_inventory(arguments.inventory)
+    operator = FleetOperator(inventory)
+    releases = ReleaseClient(inventory.repository)
+
+    if arguments.command == "validate":
+        for host in inventory.hosts:
+            if host.identity_file is not None:
+                ensure_private_file(host.identity_file, f"SSH identity for {host.name}")
+            if host.known_hosts_file is not None:
+                ensure_integrity_file(
+                    host.known_hosts_file, f"known_hosts file for {host.name}"
+                )
+            if host.bootstrap is not None:
+                for path, label in (
+                    (
+                        host.bootstrap.basic_password_file,
+                        "bootstrap Basic password file",
+                    ),
+                    (
+                        host.bootstrap.basic_client_config,
+                        "bootstrap Basic client configuration",
+                    ),
+                    (
+                        host.bootstrap.client_config,
+                        "bootstrap certificate client configuration",
+                    ),
+                ):
+                    if path is not None:
+                        ensure_secret_destination(path, label, allow_existing=True)
+                if (
+                    host.bootstrap.basic_password_file is not None
+                    and host.bootstrap.basic_password_file.exists()
+                ):
+                    read_private_password(
+                        host.bootstrap.basic_password_file,
+                        "bootstrap Basic password file",
+                    )
+            operator.probes.preflight(
+                host.probe,
+                allow_missing=operator._bootstrap_missing_probe_credentials(host),
+            )
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "repository": inventory.repository,
+            "hosts": [host.name for host in inventory.hosts],
+            "canaries": [host.name for host in inventory.hosts if host.canary],
+            "valid": True,
+        }
+        if not arguments.json:
+            print(
+                f"Inventory valid: {len(inventory.hosts)} host(s), "
+                f"{len(payload['canaries'])} canary designation(s)"
+            )
+        emit(payload, arguments.json)
+        return 0
+
+    if arguments.command == "status":
+        hosts = inventory.select(arguments.hosts)
+        statuses = operator.statuses(hosts)
+        if not arguments.json:
+            format_statuses(statuses)
+        emit(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "hosts": [item.public_dict() for item in statuses],
+            },
+            arguments.json,
+        )
+        return 0 if all(status.reachable for status in statuses) else 1
+
+    if arguments.command == "plan":
+        hosts = inventory.select(arguments.hosts)
+        release = releases.fetch(arguments.version)
+        plan = plan_upgrade(operator, hosts, release, releases)
+        if not arguments.json:
+            print_plan(plan)
+        emit(plan, arguments.json)
+        return 0 if plan["ready"] else 1
+
+    if arguments.command == "deploy":
+        require_apply(arguments.apply)
+        host = inventory.select([arguments.host], require_names=True)[0]
+        release = releases.fetch(arguments.version)
+        result = operator.deploy_one(
+            host, release, releases, bootstrap=arguments.bootstrap
+        )
+        if not arguments.json:
+            print(f"{host.name}: {result['status']} at {result['version']}")
+        emit(result, arguments.json)
+        return 0
+
+    if arguments.command == "bootstrap":
+        host = inventory.select([arguments.host], require_names=True)[0]
+        release = releases.fetch(arguments.version)
+        plan = plan_bootstrap(operator, host, release)
+        if not arguments.apply:
+            if not arguments.json:
+                blockers = plan["blockers"]
+                suffix = "" if not blockers else f" — blocked: {'; '.join(blockers)}"
+                print(
+                    f"[fresh] {host.name}: uninstalled -> {release.tag} "
+                    f"(fresh_install){suffix}"
+                )
+            emit(plan, arguments.json)
+            return 0 if plan["ready"] else 1
+        if not plan["ready"]:
+            raise OpsError("bootstrap preflight failed; the host was not modified")
+        result = operator.bootstrap_one(host, release)
+        if not arguments.json:
+            print(f"{host.name}: installed {result['version']}")
+            print(
+                f"Credential files saved privately: {result['credential_files_saved']}"
+            )
+        emit(result, arguments.json)
+        return 0
+
+    if arguments.command == "rollout":
+        require_apply(arguments.apply)
+        hosts = inventory.select(arguments.hosts)
+        release = releases.fetch(arguments.version)
+        plan = plan_upgrade(operator, hosts, release, releases)
+        if not plan["ready"]:
+            if not arguments.json:
+                print_plan(plan)
+            raise OpsError("rollout preflight failed; no host was modified")
+        if arguments.canary:
+            selected = [host for host in hosts if host.name == arguments.canary]
+            if not selected:
+                raise OpsError(
+                    "the requested canary is not in the selected rollout hosts"
+                )
+            canary = selected[0]
+        else:
+            selected = [host for host in hosts if host.canary]
+            if len(selected) != 1:
+                raise OpsError("rollout requires exactly one selected canary")
+            canary = selected[0]
+        if canary.probe is None and not arguments.allow_no_probe:
+            raise OpsError(
+                "the canary has no external probe; configure one or explicitly use --allow-no-probe"
+            )
+        ordered = [canary, *(host for host in hosts if host.name != canary.name)]
+        results = []
+        for host in ordered:
+            result = operator.deploy_one(host, release, releases)
+            results.append(result)
+            if not arguments.json:
+                print(f"{host.name}: {result['status']} at {result['version']}")
+        payload = {
+            "target_version": release.tag,
+            "status": "completed",
+            "hosts": results,
+        }
+        emit(payload, arguments.json)
+        return 0
+
+    if arguments.command == "rollback":
+        require_apply(arguments.apply)
+        host = inventory.select([arguments.host], require_names=True)[0]
+        result = operator.rollback_one(host, releases)
+        if not arguments.json:
+            print(f"{host.name}: rolled back to {result['version']}")
+        emit(result, arguments.json)
+        return 0
+
+    if arguments.command == "diagnose":
+        if not 1 <= arguments.journal_lines <= 500:
+            raise OpsError("--journal-lines must be between 1 and 500")
+        hosts = inventory.select(arguments.hosts)
+        results = []
+        if not arguments.json:
+            print(
+                "Warning: diagnostic journals may contain destination metadata; "
+                "review before sharing."
+            )
+        for host in hosts:
+            output = operator.diagnose(host, arguments.journal_lines)
+            results.append({"host": host.name, "output": output})
+            if not arguments.json:
+                print(f"\n===== {host.name} =====\n{output.rstrip()}")
+        emit({"schema_version": SCHEMA_VERSION, "hosts": results}, arguments.json)
+        return 0
+
+    raise AssertionError(f"unhandled command: {arguments.command}")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except OpsError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1)
+    except KeyboardInterrupt:
+        print("error: interrupted", file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -52,6 +52,7 @@ fi
 install -d \
     "$STAGING_ROOT/$ARCHIVE_NAME/bin" \
     "$STAGING_ROOT/$ARCHIVE_NAME/config" \
+    "$STAGING_ROOT/$ARCHIVE_NAME/maintenance" \
     "$STAGING_ROOT/$ARCHIVE_NAME/monitoring" \
     "$STAGING_ROOT/$ARCHIVE_NAME/systemd"
 install -m 0755 "target/$TARGET/release/masque-server" \
@@ -59,6 +60,10 @@ install -m 0755 "target/$TARGET/release/masque-server" \
 install -m 0755 "target/$TARGET/release/masque-probe" \
     "$STAGING_ROOT/$ARCHIVE_NAME/bin/masque-probe"
 install -m 0755 deploy/install.sh "$STAGING_ROOT/$ARCHIVE_NAME/install.sh"
+install -m 0755 deploy/masque-maintain \
+    "$STAGING_ROOT/$ARCHIVE_NAME/maintenance/masque-maintain"
+install -m 0755 install-latest.sh \
+    "$STAGING_ROOT/$ARCHIVE_NAME/maintenance/install-latest.sh"
 install -m 0644 deploy/config/masque.toml "$STAGING_ROOT/$ARCHIVE_NAME/config/masque.toml"
 install -m 0644 deploy/systemd/masque.service \
     "$STAGING_ROOT/$ARCHIVE_NAME/systemd/masque.service"

--- a/scripts/package-probe.sh
+++ b/scripts/package-probe.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TARGET="${TARGET:-}"
+if [ -z "$TARGET" ]; then
+    echo "error: TARGET is required" >&2
+    exit 1
+fi
+
+case "$TARGET" in
+    x86_64-unknown-linux-*) PLATFORM=linux; TARGET_ARCH=x86_64 ;;
+    aarch64-unknown-linux-*) PLATFORM=linux; TARGET_ARCH=aarch64 ;;
+    x86_64-apple-darwin) PLATFORM=macos; TARGET_ARCH=x86_64 ;;
+    aarch64-apple-darwin) PLATFORM=macos; TARGET_ARCH=aarch64 ;;
+    *)
+        echo "error: unsupported masque-probe release target: $TARGET" >&2
+        exit 1
+        ;;
+esac
+
+ARCH="${ARCH:-$TARGET_ARCH}"
+if [ "$ARCH" != "$TARGET_ARCH" ]; then
+    echo "error: ARCH=$ARCH does not match TARGET=$TARGET" >&2
+    exit 1
+fi
+
+PACKAGE_VERSION=$(awk '
+    /^\[package\]$/ { in_package=1; next }
+    /^\[/ { in_package=0 }
+    in_package && /^version = / { gsub(/[" ]/, "", $3); print $3; exit }
+' Cargo.toml)
+PROBE_VERSION=$(awk '
+    /^\[package\]$/ { in_package=1; next }
+    /^\[/ { in_package=0 }
+    in_package && /^version = / { gsub(/[" ]/, "", $3); print $3; exit }
+' tools/masque-probe/Cargo.toml)
+if [ -z "$PACKAGE_VERSION" ] || [ "$PACKAGE_VERSION" != "$PROBE_VERSION" ]; then
+    echo "error: masque-server and masque-probe package versions must match" >&2
+    exit 1
+fi
+
+VERSION="${VERSION:-$PROBE_VERSION}"
+OUTPUT_DIR="${OUTPUT_DIR:-dist}"
+ARCHIVE_NAME="masque-probe-v${VERSION}-${PLATFORM}-${ARCH}"
+STAGING_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/masque-probe-package.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$STAGING_ROOT"
+}
+trap cleanup EXIT INT TERM
+
+if [ "${SKIP_BUILD:-0}" != 1 ]; then
+    cargo build --locked --release --target "$TARGET" -p masque-probe
+fi
+
+PROBE_BINARY="target/$TARGET/release/masque-probe"
+[ -x "$PROBE_BINARY" ] || {
+    echo "error: built probe is missing or not executable: $PROBE_BINARY" >&2
+    exit 1
+}
+
+install -d "$STAGING_ROOT/$ARCHIVE_NAME/bin"
+install -m 0755 "$PROBE_BINARY" "$STAGING_ROOT/$ARCHIVE_NAME/bin/masque-probe"
+install -m 0644 README.md "$STAGING_ROOT/$ARCHIVE_NAME/README.md"
+install -m 0644 LICENSE "$STAGING_ROOT/$ARCHIVE_NAME/LICENSE"
+
+mkdir -p "$OUTPUT_DIR"
+COPYFILE_DISABLE=1 tar -C "$STAGING_ROOT" -czf \
+    "$OUTPUT_DIR/$ARCHIVE_NAME.tar.gz" "$ARCHIVE_NAME"
+(
+    cd "$OUTPUT_DIR"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$ARCHIVE_NAME.tar.gz" >"$ARCHIVE_NAME.tar.gz.sha256"
+    else
+        shasum -a 256 "$ARCHIVE_NAME.tar.gz" >"$ARCHIVE_NAME.tar.gz.sha256"
+    fi
+)
+
+echo "Created $OUTPUT_DIR/$ARCHIVE_NAME.tar.gz"

--- a/tests/install-probe.sh
+++ b/tests/install-probe.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+die() {
+    echo "probe installer test: $*" >&2
+    exit 1
+}
+
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/masque-probe-installer.XXXXXX")
+cleanup() {
+    rm -rf -- "$TEST_TMP"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+FIXTURES=$TEST_TMP/fixtures
+MOCK_BIN=$TEST_TMP/mock-bin
+install -d "$FIXTURES" "$MOCK_BIN"
+export FIXTURES
+
+cat >"$MOCK_BIN/uname" <<'EOF'
+#!/usr/bin/env sh
+case "${1:-}" in
+    -s) printf '%s\n' "${FAKE_UNAME_SYSTEM:?}" ;;
+    -m) printf '%s\n' "${FAKE_UNAME_ARCH:?}" ;;
+    *) exit 2 ;;
+esac
+EOF
+
+cat >"$MOCK_BIN/curl" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+output=
+url=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            output=$2
+            shift 2
+            ;;
+        *)
+            url=$1
+            shift
+            ;;
+    esac
+done
+[ -n "$output" ] && [ -n "$url" ]
+cp -- "$FIXTURES/${url##*/}" "$output"
+EOF
+chmod 0755 "$MOCK_BIN/uname" "$MOCK_BIN/curl"
+
+make_fixture() {
+    platform=$1
+    arch=$2
+    archive_root=masque-probe-v0.12.2-${platform}-${arch}
+    staging=$TEST_TMP/$archive_root
+    install -d "$staging/bin"
+    cat >"$staging/bin/masque-probe" <<'EOF'
+#!/usr/bin/env sh
+echo 'masque-probe 0.12.2'
+EOF
+    chmod 0755 "$staging/bin/masque-probe"
+    tar -C "$TEST_TMP" -czf "$FIXTURES/$archive_root.tar.gz" "$archive_root"
+    (
+        cd "$FIXTURES"
+        sha256sum "$archive_root.tar.gz" >"$archive_root.tar.gz.sha256"
+    )
+}
+
+make_fixture macos aarch64
+make_fixture macos x86_64
+
+for pair in 'arm64:aarch64' 'x86_64:x86_64'; do
+    machine=${pair%%:*}
+    normalized=${pair#*:}
+    destination=$TEST_TMP/install-$normalized
+    FAKE_UNAME_SYSTEM=Darwin \
+        FAKE_UNAME_ARCH=$machine \
+        MASQUE_VERSION=0.12.2 \
+        MASQUE_PROBE_INSTALL_DIR=$destination \
+        PATH=$MOCK_BIN:$PATH \
+        ./install-probe.sh >"$TEST_TMP/$normalized.log"
+    [ -x "$destination/masque-probe" ] ||
+        die "macOS $machine probe was not installed"
+    [ "$("$destination/masque-probe" --version)" = 'masque-probe 0.12.2' ] ||
+        die "macOS $machine probe version was not preserved"
+    grep -q "macos/$normalized" "$TEST_TMP/$normalized.log" ||
+        die "macOS $machine was normalized incorrectly"
+done
+
+# A changed archive must fail before replacing the verified executable.
+printf '%s\n' tampered >>"$FIXTURES/masque-probe-v0.12.2-macos-aarch64.tar.gz"
+if FAKE_UNAME_SYSTEM=Darwin \
+    FAKE_UNAME_ARCH=arm64 \
+    MASQUE_VERSION=0.12.2 \
+    MASQUE_PROBE_INSTALL_DIR=$TEST_TMP/install-aarch64 \
+    PATH=$MOCK_BIN:$PATH \
+    ./install-probe.sh >"$TEST_TMP/tampered.log" 2>&1; then
+    die "a tampered probe archive passed SHA-256 verification"
+fi
+[ "$("$TEST_TMP/install-aarch64/masque-probe" --version)" = \
+    'masque-probe 0.12.2' ] || die "checksum failure replaced the installed probe"
+
+echo "probe installer tests passed"

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -25,12 +25,16 @@ CANDIDATE_PROBE=${MASQUE_TEST_PACKAGE_PROBE:-}
 
 BIN_PATH=/usr/local/bin/masque-server
 PROBE_PATH=/usr/local/bin/masque-probe
+MAINTENANCE_PATH=/usr/local/sbin/masque-maintain
+LIBEXEC_DIR=/usr/local/libexec/masque-server
+BOOTSTRAP_PATH=$LIBEXEC_DIR/install-latest.sh
 CONFIG_PATH=/etc/masque/masque.toml
 UNIT_PATH=/etc/systemd/system/masque.service
 MONITORING_DIR=/usr/local/share/masque-server/monitoring
 PROMETHEUS_RULES_PATH=$MONITORING_DIR/prometheus-rules.yml
 GRAFANA_DASHBOARD_PATH=$MONITORING_DIR/grafana-dashboard.json
-for protected_path in "$BIN_PATH" "$PROBE_PATH" "$CONFIG_PATH" "$UNIT_PATH" \
+for protected_path in "$BIN_PATH" "$PROBE_PATH" "$MAINTENANCE_PATH" \
+    "$BOOTSTRAP_PATH" "$CONFIG_PATH" "$UNIT_PATH" \
     "$PROMETHEUS_RULES_PATH" "$GRAFANA_DASHBOARD_PATH"; do
     [ ! -e "$protected_path" ] || die "runner is not clean: $protected_path already exists"
 done
@@ -44,6 +48,8 @@ cleanup() {
     rm -f -- \
         "$BIN_PATH" \
         "$PROBE_PATH" \
+        "$MAINTENANCE_PATH" \
+        "$BOOTSTRAP_PATH" \
         "$CONFIG_PATH" \
         /etc/masque/.masque.toml.lock \
         "$UNIT_PATH" \
@@ -52,6 +58,7 @@ cleanup() {
         /etc/masque/certs/server.crt \
         /etc/masque/certs/server.key
     rmdir /etc/masque/certs /etc/masque >/dev/null 2>&1
+    rmdir "$LIBEXEC_DIR" /usr/local/libexec >/dev/null 2>&1
     rmdir "$MONITORING_DIR" /usr/local/share/masque-server >/dev/null 2>&1
     rm -rf -- "$TEST_TMP"
     exit "$cleanup_status"
@@ -62,11 +69,13 @@ trap 'exit 1' HUP INT TERM
 PACKAGE_DIR=$TEST_TMP/package
 MOCK_BIN=$TEST_TMP/mock-bin
 MOCK_STATE=$TEST_TMP/restart-count
-install -d "$PACKAGE_DIR/bin" "$PACKAGE_DIR/config" "$PACKAGE_DIR/monitoring" \
-    "$PACKAGE_DIR/systemd" "$MOCK_BIN"
+install -d "$PACKAGE_DIR/bin" "$PACKAGE_DIR/config" "$PACKAGE_DIR/maintenance" \
+    "$PACKAGE_DIR/monitoring" "$PACKAGE_DIR/systemd" "$MOCK_BIN"
 install -m 0755 "$CANDIDATE" "$PACKAGE_DIR/bin/masque-server"
 install -m 0755 "$CANDIDATE_PROBE" "$PACKAGE_DIR/bin/masque-probe"
 install -m 0755 deploy/install.sh "$PACKAGE_DIR/install.sh"
+install -m 0755 deploy/masque-maintain "$PACKAGE_DIR/maintenance/masque-maintain"
+install -m 0755 install-latest.sh "$PACKAGE_DIR/maintenance/install-latest.sh"
 install -m 0644 deploy/config/masque.toml "$PACKAGE_DIR/config/masque.toml"
 install -m 0644 deploy/systemd/masque.service "$PACKAGE_DIR/systemd/masque.service"
 install -m 0644 deploy/monitoring/prometheus-rules.yml \
@@ -149,6 +158,10 @@ EOF
 echo old-masque-probe
 EOF
     chmod 0755 "$PROBE_PATH"
+    install -d /usr/local/sbin "$LIBEXEC_DIR"
+    printf '%s\n' '#!/bin/sh' 'echo old-masque-maintain' >"$MAINTENANCE_PATH"
+    printf '%s\n' '#!/bin/sh' 'echo old-install-latest' >"$BOOTSTRAP_PATH"
+    chmod 0755 "$MAINTENANCE_PATH" "$BOOTSTRAP_PATH"
     printf '%s\n' 'old systemd unit' >"$UNIT_PATH"
     chmod 0644 "$UNIT_PATH"
     install -d "$MONITORING_DIR"
@@ -225,6 +238,20 @@ grep -q '^dual-proxy = masque, proxy.example, 8449, username=proxy-user, passwor
 [ "$(stat -c '%a' "$DUAL_SURGE_CONFIG")" = 600 ] ||
     die "the generated Surge configuration is not mode 0600"
 [ -x "$PROBE_PATH" ] || die "the diagnostic probe was not installed"
+[ -x "$MAINTENANCE_PATH" ] || die "the maintenance helper was not installed"
+[ -x "$BOOTSTRAP_PATH" ] || die "the pinned bootstrap was not installed"
+"$MAINTENANCE_PATH" status >"$TEST_TMP/maintenance-status.log" ||
+    die "the installed maintenance helper could not inspect the server"
+grep -q '^masque_ops_status=1$' "$TEST_TMP/maintenance-status.log" ||
+    die "the maintenance helper did not emit its stable status schema"
+grep -q '^config_check=ok$' "$TEST_TMP/maintenance-status.log" ||
+    die "the maintenance helper did not validate the active configuration"
+for invalid_version in not-a-version v1.2.3-01 v1.2.3-a..b; do
+    if "$MAINTENANCE_PATH" upgrade "$invalid_version" \
+        >"$TEST_TMP/maintenance-invalid.log" 2>&1; then
+        die "the maintenance helper accepted invalid release version $invalid_version"
+    fi
+done
 
 # The server itself must agree about what those listeners are.
 "$CANDIDATE" --config "$CONFIG_PATH" check-config >"$TEST_TMP/dual-check.log" 2>&1 ||
@@ -279,11 +306,33 @@ grep -q 'add-listener' "$TEST_TMP/dual-upgrade.log" ||
 
 rm -f -- "$CONFIG_PATH" "$(dirname "$CONFIG_PATH")/.masque.toml.lock"
 
+# Automation can provision a fresh host without putting credentials or the
+# rendered configuration into captured logs.
+MASQUE_AUTH_MODE=basic \
+    MASQUE_AUTH_USERNAME=private-automation-user \
+    MASQUE_AUTH_PASSWORD=private-automation-password \
+    MASQUE_PRINT_SECRETS=0 \
+    MASQUE_START_SERVICE=0 \
+    "$PACKAGE_DIR/install.sh" >"$TEST_TMP/suppressed-fresh.log" 2>&1 ||
+    die "fresh secret-suppressed installation failed"
+grep -q 'Credential and generated configuration output was suppressed' \
+    "$TEST_TMP/suppressed-fresh.log" ||
+    die "fresh automation did not report suppressed output"
+! grep -q 'private-automation-user' "$TEST_TMP/suppressed-fresh.log" ||
+    die "fresh automation printed its Basic username"
+! grep -q 'private-automation-password' "$TEST_TMP/suppressed-fresh.log" ||
+    die "fresh automation printed its Basic password"
+! grep -q 'Effective server configuration' "$TEST_TMP/suppressed-fresh.log" ||
+    die "fresh automation printed its rendered configuration"
+rm -f -- "$CONFIG_PATH" "$(dirname "$CONFIG_PATH")/.masque.toml.lock"
+
 # An incompatible existing configuration must fail before replacement.
 write_old_installation
 write_config not-a-controller
 old_binary_sha=$(sha256sum "$BIN_PATH" | awk '{print $1}')
 old_probe_sha=$(sha256sum "$PROBE_PATH" | awk '{print $1}')
+old_maintenance_sha=$(sha256sum "$MAINTENANCE_PATH" | awk '{print $1}')
+old_bootstrap_sha=$(sha256sum "$BOOTSTRAP_PATH" | awk '{print $1}')
 old_unit_sha=$(sha256sum "$UNIT_PATH" | awk '{print $1}')
 old_rules_sha=$(sha256sum "$PROMETHEUS_RULES_PATH" | awk '{print $1}')
 old_dashboard_sha=$(sha256sum "$GRAFANA_DASHBOARD_PATH" | awk '{print $1}')
@@ -293,6 +342,8 @@ if MASQUE_START_SERVICE=0 "$PACKAGE_DIR/install.sh" >"$TEST_TMP/preflight.log" 2
 fi
 assert_sha_unchanged "$BIN_PATH" "$old_binary_sha"
 assert_sha_unchanged "$PROBE_PATH" "$old_probe_sha"
+assert_sha_unchanged "$MAINTENANCE_PATH" "$old_maintenance_sha"
+assert_sha_unchanged "$BOOTSTRAP_PATH" "$old_bootstrap_sha"
 assert_sha_unchanged "$UNIT_PATH" "$old_unit_sha"
 assert_sha_unchanged "$PROMETHEUS_RULES_PATH" "$old_rules_sha"
 assert_sha_unchanged "$GRAFANA_DASHBOARD_PATH" "$old_dashboard_sha"
@@ -309,8 +360,12 @@ assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
 assert_upgrade_output_is_summary_only "$TEST_TMP/staged.log"
 candidate_sha=$(sha256sum "$CANDIDATE" | awk '{print $1}')
 candidate_probe_sha=$(sha256sum "$CANDIDATE_PROBE" | awk '{print $1}')
+candidate_maintenance_sha=$(sha256sum deploy/masque-maintain | awk '{print $1}')
+candidate_bootstrap_sha=$(sha256sum install-latest.sh | awk '{print $1}')
 assert_sha_unchanged "$BIN_PATH" "$candidate_sha"
 assert_sha_unchanged "$PROBE_PATH" "$candidate_probe_sha"
+assert_sha_unchanged "$MAINTENANCE_PATH" "$candidate_maintenance_sha"
+assert_sha_unchanged "$BOOTSTRAP_PATH" "$candidate_bootstrap_sha"
 
 # A successful activation restarts once and preserves operator-managed files.
 write_old_installation
@@ -321,6 +376,8 @@ MOCK_ACTIVE=1 MOCK_ENABLED=1 MASQUE_START_SERVICE=1 \
     die "successful activation did not restart the service exactly once"
 assert_sha_unchanged "$BIN_PATH" "$candidate_sha"
 assert_sha_unchanged "$PROBE_PATH" "$candidate_probe_sha"
+assert_sha_unchanged "$MAINTENANCE_PATH" "$candidate_maintenance_sha"
+assert_sha_unchanged "$BOOTSTRAP_PATH" "$candidate_bootstrap_sha"
 assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
 assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
@@ -332,6 +389,8 @@ grep -q 'Service:        started or restarted' "$TEST_TMP/activated.log" ||
 write_old_installation
 old_binary_sha=$(sha256sum "$BIN_PATH" | awk '{print $1}')
 old_probe_sha=$(sha256sum "$PROBE_PATH" | awk '{print $1}')
+old_maintenance_sha=$(sha256sum "$MAINTENANCE_PATH" | awk '{print $1}')
+old_bootstrap_sha=$(sha256sum "$BOOTSTRAP_PATH" | awk '{print $1}')
 old_unit_sha=$(sha256sum "$UNIT_PATH" | awk '{print $1}')
 old_rules_sha=$(sha256sum "$PROMETHEUS_RULES_PATH" | awk '{print $1}')
 old_dashboard_sha=$(sha256sum "$GRAFANA_DASHBOARD_PATH" | awk '{print $1}')
@@ -343,13 +402,15 @@ if MOCK_ACTIVE=1 MOCK_ENABLED=1 MOCK_FAIL_FIRST_RESTART=1 \
 fi
 assert_sha_unchanged "$BIN_PATH" "$old_binary_sha"
 assert_sha_unchanged "$PROBE_PATH" "$old_probe_sha"
+assert_sha_unchanged "$MAINTENANCE_PATH" "$old_maintenance_sha"
+assert_sha_unchanged "$BOOTSTRAP_PATH" "$old_bootstrap_sha"
 assert_sha_unchanged "$UNIT_PATH" "$old_unit_sha"
 assert_sha_unchanged "$PROMETHEUS_RULES_PATH" "$old_rules_sha"
 assert_sha_unchanged "$GRAFANA_DASHBOARD_PATH" "$old_dashboard_sha"
 assert_sha_unchanged "$CONFIG_PATH" "$valid_config_sha"
 assert_sha_unchanged /etc/masque/certs/server.crt "$tls_cert_sha"
 assert_sha_unchanged /etc/masque/certs/server.key "$tls_key_sha"
-grep -q 'Previous binaries, systemd unit, monitoring assets, and service state restored' \
+grep -q 'Previous release-managed files and service state restored' \
     "$TEST_TMP/rollback.log" || die "rollback confirmation was not printed"
 
 echo "installer upgrade preflight, preservation, and rollback passed"

--- a/tests/install-upgrade.sh
+++ b/tests/install-upgrade.sh
@@ -313,8 +313,15 @@ MASQUE_AUTH_MODE=basic \
     MASQUE_AUTH_PASSWORD=private-automation-password \
     MASQUE_PRINT_SECRETS=0 \
     MASQUE_START_SERVICE=0 \
-    "$PACKAGE_DIR/install.sh" >"$TEST_TMP/suppressed-fresh.log" 2>&1 ||
+    "$PACKAGE_DIR/install.sh" >"$TEST_TMP/suppressed-fresh.log" 2>&1 || {
+    # The values above are fixed test fixtures, but still redact them so a
+    # regression cannot teach CI logs to expose the corresponding real fields.
+    sed \
+        -e 's/private-automation-user/<redacted-user>/g' \
+        -e 's/private-automation-password/<redacted-password>/g' \
+        "$TEST_TMP/suppressed-fresh.log" >&2
     die "fresh secret-suppressed installation failed"
+}
 grep -q 'Credential and generated configuration output was suppressed' \
     "$TEST_TMP/suppressed-fresh.log" ||
     die "fresh automation did not report suppressed output"

--- a/tests/monitoring_assets.rs
+++ b/tests/monitoring_assets.rs
@@ -50,10 +50,12 @@ fn monitoring_assets_reference_exported_metric_names() {
 }
 
 #[test]
-fn release_packager_includes_both_monitoring_assets() {
+fn release_packager_includes_operational_assets() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let script = std::fs::read_to_string(root.join("scripts/package-linux.sh")).unwrap();
     assert!(script.contains("monitoring/prometheus-rules.yml"));
     assert!(script.contains("monitoring/grafana-dashboard.json"));
     assert!(script.contains("bin/masque-probe"));
+    assert!(script.contains("maintenance/masque-maintain"));
+    assert!(script.contains("maintenance/install-latest.sh"));
 }

--- a/tests/test_masque_ops.py
+++ b/tests/test_masque_ops.py
@@ -1,0 +1,615 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "masque-ops.py"
+SPEC = importlib.util.spec_from_file_location("masque_ops", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+ops = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = ops
+SPEC.loader.exec_module(ops)
+
+
+def release(tag: str) -> object:
+    version = tag.removeprefix("v")
+    archive = f"masque-v{version}-linux-x86_64.tar.gz"
+    return ops.Release(
+        tag=tag,
+        prerelease="-" in tag,
+        published_at="2026-09-02T00:00:00Z",
+        assets=frozenset({archive, f"{archive}.sha256"}),
+    )
+
+
+class FakeReleases:
+    def __init__(self, *tags: str) -> None:
+        self.releases = {tag: release(tag) for tag in tags}
+
+    def fetch(self, version: str | None) -> object:
+        if version is None:
+            return self.releases[max(self.releases)]
+        tag = ops.normalize_version(version)
+        try:
+            return self.releases[tag]
+        except KeyError as error:
+            raise ops.OpsError(f"release not found: {tag}") from error
+
+
+class FakeSsh:
+    def __init__(
+        self,
+        version: str,
+        unhealthy: set[str] | None = None,
+        config_drift: set[str] | None = None,
+    ) -> None:
+        self.version = version
+        self.unhealthy = unhealthy or set()
+        self.config_drift = config_drift or set()
+        self.upgrades: list[str] = []
+
+    def run(
+        self,
+        host: object,
+        command: str,
+        *,
+        input_text: str | None = None,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del input_text, timeout
+        arguments = shlex.split(command)
+        if arguments[-1] == "status":
+            active = "failed" if self.version in self.unhealthy else "active"
+            config_sha256 = ("b" if self.version in self.config_drift else "a") * 64
+            output = "\n".join(
+                [
+                    "masque_ops_status=1",
+                    f"version=masque-server {self.version.removeprefix('v')}",
+                    "arch=x86_64",
+                    f"service_active={active}",
+                    "service_enabled=enabled",
+                    "config_exists=yes",
+                    "config_check=ok",
+                    f"config_sha256={config_sha256}",
+                    "cert_not_after=Sep 30 12:00:00 2030 GMT",
+                    "disk_available_kb=1048576",
+                    "disk_used_percent=40%",
+                    "",
+                ]
+            )
+            return subprocess.CompletedProcess(arguments, 0, output, "")
+        if "upgrade" in arguments:
+            target = arguments[-1]
+            self.version = target
+            self.upgrades.append(target)
+            return subprocess.CompletedProcess(arguments, 0, "installed", "")
+        raise AssertionError(f"unexpected fake SSH command: {command}")
+
+
+class FakeBootstrapSsh:
+    def __init__(self) -> None:
+        self.installed = False
+        self.install_command = ""
+        self.install_input = ""
+
+    def run(
+        self,
+        host: object,
+        command: str,
+        *,
+        input_text: str | None = None,
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del host, timeout
+        arguments = shlex.split(command)
+        if input_text == ops.BOOTSTRAP_PREFLIGHT_SCRIPT:
+            output = (
+                "masque_ops_bootstrap_preflight=1\n"
+                "os=Linux\n"
+                "arch=x86_64\n"
+                "binary_exists=no\n"
+                "config_exists=no\n"
+                "tls_cert_readable=yes\n"
+                "tls_key_readable=yes\n"
+                "missing_commands=\n"
+            )
+            return subprocess.CompletedProcess(arguments, 0, output, "")
+        if input_text is not None and "export MASQUE_VERSION=" in input_text:
+            self.install_command = command
+            self.install_input = input_text
+            self.installed = True
+            return subprocess.CompletedProcess(arguments, 0, "installed", "")
+        if arguments[-1] == "status" and self.installed:
+            output = "\n".join(
+                [
+                    "masque_ops_status=1",
+                    "version=masque-server 0.13.0",
+                    "arch=x86_64",
+                    "service_active=active",
+                    "service_enabled=enabled",
+                    "config_exists=yes",
+                    "config_check=ok",
+                    f"config_sha256={'a' * 64}",
+                    "cert_not_after=Sep 30 12:00:00 2030 GMT",
+                    "disk_available_kb=1048576",
+                    "disk_used_percent=40%",
+                    "",
+                ]
+            )
+            return subprocess.CompletedProcess(arguments, 0, output, "")
+        if arguments[:3] == ["rm", "-f", "--"]:
+            return subprocess.CompletedProcess(arguments, 0, "", "")
+        raise AssertionError(f"unexpected fake SSH command: {command}")
+
+    def download_private(
+        self,
+        host: object,
+        command: str,
+        destination: Path,
+        label: str,
+    ) -> None:
+        del host, command
+        ops.write_private_file(
+            destination,
+            b'{"private_key":"client-secret"}\n',
+            label,
+        )
+
+
+class FailingState:
+    def audit(self, _event: str, _host: str, **_fields: object) -> None:
+        pass
+
+    def save_transition(self, _host: str, _old: str, _new: str) -> None:
+        raise ops.OpsError("state write failed")
+
+
+class AuditFailsAfterStart:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def audit(self, _event: str, _host: str, **_fields: object) -> None:
+        self.calls += 1
+        if self.calls > 1:
+            raise ops.OpsError("audit write failed")
+
+    def save_transition(self, _host: str, _old: str, _new: str) -> None:
+        pass
+
+
+class InventoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.key = self.root / "id_ed25519"
+        self.key.write_text("fixture", encoding="utf-8")
+        self.key.chmod(0o600)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_inventory(self, extra: str = "") -> Path:
+        path = self.root / "fleet.toml"
+        path.write_text(
+            "\n".join(
+                [
+                    "schema_version = 1",
+                    'repository = "Vincent-bin/masque-server"',
+                    f'state_path = "{self.root / "state.json"}"',
+                    "[defaults]",
+                    'user = "root"',
+                    f'identity_file = "{self.key}"',
+                    "sudo = false",
+                    "[[hosts]]",
+                    'name = "canary"',
+                    'address = "203.0.113.10"',
+                    "canary = true",
+                    extra,
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        path.chmod(0o600)
+        return path
+
+    def test_inventory_is_private_and_typed(self) -> None:
+        inventory = ops.load_inventory(self.write_inventory())
+        self.assertEqual(inventory.hosts[0].name, "canary")
+        self.assertFalse(inventory.hosts[0].use_sudo)
+        self.assertEqual(inventory.hosts[0].identity_file, self.key)
+
+        inventory.path.chmod(0o644)
+        with self.assertRaisesRegex(ops.OpsError, "group or others"):
+            ops.load_inventory(inventory.path)
+
+    def test_repository_example_inventory_matches_the_schema(self) -> None:
+        path = self.root / "fleet.example.toml"
+        path.write_text(
+            (ROOT / "deploy/config/fleet.example.toml").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        path.chmod(0o600)
+        inventory = ops.load_inventory(path)
+        self.assertEqual(len(inventory.hosts), 2)
+        self.assertIsNotNone(inventory.hosts[0].bootstrap)
+        self.assertIsNotNone(inventory.hosts[0].probe)
+
+    def test_unknown_inventory_key_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ops.OpsError, "unknown hosts.* key"):
+            ops.load_inventory(self.write_inventory("unexpected = true"))
+
+    def test_remote_installation_paths_cannot_be_overridden(self) -> None:
+        with self.assertRaisesRegex(ops.OpsError, "unknown hosts.*config_path"):
+            ops.load_inventory(
+                self.write_inventory('config_path = "/tmp/untrusted.toml"')
+            )
+
+    def test_release_source_is_pinned_to_the_official_repository(self) -> None:
+        path = self.write_inventory()
+        contents = path.read_text(encoding="utf-8").replace(
+            'repository = "Vincent-bin/masque-server"',
+            'repository = "example/masque-server"',
+        )
+        path.write_text(contents, encoding="utf-8")
+        with self.assertRaisesRegex(ops.OpsError, "release source"):
+            ops.load_inventory(path)
+
+    def test_inventory_symlink_is_rejected(self) -> None:
+        target = self.write_inventory()
+        link = self.root / "linked.toml"
+        link.symlink_to(target)
+        with self.assertRaisesRegex(ops.OpsError, "symbolic link"):
+            ops.load_inventory(link)
+
+    def test_probe_requires_secret_reference_not_inline_password(self) -> None:
+        with self.assertRaisesRegex(ops.OpsError, "unknown .*probe.*password"):
+            ops.load_inventory(
+                self.write_inventory(
+                    "[hosts.probe]\n"
+                    'endpoint = "proxy.example:443"\n'
+                    'username = "probe"\n'
+                    'password = "must-not-be-supported"'
+                )
+            )
+
+    def test_bootstrap_requires_external_password_file_not_inline_secret(self) -> None:
+        with self.assertRaisesRegex(ops.OpsError, "unknown .*bootstrap.*password"):
+            ops.load_inventory(
+                self.write_inventory(
+                    "[hosts.bootstrap]\n"
+                    'auth_mode = "basic"\n'
+                    'tls_cert_path = "/root/fullchain.pem"\n'
+                    'tls_key_path = "/root/privkey.pem"\n'
+                    f'basic_password_file = "{self.root / "password"}"\n'
+                    'password = "must-not-be-supported"'
+                )
+            )
+
+    def test_bootstrap_probe_must_share_generated_credentials(self) -> None:
+        other_password = self.root / "other-password"
+        with self.assertRaisesRegex(ops.OpsError, "must use the bootstrap"):
+            ops.load_inventory(
+                self.write_inventory(
+                    "[hosts.bootstrap]\n"
+                    'auth_mode = "basic"\n'
+                    'tls_cert_path = "/root/fullchain.pem"\n'
+                    'tls_key_path = "/root/privkey.pem"\n'
+                    f'basic_password_file = "{self.root / "password"}"\n'
+                    "[hosts.probe]\n"
+                    'endpoint = "proxy.example:443"\n'
+                    'username = "masque"\n'
+                    f'password_file = "{other_password}"'
+                )
+            )
+
+    def test_release_versions_follow_semver_prerelease_rules(self) -> None:
+        for invalid in ("v1.2.3-01", "v1.2.3-a..b", "v1.2.3-a."):
+            with self.subTest(invalid=invalid), self.assertRaises(ops.OpsError):
+                ops.normalize_version(invalid)
+        self.assertLess(
+            ops.version_order("v1.2.3-rc.2"), ops.version_order("v1.2.3-rc.10")
+        )
+        self.assertLess(ops.version_order("v1.2.3-rc.10"), ops.version_order("v1.2.3"))
+
+
+class OperationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        inventory_path = self.root / "fleet.toml"
+        inventory_path.write_text(
+            "\n".join(
+                [
+                    "schema_version = 1",
+                    f'state_path = "{self.root / "state.json"}"',
+                    "[[hosts]]",
+                    'name = "edge-a"',
+                    'address = "203.0.113.10"',
+                    'user = "root"',
+                    "sudo = false",
+                    "canary = true",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        inventory_path.chmod(0o600)
+        self.inventory = ops.load_inventory(inventory_path)
+        self.host = self.inventory.hosts[0]
+        self.original_sleep = ops.time.sleep
+        ops.time.sleep = lambda _seconds: None
+
+    def tearDown(self) -> None:
+        ops.time.sleep = self.original_sleep
+        self.temporary.cleanup()
+
+    def test_deploy_records_transition_and_rollback_is_reversible(self) -> None:
+        ssh = FakeSsh("v0.12.2")
+        operator = ops.FleetOperator(self.inventory, ssh=ssh)
+        releases = FakeReleases("v0.12.2", "v0.13.0")
+
+        deployed = operator.deploy_one(self.host, release("v0.13.0"), releases)
+        self.assertEqual(deployed["status"], "deployed")
+        self.assertEqual(ssh.upgrades, ["v0.13.0"])
+        state = json.loads(self.inventory.state_path.read_text(encoding="utf-8"))
+        self.assertEqual(state["hosts"]["edge-a"]["rollback_version"], "v0.12.2")
+        self.assertEqual(stat.S_IMODE(self.inventory.state_path.stat().st_mode), 0o600)
+        audit = self.inventory.state_path.with_name("ops-audit.jsonl")
+        self.assertEqual(stat.S_IMODE(audit.stat().st_mode), 0o600)
+        self.assertNotIn(self.host.address, audit.read_text(encoding="utf-8"))
+
+        rolled_back = operator.rollback_one(self.host, releases)
+        self.assertEqual(rolled_back["version"], "v0.12.2")
+        self.assertEqual(ssh.upgrades, ["v0.13.0", "v0.12.2"])
+
+    def test_failed_post_deploy_health_check_restores_previous_release(self) -> None:
+        ssh = FakeSsh("v0.12.2", unhealthy={"v0.13.0"})
+        operator = ops.FleetOperator(self.inventory, ssh=ssh)
+        releases = FakeReleases("v0.12.2", "v0.13.0")
+
+        with self.assertRaisesRegex(ops.OpsError, "was restored"):
+            operator.deploy_one(self.host, release("v0.13.0"), releases)
+        self.assertEqual(ssh.version, "v0.12.2")
+        self.assertEqual(ssh.upgrades, ["v0.13.0", "v0.12.2"])
+        self.assertFalse(self.inventory.state_path.exists())
+
+    def test_configuration_hash_drift_restores_previous_release(self) -> None:
+        ssh = FakeSsh("v0.12.2", config_drift={"v0.13.0"})
+        operator = ops.FleetOperator(self.inventory, ssh=ssh)
+        releases = FakeReleases("v0.12.2", "v0.13.0")
+
+        with self.assertRaisesRegex(ops.OpsError, "was restored"):
+            operator.deploy_one(self.host, release("v0.13.0"), releases)
+        self.assertEqual(ssh.version, "v0.12.2")
+        self.assertEqual(ssh.upgrades, ["v0.13.0", "v0.12.2"])
+
+    def test_failed_local_state_write_restores_previous_release(self) -> None:
+        ssh = FakeSsh("v0.12.2")
+        operator = ops.FleetOperator(self.inventory, ssh=ssh)
+        operator.state = FailingState()
+        releases = FakeReleases("v0.12.2", "v0.13.0")
+
+        with self.assertRaisesRegex(ops.OpsError, "was restored"):
+            operator.deploy_one(self.host, release("v0.13.0"), releases)
+        self.assertEqual(ssh.version, "v0.12.2")
+        self.assertEqual(ssh.upgrades, ["v0.13.0", "v0.12.2"])
+
+    def test_failed_audit_does_not_interrupt_automatic_restore(self) -> None:
+        ssh = FakeSsh("v0.12.2", unhealthy={"v0.13.0"})
+        operator = ops.FleetOperator(self.inventory, ssh=ssh)
+        operator.state = AuditFailsAfterStart()
+        releases = FakeReleases("v0.12.2", "v0.13.0")
+
+        with self.assertRaisesRegex(ops.OpsError, "audit logging also failed"):
+            operator.deploy_one(self.host, release("v0.13.0"), releases)
+        self.assertEqual(ssh.version, "v0.12.2")
+        self.assertEqual(ssh.upgrades, ["v0.13.0", "v0.12.2"])
+
+    def test_plan_requires_current_release_assets_for_rollback(self) -> None:
+        ssh = FakeSsh("v0.12.2")
+        operator = ops.FleetOperator(self.inventory, ssh=ssh)
+        releases = FakeReleases("v0.13.0")
+
+        plan = ops.plan_upgrade(operator, [self.host], release("v0.13.0"), releases)
+        self.assertFalse(plan["ready"])
+        self.assertIn(
+            "current release is unavailable for automatic rollback",
+            plan["hosts"][0]["blockers"],
+        )
+
+    def test_mutation_requires_explicit_apply(self) -> None:
+        with self.assertRaisesRegex(ops.OpsError, "not authorized"):
+            ops.require_apply(False)
+
+    def test_non_object_state_is_rejected_cleanly(self) -> None:
+        self.inventory.state_path.write_text("[]\n", encoding="utf-8")
+        self.inventory.state_path.chmod(0o600)
+        with self.assertRaisesRegex(ops.OpsError, "state schema"):
+            ops.StateStore(self.inventory.state_path).load()
+
+    def test_fresh_bootstrap_keeps_password_out_of_ssh_arguments_and_results(
+        self,
+    ) -> None:
+        password_path = self.root / "bootstrap.password"
+        inventory_path = self.root / "bootstrap.toml"
+        inventory_path.write_text(
+            "\n".join(
+                [
+                    "schema_version = 1",
+                    f'state_path = "{self.root / "bootstrap-state.json"}"',
+                    "[[hosts]]",
+                    'name = "new-edge"',
+                    'address = "203.0.113.20"',
+                    'user = "root"',
+                    "sudo = false",
+                    "[hosts.bootstrap]",
+                    'auth_mode = "basic"',
+                    'tls_cert_path = "/root/fullchain.pem"',
+                    'tls_key_path = "/root/privkey.pem"',
+                    'basic_username = "probe-user"',
+                    f'basic_password_file = "{password_path}"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        inventory_path.chmod(0o600)
+        inventory = ops.load_inventory(inventory_path)
+        host = inventory.hosts[0]
+        ssh = FakeBootstrapSsh()
+        operator = ops.FleetOperator(inventory, ssh=ssh)
+
+        plan = ops.plan_bootstrap(operator, host, release("v0.13.0"))
+        self.assertTrue(plan["ready"], plan["blockers"])
+        result = operator.bootstrap_one(host, release("v0.13.0"))
+
+        password = password_path.read_text(encoding="utf-8").strip()
+        self.assertGreaterEqual(len(password), 32)
+        self.assertNotIn(password, ssh.install_command)
+        self.assertIn(password, ssh.install_input)
+        self.assertIn("export MASQUE_PRINT_SECRETS=0", ssh.install_input)
+        self.assertNotIn(password, json.dumps(result))
+        self.assertEqual(stat.S_IMODE(password_path.stat().st_mode), 0o600)
+        self.assertEqual(result["status"], "installed")
+        audit = inventory.state_path.with_name("ops-audit.jsonl").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn(password, audit)
+        self.assertNotIn(host.address, audit)
+
+    def test_certificate_bootstrap_streams_client_key_to_private_file(self) -> None:
+        client_path = self.root / "client.json"
+        inventory_path = self.root / "certificate-bootstrap.toml"
+        inventory_path.write_text(
+            "\n".join(
+                [
+                    "schema_version = 1",
+                    f'state_path = "{self.root / "certificate-state.json"}"',
+                    "[[hosts]]",
+                    'name = "new-cert-edge"',
+                    'address = "203.0.113.30"',
+                    'user = "root"',
+                    "sudo = false",
+                    "[hosts.bootstrap]",
+                    'auth_mode = "client_cert"',
+                    "listen_port = 4443",
+                    'tls_cert_path = "/root/fullchain.pem"',
+                    'tls_key_path = "/root/privkey.pem"',
+                    'client_name = "laptop"',
+                    'client_endpoint = "proxy.example:4443"',
+                    f'client_config = "{client_path}"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        inventory_path.chmod(0o600)
+        inventory = ops.load_inventory(inventory_path)
+        host = inventory.hosts[0]
+        ssh = FakeBootstrapSsh()
+        operator = ops.FleetOperator(inventory, ssh=ssh)
+
+        result = operator.bootstrap_one(host, release("v0.13.0"))
+
+        self.assertIn("client-secret", client_path.read_text(encoding="utf-8"))
+        self.assertEqual(stat.S_IMODE(client_path.stat().st_mode), 0o600)
+        self.assertNotIn("client-secret", json.dumps(result))
+        self.assertNotIn("client-secret", ssh.install_command)
+
+
+class SecurityTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("sh"), "POSIX shell is required")
+    def test_embedded_remote_scripts_have_valid_shell_syntax(self) -> None:
+        for name in (
+            "STATUS_SCRIPT",
+            "DIAGNOSE_SCRIPT",
+            "BOOTSTRAP_PREFLIGHT_SCRIPT",
+        ):
+            with self.subTest(script=name):
+                completed = subprocess.run(
+                    ["sh", "-n"],
+                    input=getattr(ops, name),
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_safe_tail_removes_credentials(self) -> None:
+        output = ops.safe_tail(
+            "Password: secret\nnormal failure",
+            "private_key = hidden\nservice failed",
+        )
+        self.assertEqual(output, "normal failure | service failed")
+
+    def test_diagnostic_output_redacts_authentication_material(self) -> None:
+        output = ops.sanitize_diagnostics(
+            "healthy\n"
+            "username = alice\n"
+            "client=certificate-label connection accepted\n"
+            "Proxy-Authorization: Basic c2VjcmV0\n"
+            "-----BEGIN PRIVATE KEY-----\n"
+            "secret-body\n"
+            "-----END PRIVATE KEY-----\n"
+            "complete\n"
+        )
+        self.assertIn("healthy", output)
+        self.assertIn("complete", output)
+        self.assertNotIn("alice", output)
+        self.assertNotIn("certificate-label", output)
+        self.assertNotIn("c2VjcmV0", output)
+        self.assertNotIn("secret-body", output)
+
+    def test_ssh_arguments_disable_ambient_configuration_and_forwarding(self) -> None:
+        host = ops.Host(
+            name="edge",
+            address="203.0.113.1",
+            user="root",
+            port=22,
+            identity_file=None,
+            known_hosts_file=None,
+            use_sudo=False,
+            service="masque.service",
+            config_path="/etc/masque/masque.toml",
+            binary_path="/usr/local/bin/masque-server",
+            cert_path="/etc/masque/certs/server.crt",
+            maintenance_path="/usr/local/sbin/masque-maintain",
+            connect_timeout_secs=10,
+            command_timeout_secs=60,
+            deploy_timeout_secs=900,
+            canary=False,
+            probe=None,
+            bootstrap=None,
+        )
+        arguments = ops.SshClient().arguments(host, "true")
+        joined = " ".join(arguments)
+        self.assertIn("-F /dev/null", joined)
+        self.assertIn("StrictHostKeyChecking=yes", joined)
+        self.assertIn("PasswordAuthentication=no", joined)
+        self.assertIn("KbdInteractiveAuthentication=no", joined)
+        self.assertIn("ClearAllForwardings=yes", joined)
+        self.assertIn("ForwardAgent=no", joined)
+
+    def test_host_key_file_must_not_be_a_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "known_hosts.real"
+            target.write_text("example fixture", encoding="utf-8")
+            link = root / "known_hosts"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(ops.OpsError, "symbolic link"):
+                ops.ensure_integrity_file(link, "known_hosts")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a deterministic local operations CLI and repository skill for inspection, planning, bootstrap, deployment, verification, and rollback
- support guarded empty-host bootstrap with explicit `--apply`, exact release tags, strict host checks, and secret transport over stdin
- publish standalone `masque-probe` archives for Linux and macOS x86_64/aarch64
- add an architecture-detecting probe installer with SHA-256 verification and atomic installation
- package the maintenance helper and document the operations workflow
- extend CI and tests for packaging, installer tamper rejection, bootstrap safety, redaction, and rollback behavior

## Security boundaries

- inventory, SSH identity files, authentication files, and generated client credentials remain outside the repository
- OpenSSH reads SSH keys directly; the AI-facing workflow does not parse or print them
- credentials are not passed in process arguments or included in audit/result output
- bootstrap does not modify firewall, NAT, DNS, or ACME state

## Verification

- `cargo test --workspace --locked` — 478 tests passed
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- 25 Python operations tests
- Ruff check and format check
- ShellCheck for shell scripts
- probe installer checksum/tamper tests
- macOS ARM64 production package inspection and version check
- workflow YAML and skill validation